### PR TITLE
fix: 修复 LLM 未正确输出完整章节内容导致的字数截断问题

### DIFF
--- a/packages/core/src/agents/reviser.ts
+++ b/packages/core/src/agents/reviser.ts
@@ -38,7 +38,7 @@ const MODE_DESCRIPTIONS: Record<ReviseMode, string> = {
 7. 群像反应具体化：✗"全场震惊" → ✓"老陈的烟掉在裤子上，烫得他跳起来"
 8. 段落长度差异化：不再等长段落，有的段只有一句话，有的段七八行
 9. 消灭"不禁""仿佛""宛如"等AI标记词：换成具体感官描写`,
-  "spot-fix": "定点修复：只修改审稿意见指出的具体句子或段落，其余所有内容必须原封不动保留。修改范围限定在问题句子及其前后各一句。禁止改动无关段落",
+  "spot-fix": "定点修复：只修改审稿意见指出的具体句子或段落，其余所有内容必须原封不动保留。修改范围限定在问题句子及其前后各一句。禁止改动无关段落。【重要】REVISED_CONTENT 必须输出修改后的完整章节正文，不是只输出修改的部分",
 };
 
 export class ReviserAgent extends BaseAgent {
@@ -165,7 +165,8 @@ ${styleGuide}
 ## 待修正章节
 ${chapterContent}`;
 
-    const maxTokens = mode === "spot-fix" ? 8192 : 16384;
+    // spot-fix needs full chapter output, use same limit as other modes
+    const maxTokens = 16384;
 
     const response = await this.chat(
       [

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -580,10 +580,17 @@ export class PipelineRunner {
         book.genre,
       );
       totalUsage = PipelineRunner.addUsage(totalUsage, fixResult.tokenUsage);
-      if (fixResult.revisedContent.length > 0) {
+      // Guard: only accept spot-fix if word count is at least 50% of original
+      const minAcceptable = Math.floor(finalContent.length * 0.5);
+      if (fixResult.revisedContent.length >= minAcceptable) {
         finalContent = fixResult.revisedContent;
         finalWordCount = fixResult.wordCount;
         revised = true;
+      } else {
+        this.config.logger?.warn(
+          `Spot-fix output too short (${fixResult.revisedContent.length} chars vs original ${finalContent.length}), keeping original content`,
+        );
+        // Keep finalContent unchanged, skip the broken spot-fix
       }
     }
 
@@ -622,7 +629,9 @@ export class PipelineRunner {
         );
         totalUsage = PipelineRunner.addUsage(totalUsage, reviseOutput.tokenUsage);
 
-        if (reviseOutput.revisedContent.length > 0) {
+        // Guard: only accept revision if word count is at least 50% of original
+        const minAcceptableLen = Math.floor(finalContent.length * 0.5);
+        if (reviseOutput.revisedContent.length >= minAcceptableLen) {
           // Guard: reject revision if AI markers increased
           const preMarkers = analyzeAITells(finalContent);
           const postMarkers = analyzeAITells(reviseOutput.revisedContent);
@@ -654,6 +663,10 @@ export class PipelineRunner {
             issues: [...reAudit.issues, ...reAITells.issues, ...reSensitive.issues],
             summary: reAudit.summary,
           };
+        } else if (reviseOutput.revisedContent.length > 0) {
+          this.config.logger?.warn(
+            `Revision output too short (${reviseOutput.revisedContent.length} chars vs original ${finalContent.length}), keeping original content`,
+          );
         }
       }
     }
@@ -1128,8 +1141,12 @@ ${matrix}`,
       chapterTitle: output.title,
     });
 
+    // Use finalContent directly instead of relying on LLM to "echo" it back
+    // This fixes the issue where Gemini truncates CHAPTER_CONTENT
     return {
       ...analyzed,
+      content: finalContent,
+      wordCount: finalContent.length,
       postWriteErrors: [],
       postWriteWarnings: [],
       tokenUsage: output.tokenUsage,


### PR DESCRIPTION
## 问题描述

使用 Gemini（及其他模型）时，修订/分析流程可能产生字数极少的章节（如 3000+ 字变成 20 字）。

### 复现步骤
1. 使用 Gemini 3 Flash Preview 作为 LLM
2. 写章时触发 spot-fix（如出现禁止句式）
3. 最终保存的章节字数可能只有几十字

### 根因分析
1. `ChapterAnalyzerAgent` 要求 LLM 在 `CHAPTER_CONTENT` 中"原样输出"章节内容
2. Gemini 不会可靠地输出完整内容（可能省略或截断）
3. 截断后的内容长度被用作 `wordCount`，覆盖了正确的值

## 解决方案

- 在 `buildPersistenceOutput` 中直接使用 `finalContent`，不再依赖 LLM 回显
- 添加字数守卫：修订后字数低于原文 50% 时拒绝修订
- spot-fix 的 `maxTokens` 从 8192 提升到 16384
- 强化 spot-fix 提示词，明确要求输出完整章节正文

## 测试

- [x] 使用 Gemini 3 Flash Preview 测试，字数截断问题已修复
- [x] 编译通过

---
🤖 Generated with [Claude Code](https://claude.ai/code)