### PR TITLE
parts of thfeat(studio): improve truth files filtering and UI feedback

### DIFF
--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -451,9 +451,9 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     const storyDir = join(bookDir, "story");
     try {
       const files = await readdir(storyDir);
-      const mdFiles = files.filter((f) => f.endsWith(".md") || f.endsWith(".json"));
+      const filteredFiles = files.filter((f) => TRUTH_FILES.includes(f));
       const result = await Promise.all(
-        mdFiles.map(async (f) => {
+        filteredFiles.map(async (f) => {
           const content = await readFile(join(storyDir, f), "utf-8");
           return { name: f, size: content.length, preview: content.slice(0, 200) };
         }),

--- a/packages/studio/src/pages/TruthFiles.tsx
+++ b/packages/studio/src/pages/TruthFiles.tsx
@@ -23,9 +23,15 @@ export function TruthFiles({ bookId, nav, theme, t }: { bookId: string; nav: Nav
   const [editMode, setEditMode] = useState(false);
   const [editText, setEditText] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
-  const { data: fileData, refetch: refetchFile } = useApi<{ file: string; content: string | null }>(
+  const { data: fileData, loading: fileLoading, error: fileError, refetch: refetchFile } = useApi<{ file: string; content: string | null }>(
     selected ? `/books/${bookId}/truth/${selected}` : "",
   );
+
+  // Clear edit mode when switching files
+  const handleSelect = (name: string) => {
+    setSelected(name);
+    setEditMode(false);
+  };
 
   const startEdit = () => {
     setEditText(fileData?.content ?? "");
@@ -72,7 +78,7 @@ export function TruthFiles({ bookId, nav, theme, t }: { bookId: string; nav: Nav
           {data?.files.map((f) => (
             <button
               key={f.name}
-              onClick={() => { setSelected(f.name); setEditMode(false); }}
+              onClick={() => handleSelect(f.name)}
               className={`w-full text-left px-3 py-2.5 text-sm border-b border-border/40 transition-colors ${
                 selected === f.name
                   ? "bg-primary/10 text-primary"
@@ -90,7 +96,15 @@ export function TruthFiles({ bookId, nav, theme, t }: { bookId: string; nav: Nav
 
         {/* Content viewer */}
         <div className={`border ${c.cardStatic} rounded-lg p-5 min-h-[400px] flex flex-col`}>
-          {selected && fileData?.content != null ? (
+          {fileLoading || (fileData && fileData.file !== selected) ? (
+            <div className="flex-1 flex items-center justify-center">
+              <div className="animate-pulse text-muted-foreground text-sm">Loading...</div>
+            </div>
+          ) : fileError ? (
+            <div className="flex-1 flex items-center justify-center">
+              <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md">{fileError}</div>
+            </div>
+          ) : selected && fileData?.content != null ? (
             <>
               <div className="flex items-center justify-end gap-2 mb-3">
                 {editMode ? (


### PR DESCRIPTION
## Summary
- Updated the studio server API to accurately filter story files using the `TRUTH_FILES` constant.
- Added explicit loading and error states to the TruthFiles page to improve UI feedback.
- Fixed an issue where stale content or edit mode would persist when switching between files.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation (optional)
To ensure the Truth Files feature only displays supported markdown/JSON files and provides a smoother user experience with proper loading/error indicators.

## Changes
| File | Change |
| :--- | :--- |
| packages/studio/src/api/server.ts | Updated readdir filtering to use `TRUTH_FILES` constant. |
| packages/studio/src/pages/TruthFiles.tsx | Integrated loading and error from `useApi`, and added state reset logic in `handleSelect`. |

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] Manual verification: Verified that only allowed files are listed, loading pulses appear, and edit mode resets correctly on file change.