### PR TITLE
fix: ensure chapters/ and story/ subdirectories are created before writing files (fixes Windows ENOENT)

### DIFF
--- a/packages/core/src/agents/writer.ts
+++ b/packages/core/src/agents/writer.ts
@@ -265,6 +265,7 @@ export class WriterAgent extends BaseAgent {
     const chaptersDir = join(bookDir, "chapters");
     const storyDir = join(bookDir, "story");
     await mkdir(chaptersDir, { recursive: true });
+    await mkdir(storyDir, { recursive: true });
 
     const paddedNum = String(output.chapterNumber).padStart(4, "0");
     const filename = `${paddedNum}_${this.sanitizeFilename(output.title)}.md`;

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -360,6 +360,7 @@ export class PipelineRunner {
 
       // Update truth files
       const storyDir = join(bookDir, "story");
+      await mkdir(storyDir, { recursive: true });
       if (reviseOutput.updatedState !== "(状态卡未更新)") {
         await writeFile(join(storyDir, "current_state.md"), reviseOutput.updatedState, "utf-8");
       }
@@ -581,6 +582,7 @@ export class PipelineRunner {
 
           // Update state files from revision
           const storyDir = join(bookDir, "story");
+          await mkdir(storyDir, { recursive: true });
           if (reviseOutput.updatedState !== "(状态卡未更新)") {
             await writeFile(join(storyDir, "current_state.md"), reviseOutput.updatedState, "utf-8");
           }
@@ -596,6 +598,7 @@ export class PipelineRunner {
 
     // 4. Save chapter (original or revised)
     const chaptersDir = join(bookDir, "chapters");
+    await mkdir(chaptersDir, { recursive: true });
     const paddedNum = String(chapterNumber).padStart(4, "0");
     const title = output.title;
     const filename = `${paddedNum}_${title.replace(/[/\\?%*:|"<>]/g, "").replace(/\s+/g, "_").slice(0, 50)}.md`;


### PR DESCRIPTION
## Problem

On Windows, `inkos write next` and `inkos draft` fail with `ENOENT: no such file or directory` because the `chapters/` and `story/` subdirectories under a book's directory are not created before writing files.

`inkos book create` only creates the book root directory and `book.json`. The subdirectories are expected to exist when the writer agent tries to save chapter content and truth files.

Related issue: #41

## Root Cause

In `packages/core/src/agents/writer.ts`, the `saveChapter` method creates `chapters/` with `mkdir({ recursive: true })` but does **not** create `story/` before writing `current_state.md`, `particle_ledger.md`, and `pending_hooks.md`.

In `packages/core/src/pipeline/runner.ts`, there are two additional code paths in `runWriteChapter` that write to `storyDir` and `chaptersDir` without ensuring the directories exist first.

## Fix

- `packages/core/src/agents/writer.ts`: add `await mkdir(storyDir, { recursive: true })` in `saveChapter`
- `packages/core/src/pipeline/runner.ts`: add `await mkdir(storyDir, { recursive: true })` in two revise paths, add `await mkdir(chaptersDir, { recursive: true })` in the final chapter save path

## Testing

Verified on Windows 11 Pro (Node.js v24.12.0, inkos 0.4.5):
- Before fix: `inkos write next` fails with ENOENT after LLM generates chapter content
- After fix: full `write next` pipeline completes successfully including audit

Closes #41