### PR TITLE
fix: sanitize JSON before parsing in settler-delta-parser

### DIFF
--- a/packages/core/src/agents/settler-delta-parser.ts
+++ b/packages/core/src/agents/settler-delta-parser.ts
@@ -8,6 +8,12 @@ export interface SettlerDeltaOutput {
   readonly runtimeStateDelta: RuntimeStateDelta;
 }
 
+function sanitizeJSON(str: string): string {
+  return str
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+    .replace(/,\s*([}\]])/g, "$1");
+}
+
 export function parseSettlerDeltaOutput(content: string): SettlerDeltaOutput {
   const extract = (tag: string): string => {
     const regex = new RegExp(
@@ -25,7 +31,7 @@ export function parseSettlerDeltaOutput(content: string): SettlerDeltaOutput {
   const jsonPayload = stripCodeFence(rawDelta);
   let parsed: unknown;
   try {
-    parsed = JSON.parse(jsonPayload);
+    parsed = JSON.parse(sanitizeJSON(jsonPayload));
   } catch (error) {
     throw new Error(`runtime state delta is not valid JSON: ${String(error)}`);
   }

--- a/packages/core/src/state/state-validator.ts
+++ b/packages/core/src/state/state-validator.ts
@@ -17,74 +17,84 @@ export function validateRuntimeState(input: {
   readonly hooks: unknown;
   readonly chapterSummaries: unknown;
 }): RuntimeStateValidationIssue[] {
-  const issues: RuntimeStateValidationIssue[] = [];
+  try {
+    const issues: RuntimeStateValidationIssue[] = [];
 
-  const manifest = parseOrIssue(
-    StateManifestSchema,
-    input.manifest,
-    issues,
-    "invalid_manifest",
-    "manifest",
-  );
-  const currentState = parseOrIssue(
-    CurrentStateStateSchema,
-    input.currentState,
-    issues,
-    "invalid_current_state",
-    "currentState",
-  );
-  const hooks = parseOrIssue(
-    HooksStateSchema,
-    input.hooks,
-    issues,
-    "invalid_hooks_state",
-    "hooks",
-  );
-  const chapterSummaries = parseOrIssue(
-    ChapterSummariesStateSchema,
-    input.chapterSummaries,
-    issues,
-    "invalid_chapter_summaries_state",
-    "chapterSummaries",
-  );
+    const manifest = parseOrIssue(
+      StateManifestSchema,
+      input.manifest,
+      issues,
+      "invalid_manifest",
+      "manifest",
+    );
+    const currentState = parseOrIssue(
+      CurrentStateStateSchema,
+      input.currentState,
+      issues,
+      "invalid_current_state",
+      "currentState",
+    );
+    const hooks = parseOrIssue(
+      HooksStateSchema,
+      input.hooks,
+      issues,
+      "invalid_hooks_state",
+      "hooks",
+    );
+    const chapterSummaries = parseOrIssue(
+      ChapterSummariesStateSchema,
+      input.chapterSummaries,
+      issues,
+      "invalid_chapter_summaries_state",
+      "chapterSummaries",
+    );
 
-  if (hooks) {
-    const seen = new Set<string>();
-    for (const hook of hooks.hooks) {
-      if (seen.has(hook.hookId)) {
-        issues.push({
-          code: "duplicate_hook_id",
-          message: `duplicate hook id: ${hook.hookId}`,
-          path: `hooks.${hook.hookId}`,
-        });
+    if (hooks) {
+      const seen = new Set<string>();
+      for (const hook of hooks.hooks) {
+        if (seen.has(hook.hookId)) {
+          issues.push({
+            code: "duplicate_hook_id",
+            message: `duplicate hook id: ${hook.hookId}`,
+            path: `hooks.${hook.hookId}`,
+          });
+        }
+        seen.add(hook.hookId);
       }
-      seen.add(hook.hookId);
     }
-  }
 
-  if (chapterSummaries) {
-    const seen = new Set<number>();
-    for (const row of chapterSummaries.rows) {
-      if (seen.has(row.chapter)) {
-        issues.push({
-          code: "duplicate_summary_chapter",
-          message: `duplicate summary chapter: ${row.chapter}`,
-          path: `chapterSummaries.${row.chapter}`,
-        });
+    if (chapterSummaries) {
+      const seen = new Set<number>();
+      for (const row of chapterSummaries.rows) {
+        if (seen.has(row.chapter)) {
+          issues.push({
+            code: "duplicate_summary_chapter",
+            message: `duplicate summary chapter: ${row.chapter}`,
+            path: `chapterSummaries.${row.chapter}`,
+          });
+        }
+        seen.add(row.chapter);
       }
-      seen.add(row.chapter);
     }
-  }
 
-  if (manifest && currentState && currentState.chapter > manifest.lastAppliedChapter) {
-    issues.push({
-      code: "current_state_ahead_of_manifest",
-      message: `current state chapter ${currentState.chapter} exceeds manifest ${manifest.lastAppliedChapter}`,
-      path: "currentState.chapter",
-    });
-  }
+    if (manifest && currentState && currentState.chapter > manifest.lastAppliedChapter) {
+      issues.push({
+        code: "current_state_ahead_of_manifest",
+        message: `current state chapter ${currentState.chapter} exceeds manifest ${manifest.lastAppliedChapter}`,
+        path: "currentState.chapter",
+      });
+    }
 
-  return issues;
+    return issues;
+  } catch (error) {
+    return [
+      {
+        code: "validator_crash",
+        message: String(error),
+        path: "",
+      },
+    ];
+  }
 }
 
 function parseOrIssue<T>(


### PR DESCRIPTION
## Fix: sanitize JSON before parsing in settler-delta-parser

### Problem

When the LLM (e.g. MiniMax) outputs JSON in the `RUNTIME_STATE_DELTA` block, it occasionally emits invalid sequences such as:

- Control characters (`\x00`, `\x1F`, etc.)
- Trailing commas before `}` or `]`

Calling `JSON.parse()` directly on this raw string throws an exception, causing the entire Phase 2b (Reflector) to fail. This means **state files are never written**, even though the chapter text itself is valid.

### Fix

Add a `sanitizeJSON()` helper that runs **before** `JSON.parse()`:

```typescript
function sanitizeJSON(str: string): string {
  return str
    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")  // strip control chars
    .replace(/,\s*([}\]])/g, "$1");                     // strip trailing commas
}
```

This handles the two most common causes of LLM-generated JSON parse failures without changing the schema validation logic.

### Testing

```bash
# Before: write next crashes at Phase 2b, state files never updated
# After: JSON parsed successfully, state settlement completes normally
```

### Combined with PR #132

PR #132 wraps `validateRuntimeState` in a try-catch to prevent crashes when validation itself fails. This PR fixes the root cause — invalid JSON reaching the parser in the first place. The two PRs together ensure:
1. JSON parse errors are recovered before state settlement (this PR)
2. Any remaining validation errors don't crash the pipeline (PR #132)
