### PR TITLE
feat(notify): add proxy support for Telegram notifications

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "js-yaml": "^4.1.1",
     "openai": "^4.80.0",
+    "undici": "^7.24.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -18,6 +18,7 @@ export const NotifyChannelSchema = z.discriminatedUnion("type", [
     type: z.literal("telegram"),
     botToken: z.string().min(1),
     chatId: z.string().min(1),
+    proxy: z.string().optional(),
   }),
   z.object({
     type: z.literal("wechat-work"),

--- a/packages/core/src/notify/dispatcher.ts
+++ b/packages/core/src/notify/dispatcher.ts
@@ -20,7 +20,7 @@ export async function dispatchNotification(
       switch (channel.type) {
         case "telegram":
           await sendTelegram(
-            { botToken: channel.botToken, chatId: channel.chatId },
+            { botToken: channel.botToken, chatId: channel.chatId, proxy: channel.proxy },
             fullText,
           );
           break;

--- a/packages/core/src/notify/telegram.ts
+++ b/packages/core/src/notify/telegram.ts
@@ -1,6 +1,9 @@
+import { ProxyAgent } from "undici";
+
 export interface TelegramConfig {
   readonly botToken: string;
   readonly chatId: string;
+  readonly proxy?: string;
 }
 
 export async function sendTelegram(
@@ -8,7 +11,14 @@ export async function sendTelegram(
   message: string,
 ): Promise<void> {
   const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
-  const response = await fetch(url, {
+  const proxyUrl =
+    config.proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  const fetchOptions: Record<string, unknown> = {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -16,7 +26,13 @@ export async function sendTelegram(
       text: message,
       parse_mode: "Markdown",
     }),
-  });
+  };
+
+  if (proxyUrl) {
+    fetchOptions.dispatcher = new ProxyAgent(proxyUrl);
+  }
+
+  const response = await fetch(url, fetchOptions as RequestInit);
 
   if (!response.ok) {
     const body = await response.text();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       openai:
         specifier: ^4.80.0
         version: 4.104.0(zod@3.25.76)
+      undici:
+        specifier: ^7.24.2
+        version: 7.24.2
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -715,6 +718,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.24.2:
+    resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
+    engines: {node: '>=20.18.1'}
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -1332,6 +1339,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.24.2: {}
 
   vite-node@3.2.4(@types/node@22.19.15):
     dependencies:


### PR DESCRIPTION
## Summary
- Add optional `proxy` field to Telegram notify channel config
- Use `undici.ProxyAgent` to route Telegram API requests through a proxy
- Fall back to `HTTPS_PROXY` / `HTTP_PROXY` environment variables when `proxy` is not set in config

## Motivation
Telegram API (`api.telegram.org`) is blocked in some regions (e.g. China). Users currently have no way to configure a proxy for Telegram notifications without system-wide TUN/VPN, which may interfere with other services (e.g. LLM API endpoints on internal networks).

## Usage
```json
{
  "type": "telegram",
  "botToken": "...",
  "chatId": "...",
  "proxy": "http://127.0.0.1:7890"
}
```

The `proxy` field is optional. When omitted, the code checks `HTTPS_PROXY` / `HTTP_PROXY` env vars. If none is set, fetch proceeds without a proxy (existing behavior).

## Changes
- `packages/core/src/models/project.ts` — Add optional `proxy` to Telegram schema
- `packages/core/src/notify/telegram.ts` — Import `undici.ProxyAgent`, apply when proxy is configured
- `packages/core/src/notify/dispatcher.ts` — Pass `channel.proxy` to `sendTelegram`
- `packages/core/package.json` — Add `undici` dependency (bundled in Node 20+ but needed for TypeScript types)

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 151 existing tests pass (`vitest run`)
- [x] Manual test: Telegram notification sent successfully via `http://127.0.0.1:7890` proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)