### PR TITLE
fix(build): restore workspace:* for internal deps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,8 +43,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@actalk/inkos-core": "1.1.1",
-    "@actalk/inkos-studio": "1.1.1",
+    "@actalk/inkos-core": "workspace:*",
+    "@actalk/inkos-studio": "workspace:*",
     "commander": "^13.0.0",
     "dotenv": "^16.4.0",
     "epub-gen-memory": "^1.0.10",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -28,7 +28,7 @@
     "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit"
   },
   "dependencies": {
-    "@actalk/inkos-core": "1.1.1",
+    "@actalk/inkos-core": "workspace:*",
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/geist": "^5.2.8",
     "@hono/node-server": "^1.13.0",


### PR DESCRIPTION
## Summary

Source manifests were rewritten from `workspace:*` to `"1.1.1"` in `0adfab8 chore(release): sync source manifests to v1.1.1`, which breaks both local builds and both CI workflows on pnpm 10. This PR reverts them to `workspace:*`, which is the intended state — the repo already has prepack/postpack hooks that handle version rewriting at publish time.

## Reproduce on current master

```bash
pnpm install --frozen-lockfile
# ERR_PNPM_OUTDATED_LOCKFILE
# specifiers in the lockfile don't match specifiers in package.json:
#   - @actalk/inkos-core (lockfile: workspace:*, manifest: 1.1.1)
#   - @actalk/inkos-studio (lockfile: workspace:*, manifest: 1.1.1)
```

```bash
pnpm install --no-frozen-lockfile && pnpm build
# packages/cli build: src/commands/write.ts(236,37): error TS2339:
#   Property 'resyncChapterArtifacts' does not exist on type 'PipelineRunner'.
# packages/studio build: src/api/server.ts(956,37): error TS2339:
#   Property 'resyncChapterArtifacts' does not exist on type 'PipelineRunner'.
```

## Two interlocking problems

### 1. Lockfile vs. manifest mismatch blocks `--frozen-lockfile`

`pnpm-lock.yaml` still records `specifier: workspace:*` for cli's `@actalk/inkos-core` / `@actalk/inkos-studio` and studio's `@actalk/inkos-core`, but the source manifests pin `"1.1.1"`. Both `.github/workflows/ci.yml` and `.github/workflows/release.yml` install with `--frozen-lockfile`, so install fails before anything else runs.

### 2. pnpm 10 no longer auto-links fixed-version internal deps

pnpm 10 changed `link-workspace-packages` default from `true` to `false`. With fixed-version specifiers (`"@actalk/inkos-core": "1.1.1"`), pnpm 10 resolves them from the npm registry rather than linking `packages/core`. The published `@actalk/inkos-core@1.1.1` predates `f660a35 feat(revision): add brief-aware revise/rewrite and chapter resync` (which added `PipelineRunner.resyncChapterArtifacts`), so cli's `write.ts` and studio's `server.ts` can't find the method and tsc fails.

## Root cause

The `workspace:*` → `"1.1.1"` rewrite in `0adfab8` was unnecessary. This repo already has all the machinery for publish-time version rewriting:

- `scripts/prepare-package-for-publish.mjs` — **prepack** hook that temporarily rewrites `workspace:*` to real versions before `npm pack` / `pnpm publish`
- `scripts/restore-package-json.mjs` — **postpack** hook that restores the original manifest afterward
- `scripts/set-package-versions.mjs` — invoked in `release.yml` to rewrite versions in CI before publish
- `scripts/verify-no-workspace-protocol.mjs` — explicitly documents that `workspace:*` source manifests are valid (see its header comment: *"safe to run on source manifests before prepack"*)

So the right source state is `workspace:*`, and the manual sync in `0adfab8` actively fought the designed flow.

## The fix

Revert `packages/cli/package.json` and `packages/studio/package.json` to `workspace:*` for internal deps. No lockfile changes needed — `pnpm-lock.yaml` already records `specifier: workspace:*` for these deps, so this single edit makes manifest and lockfile consistent again.

```diff
# packages/cli/package.json
-    "@actalk/inkos-core": "1.1.1",
-    "@actalk/inkos-studio": "1.1.1",
+    "@actalk/inkos-core": "workspace:*",
+    "@actalk/inkos-studio": "workspace:*",

# packages/studio/package.json
-    "@actalk/inkos-core": "1.1.1",
+    "@actalk/inkos-core": "workspace:*",
```

Release flow stays intact: both `set-package-versions.mjs` (in `release.yml`) and the `prepack` hook (as fallback) will replace `workspace:*` with the actual version before tarball creation and publish. `verify-no-workspace-protocol.mjs` already normalizes both forms.

## Verification (local, Node v25.6.1 / pnpm 10.16.1)

- [x] `pnpm install --frozen-lockfile` → `Lockfile is up to date, resolution step is skipped`
- [x] `pnpm build` → all three packages build cleanly
- [x] `pnpm test` → 82 passed, see pre-existing failures note below
- [x] `node packages/cli/dist/index.js --version` prints `1.1.1`
- [x] `ls -la packages/cli/node_modules/@actalk/inkos-core` confirms symlink to `../../../core` (local workspace, not the npm registry copy)

## ⚠️ Pre-existing test failures (unrelated to this PR)

`packages/cli` has 2 failing tests in `src/__tests__/studio.test.ts` that fail on master before this change too:

```
FAIL  studio command > launches TypeScript sources through tsx in monorepo mode
FAIL  studio command > launches built JavaScript entries through node
  TypeError: browser.unref is not a function
    at src/commands/studio.ts:141:13
```

Root cause is an incomplete vitest mock at `studio.test.ts:4-6`:

```typescript
const spawnMock = vi.fn(() => ({
  on: vi.fn(),
}));
```

The mock object only provides `on()`, but `studio.ts:141` calls `browser.unref()`. These tests were never touched by this PR (only two `package.json` files are modified). I can send a follow-up one-line PR adding `unref: vi.fn()` to the mock if you'd like.

## Test plan

- [ ] CI job `build-and-test` passes on PR (should now succeed for the first time in a while)
- [ ] CI job `verify-pack` passes (both `prepack`/`postpack` rewriting still holds the invariant)
- [ ] Maintainer sanity-checks that the next release still produces clean tarballs via the existing `release.yml` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)