### PR TITLE
fix(llm): add GLM compatibility for reasoning_content field

### DIFF
--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -345,10 +345,19 @@ async function chatCompletionOpenAIChat(
   try {
     for await (const chunk of stream) {
       const delta = chunk.choices[0]?.delta?.content;
-      if (delta) {
+      const reasoningDelta = (chunk.choices[0]?.delta as { reasoning_content?: string } | undefined)?.reasoning_content;
+
+      // GLM models (glm-4, glm-5) return content in reasoning_content field
+      if (reasoningDelta) {
+        // For GLM models, treat reasoning_content as main content
+        chunks.push(reasoningDelta);
+        monitor.onChunk(reasoningDelta);
+      } else if (delta) {
+        // Standard OpenAI format
         chunks.push(delta);
         monitor.onChunk(delta);
       }
+
       if (chunk.usage) {
         inputTokens = chunk.usage.prompt_tokens ?? 0;
         outputTokens = chunk.usage.completion_tokens ?? 0;
@@ -393,11 +402,17 @@ async function chatCompletionOpenAIChatSync(
     stream: false,
   });
 
-  const content = response.choices[0]?.message?.content ?? "";
-  if (!content) throw new Error("LLM returned empty response");
+  // GLM models (glm-4, glm-5) return content in reasoning_content field
+  const choice = response.choices[0]?.message;
+  const content = choice?.content ?? "";
+  const reasoningContent = (choice as { reasoning_content?: string } | undefined)?.reasoning_content ?? "";
+
+  // For GLM models, use reasoning_content when content is empty
+  const finalContent = content || reasoningContent;
+  if (!finalContent) throw new Error("LLM returned empty response");
 
   return {
-    content,
+    content: finalContent,
     usage: {
       promptTokens: response.usage?.prompt_tokens ?? 0,
       completionTokens: response.usage?.completion_tokens ?? 0,


### PR DESCRIPTION
## Summary
Add compatibility for Zhipu GLM responses where text may appear in `reasoning_content` when `content` is empty.

## Changes
- `packages/core/src/llm/provider.ts`
- Streaming path: accept `delta.reasoning_content` as output fallback.
- Sync path: fallback to `message.reasoning_content` when `message.content` is empty.
- Uses type assertions to keep TypeScript build passing.

## Why
Some GLM models can return:
- `content: ""`
- `reasoning_content: "actual text"`

Without this fallback, InkOS may throw `LLM returned empty response`.

## Validation
- `pnpm -r build` passes after changes.
- Runtime behavior verified with GLM endpoint.