### PR TITLE
fix(tui): fix chat truncation, book dir detection, and UI polish

### DIFF
--- a/packages/core/src/interaction/project-tools.ts
+++ b/packages/core/src/interaction/project-tools.ts
@@ -588,9 +588,13 @@ export function createInteractionToolsFromDeps(
               onTextDelta: hooks?.onChatTextDelta,
             },
           );
-        } catch {
+        } catch (err) {
           // Thinking models (e.g. kimi-k2.5) may return empty content for simple inputs.
-          // Fall through to the built-in reply below.
+          // Only swallow empty-content errors; re-throw everything else (network, auth, etc.)
+          const msg = err instanceof Error ? err.message : "";
+          if (!msg.includes("empty") && !msg.includes("content")) {
+            throw err;
+          }
         }
       }
 


### PR DESCRIPTION
## 改动摘要

### Bug 修复

- **对话截断**：移除 chat 和 developBookDraft 工具中硬编码的 `maxTokens` 上限（原为 240/700）。`ChatDepthProfile` 的 `maxTokens` 改为可选，默认深度 `normal` 不传 `maxTokens`，让模型自行决定输出长度。只有用户通过 `/depth light|deep` 显式设置时才传。
- **书目录检测**：`launchTui` 新增 `resolveProjectRoot()`，在书目录（`books/<id>/`）内运行 `inkos` 时自动向上解析到项目根目录。同时修复 `loadConfig` 未使用已解析的 projectRoot 的问题。
- **NL 路由误触**：`为什么`/`why` 仅在当前会话处于失败状态（`hasFailed`）时才路由到 `explain_failure`。
- **chat 错误兜底**：chat 工具的 LLM 调用增加 try-catch，thinking 模型返回空内容时优雅降级。
- **import future state 泄漏**：`resetImportReplayTruthFiles` 增加 `pending_hooks.md` 重置，防止 architect 返回的 future hooks 泄漏到 replay chapter 1 的上下文。修复 CI 预存在失败。

### Markdown 渲染

- assistant 消息接入 `marked` + `marked-terminal`，支持加粗、列表、表格等终端渲染。
- `strong` 选项保留 `**` 纯文本标记通过 reflow，在后处理阶段转换为 ANSI bold，防止换行劈开 ANSI 码。
- 剥离 `\x1b[0m` 全属性重置码，防止覆盖 Ink `<Text color>` 设置的颜色。
- 列表 bullet `*` → `·`，表头禁用红色样式。
- Terminal.app：使用 `stripAnsi` 保留 box-drawing 字符但去掉 ANSI 码。

### UI 布局

- 前缀图标（`◆` `│` `·`）使用 `<Box minWidth={2}>` 固定占位（Claude Code 同款）。Terminal.app 使用 main 分支同款简单布局。
- 用户消息正文使用 `ROLE_USER` 色。
- 移除 composer 状态栏和斜杠命令提示行、statusSecondaryLine、模式标签。
- 退格使用 `Intl.Segmenter` grapheme 感知。
- Page Up/Down 支持对话历史滚动。

## 测试

- [x] `interaction-chat-tokens.test.ts`：maxTokens 转发行为（3 条）
- [x] `markdown.test.ts`：bold、bullet、bold leak、表格、`\x1b[0m` 剥离（7 条）
- [x] `tui-chat-depth.test.ts`：normal 深度无 maxTokens
- [x] `nl-router` 测试适配 `hasFailed`
- [x] `pipeline-runner.test.ts`：future state 泄漏修复（CI 预存在失败已修复）

## 已知限制

- Terminal.app 2.14 (macOS 14.5) 在 Ink TUI 中输入中文会触发 CoreGraphics SIGSEGV（`CGFontStrikeGetValue`）——main 分支同样存在此问题，非本 PR 引入。建议使用 iTerm2 或 Ghostty。

🤖 Generated with [Claude Code](https://claude.com/claude-code)