### PR TITLE
feat(studio): split session routing foundation from #182

### DIFF
--- a/packages/core/src/__tests__/book-session-store.test.ts
+++ b/packages/core/src/__tests__/book-session-store.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadBookSession,
+  persistBookSession,
+  listBookSessions,
+  findOrCreateBookSession,
+} from "../interaction/book-session-store.js";
+import { createBookSession, appendBookSessionMessage } from "../interaction/session.js";
+
+describe("book-session-store", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "inkos-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("persistBookSession + loadBookSession", () => {
+    it("round-trips a session", async () => {
+      const session = createBookSession("my-book");
+      await persistBookSession(tempDir, session);
+      const loaded = await loadBookSession(tempDir, session.sessionId);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.sessionId).toBe(session.sessionId);
+      expect(loaded!.bookId).toBe("my-book");
+    });
+
+    it("returns null for non-existent session", async () => {
+      const loaded = await loadBookSession(tempDir, "nonexistent");
+      expect(loaded).toBeNull();
+    });
+
+    it("persists messages", async () => {
+      let session = createBookSession("book");
+      session = appendBookSessionMessage(session, { role: "user" as const, content: "test", timestamp: 100 });
+      await persistBookSession(tempDir, session);
+      const loaded = await loadBookSession(tempDir, session.sessionId);
+      expect(loaded!.messages).toHaveLength(1);
+      expect(loaded!.messages[0].content).toBe("test");
+    });
+  });
+
+  describe("listBookSessions", () => {
+    it("returns empty for no sessions", async () => {
+      const list = await listBookSessions(tempDir, "no-book");
+      expect(list).toEqual([]);
+    });
+
+    it("filters by bookId", async () => {
+      const s1 = createBookSession("book-a");
+      const s2 = createBookSession("book-b");
+      const s3 = createBookSession("book-a");
+      await persistBookSession(tempDir, s1);
+      await persistBookSession(tempDir, s2);
+      await persistBookSession(tempDir, s3);
+
+      const listA = await listBookSessions(tempDir, "book-a");
+      expect(listA).toHaveLength(2);
+      expect(listA.every((s) => s.bookId === "book-a")).toBe(true);
+
+      const listB = await listBookSessions(tempDir, "book-b");
+      expect(listB).toHaveLength(1);
+    });
+
+    it("sorts by updatedAt descending", async () => {
+      const s1 = { ...createBookSession("book"), updatedAt: 100 };
+      const s2 = { ...createBookSession("book"), updatedAt: 300 };
+      const s3 = { ...createBookSession("book"), updatedAt: 200 };
+      await persistBookSession(tempDir, s1);
+      await persistBookSession(tempDir, s2);
+      await persistBookSession(tempDir, s3);
+
+      const list = await listBookSessions(tempDir, "book");
+      expect(list[0].updatedAt).toBe(300);
+      expect(list[1].updatedAt).toBe(200);
+      expect(list[2].updatedAt).toBe(100);
+    });
+
+    it("lists null bookId sessions", async () => {
+      const s = createBookSession(null);
+      await persistBookSession(tempDir, s);
+      const list = await listBookSessions(tempDir, null);
+      expect(list).toHaveLength(1);
+    });
+  });
+
+  describe("findOrCreateBookSession", () => {
+    it("creates new if none exist", async () => {
+      const session = await findOrCreateBookSession(tempDir, "new-book");
+      expect(session.bookId).toBe("new-book");
+      // Verify it was persisted
+      const loaded = await loadBookSession(tempDir, session.sessionId);
+      expect(loaded).not.toBeNull();
+    });
+
+    it("returns existing if found", async () => {
+      const existing = createBookSession("book");
+      await persistBookSession(tempDir, existing);
+      const found = await findOrCreateBookSession(tempDir, "book");
+      expect(found.sessionId).toBe(existing.sessionId);
+    });
+  });
+});

--- a/packages/core/src/__tests__/book-session.test.ts
+++ b/packages/core/src/__tests__/book-session.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  BookSessionSchema,
+  GlobalSessionSchema,
+  createBookSession,
+  appendBookSessionMessage,
+} from "../interaction/session.js";
+
+describe("BookSession", () => {
+  describe("BookSessionSchema", () => {
+    it("parses a valid session", () => {
+      const raw = {
+        sessionId: "123-abc",
+        bookId: "my-book",
+        messages: [],
+        draftRounds: [],
+        events: [],
+        createdAt: 1000,
+        updatedAt: 1000,
+      };
+      const result = BookSessionSchema.parse(raw);
+      expect(result.sessionId).toBe("123-abc");
+      expect(result.bookId).toBe("my-book");
+    });
+
+    it("accepts null bookId for draft sessions", () => {
+      const raw = {
+        sessionId: "123-abc",
+        bookId: null,
+        messages: [],
+        draftRounds: [],
+        events: [],
+        createdAt: 1000,
+        updatedAt: 1000,
+      };
+      const result = BookSessionSchema.parse(raw);
+      expect(result.bookId).toBeNull();
+    });
+
+    it("defaults empty arrays", () => {
+      const raw = {
+        sessionId: "123-abc",
+        bookId: null,
+        createdAt: 1000,
+        updatedAt: 1000,
+      };
+      const result = BookSessionSchema.parse(raw);
+      expect(result.messages).toEqual([]);
+      expect(result.draftRounds).toEqual([]);
+      expect(result.events).toEqual([]);
+    });
+  });
+
+  describe("GlobalSessionSchema", () => {
+    it("parses with defaults", () => {
+      const result = GlobalSessionSchema.parse({});
+      expect(result.automationMode).toBe("semi");
+      expect(result.activeBookId).toBeUndefined();
+    });
+
+    it("parses with values", () => {
+      const result = GlobalSessionSchema.parse({ activeBookId: "book-1", automationMode: "auto" });
+      expect(result.activeBookId).toBe("book-1");
+      expect(result.automationMode).toBe("auto");
+    });
+  });
+
+  describe("createBookSession", () => {
+    it("creates session with bookId", () => {
+      const session = createBookSession("my-book");
+      expect(session.bookId).toBe("my-book");
+      expect(session.sessionId).toBeTruthy();
+      expect(session.messages).toEqual([]);
+      expect(session.createdAt).toBeGreaterThan(0);
+      expect(session.updatedAt).toBe(session.createdAt);
+    });
+
+    it("creates session with null bookId", () => {
+      const session = createBookSession(null);
+      expect(session.bookId).toBeNull();
+    });
+
+    it("generates unique sessionIds", () => {
+      const a = createBookSession("book");
+      const b = createBookSession("book");
+      expect(a.sessionId).not.toBe(b.sessionId);
+    });
+  });
+
+  describe("appendBookSessionMessage", () => {
+    it("appends message and updates timestamp", () => {
+      const session = createBookSession("book");
+      const msg = { role: "user" as const, content: "hello", timestamp: Date.now() };
+      const updated = appendBookSessionMessage(session, msg);
+      expect(updated.messages).toHaveLength(1);
+      expect(updated.messages[0].content).toBe("hello");
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(session.updatedAt);
+    });
+
+    it("sorts messages by timestamp", () => {
+      let session = createBookSession("book");
+      session = appendBookSessionMessage(session, { role: "user" as const, content: "second", timestamp: 200 });
+      session = appendBookSessionMessage(session, { role: "assistant" as const, content: "first", timestamp: 100 });
+      expect(session.messages[0].content).toBe("first");
+      expect(session.messages[1].content).toBe("second");
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,12 @@ export {
   updateCreationDraft,
   appendInteractionMessage,
   appendInteractionEvent,
+  BookSessionSchema,
+  GlobalSessionSchema,
+  type BookSession,
+  type GlobalSession,
+  createBookSession,
+  appendBookSessionMessage,
 } from "./interaction/session.js";
 export {
   resolveProjectSessionPath,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,7 +117,10 @@ export {
   loadProjectSession,
   persistProjectSession,
   resolveSessionActiveBook,
+  loadGlobalSession,
+  persistGlobalSession,
 } from "./interaction/project-session-store.js";
+export { loadBookSession, persistBookSession, listBookSessions, findOrCreateBookSession } from "./interaction/book-session-store.js";
 export { routeInteractionRequest } from "./interaction/request-router.js";
 export {
   routeNaturalLanguageIntent,

--- a/packages/core/src/interaction/book-session-store.ts
+++ b/packages/core/src/interaction/book-session-store.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile, readdir, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { BookSessionSchema, createBookSession } from "./session.js";
+import type { BookSession } from "./session.js";
+
+const SESSIONS_DIR = ".inkos/sessions";
+
+function sessionsDir(projectRoot: string): string {
+  return join(projectRoot, SESSIONS_DIR);
+}
+
+function sessionPath(projectRoot: string, sessionId: string): string {
+  return join(sessionsDir(projectRoot), `${sessionId}.json`);
+}
+
+export async function loadBookSession(
+  projectRoot: string,
+  sessionId: string,
+): Promise<BookSession | null> {
+  try {
+    const raw = await readFile(sessionPath(projectRoot, sessionId), "utf-8");
+    return BookSessionSchema.parse(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export async function persistBookSession(
+  projectRoot: string,
+  session: BookSession,
+): Promise<void> {
+  const dir = sessionsDir(projectRoot);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    sessionPath(projectRoot, session.sessionId),
+    JSON.stringify(session, null, 2),
+  );
+}
+
+export async function listBookSessions(
+  projectRoot: string,
+  bookId: string | null,
+): Promise<ReadonlyArray<BookSession>> {
+  const dir = sessionsDir(projectRoot);
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const sessions: BookSession[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = await readFile(join(dir, file), "utf-8");
+      const session = BookSessionSchema.parse(JSON.parse(raw));
+      if (session.bookId === bookId) {
+        sessions.push(session);
+      }
+    } catch {
+      // skip corrupt files
+    }
+  }
+
+  return sessions.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export async function findOrCreateBookSession(
+  projectRoot: string,
+  bookId: string | null,
+): Promise<BookSession> {
+  const existing = await listBookSessions(projectRoot, bookId);
+  if (existing.length > 0) return existing[0];
+  const session = createBookSession(bookId);
+  await persistBookSession(projectRoot, session);
+  return session;
+}

--- a/packages/core/src/interaction/project-session-store.ts
+++ b/packages/core/src/interaction/project-session-store.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { InteractionSessionSchema, type InteractionSession } from "./session.js";
+import { InteractionSessionSchema, type InteractionSession, GlobalSessionSchema, type GlobalSession } from "./session.js";
 
 const SESSION_DIR = ".inkos";
 const SESSION_FILE = "session.json";
@@ -34,6 +34,28 @@ export async function persistProjectSession(
   const dir = join(projectRoot, SESSION_DIR);
   await mkdir(dir, { recursive: true });
   await writeFile(resolveProjectSessionPath(projectRoot), JSON.stringify(session, null, 2), "utf-8");
+}
+
+export async function loadGlobalSession(projectRoot: string): Promise<GlobalSession> {
+  try {
+    const raw = await readFile(join(projectRoot, SESSION_DIR, SESSION_FILE), "utf-8");
+    const data = JSON.parse(raw);
+    return GlobalSessionSchema.parse({
+      activeBookId: data.activeBookId,
+      automationMode: data.automationMode ?? "semi",
+    });
+  } catch {
+    return { automationMode: "semi" };
+  }
+}
+
+export async function persistGlobalSession(
+  projectRoot: string,
+  global: GlobalSession,
+): Promise<void> {
+  const dir = join(projectRoot, SESSION_DIR);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, SESSION_FILE), JSON.stringify(global, null, 2));
 }
 
 export async function resolveSessionActiveBook(

--- a/packages/core/src/interaction/session.ts
+++ b/packages/core/src/interaction/session.ts
@@ -59,6 +59,55 @@ export const InteractionSessionSchema = z.object({
 
 export type InteractionSession = z.infer<typeof InteractionSessionSchema>;
 
+// -- Per-book session --
+
+export const BookSessionSchema = z.object({
+  sessionId: z.string().min(1),
+  bookId: z.string().nullable(),
+  messages: z.array(InteractionMessageSchema).default([]),
+  creationDraft: BookCreationDraftSchema.optional(),
+  draftRounds: z.array(DraftRoundSchema).default([]),
+  events: z.array(InteractionEventSchema).default([]),
+  currentExecution: ExecutionStateSchema.optional(),
+  createdAt: z.number().int().nonnegative(),
+  updatedAt: z.number().int().nonnegative(),
+});
+
+export type BookSession = z.infer<typeof BookSessionSchema>;
+
+// -- Global session (simplified) --
+
+export const GlobalSessionSchema = z.object({
+  activeBookId: z.string().min(1).optional(),
+  automationMode: AutomationModeSchema.default("semi"),
+});
+
+export type GlobalSession = z.infer<typeof GlobalSessionSchema>;
+
+export function createBookSession(bookId: string | null): BookSession {
+  const now = Date.now();
+  return {
+    sessionId: `${now}-${Math.random().toString(36).slice(2, 8)}`,
+    bookId,
+    messages: [],
+    draftRounds: [],
+    events: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function appendBookSessionMessage(
+  session: BookSession,
+  message: InteractionMessage,
+): BookSession {
+  return {
+    ...session,
+    messages: [...session.messages, message].sort((a, b) => a.timestamp - b.timestamp),
+    updatedAt: Date.now(),
+  };
+}
+
 export function bindActiveBook(
   session: InteractionSession,
   bookId: string,

--- a/packages/core/src/interaction/session.ts
+++ b/packages/core/src/interaction/session.ts
@@ -44,12 +44,24 @@ export const BookCreationDraftSchema = z.object({
 
 export type BookCreationDraft = z.infer<typeof BookCreationDraftSchema>;
 
+export const DraftRoundSchema = z.object({
+  roundId: z.number().int().min(1),
+  userMessage: z.string(),
+  assistantRaw: z.string(),
+  fieldsUpdated: z.array(z.string()).default([]),
+  summary: z.string().default(""),
+  timestamp: z.number().int().nonnegative(),
+});
+
+export type DraftRound = z.infer<typeof DraftRoundSchema>;
+
 export const InteractionSessionSchema = z.object({
   sessionId: z.string().min(1),
   projectRoot: z.string().min(1),
   activeBookId: z.string().min(1).optional(),
   activeChapterNumber: z.number().int().min(1).optional(),
   creationDraft: BookCreationDraftSchema.optional(),
+  draftRounds: z.array(DraftRoundSchema).default([]),
   automationMode: AutomationModeSchema.default("semi"),
   messages: z.array(InteractionMessageSchema).default([]),
   events: z.array(InteractionEventSchema).default([]),
@@ -149,6 +161,7 @@ export function clearCreationDraft(session: InteractionSession): InteractionSess
   return {
     ...session,
     creationDraft: undefined,
+    draftRounds: [],
   };
 }
 

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from "react";
+import { useHashRoute } from "./hooks/use-hash-route";
+import type { HashRoute } from "./hooks/use-hash-route";
 import { Sidebar } from "./components/Sidebar";
 import { ChatPanel } from "./components/ChatBar";
 import { Dashboard } from "./pages/Dashboard";
@@ -23,30 +25,15 @@ import { postApi, useApi } from "./hooks/use-api";
 import { Sun, Moon, MessageSquare } from "lucide-react";
 import { DEFAULT_CHAT_OPEN } from "./app-state";
 
-export type Route =
-  | { page: "dashboard" }
-  | { page: "book"; bookId: string }
-  | { page: "book-create" }
-  | { page: "chapter"; bookId: string; chapterNumber: number }
-  | { page: "analytics"; bookId: string }
-  | { page: "config" }
-  | { page: "truth"; bookId: string }
-  | { page: "daemon" }
-  | { page: "logs" }
-  | { page: "genres" }
-  | { page: "style" }
-  | { page: "import" }
-  | { page: "radar" }
-  | { page: "doctor" };
+export type { HashRoute as Route } from "./hooks/use-hash-route";
 
-export function deriveActiveBookId(route: Route): string | undefined {
-  return route.page === "book" || route.page === "chapter" || route.page === "truth" || route.page === "analytics"
-    ? route.bookId
-    : undefined;
+export function deriveActiveBookId(route: HashRoute): string | undefined {
+  if ("bookId" in route) return route.bookId;
+  return undefined;
 }
 
 export function App() {
-  const [route, setRoute] = useState<Route>({ page: "dashboard" });
+  const { route, setRoute } = useHashRoute();
   const sse = useSSE();
   const { theme, setTheme } = useTheme();
   const { t } = useI18n();

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -14,10 +14,16 @@ import {
   processProjectInteractionInput,
   processProjectInteractionRequest,
   resolveSessionActiveBook,
+  findOrCreateBookSession,
+  listBookSessions,
+  loadBookSession,
+  persistBookSession,
+  appendBookSessionMessage,
   type PipelineConfig,
   type ProjectConfig,
   type LogSink,
   type LogEntry,
+  type BookSession,
 } from "@actalk/inkos-core";
 import { access, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
@@ -576,8 +582,35 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     });
   });
 
+  // -- Per-book session endpoints --
+
+  app.get("/api/sessions", async (c) => {
+    const bookId = c.req.query("bookId");
+    const sessions = await listBookSessions(root, bookId === undefined ? null : bookId === "null" ? null : bookId);
+    return c.json({ sessions: sessions.map((s) => ({
+      sessionId: s.sessionId,
+      bookId: s.bookId,
+      messageCount: s.messages.length,
+      createdAt: s.createdAt,
+      updatedAt: s.updatedAt,
+    })) });
+  });
+
+  app.get("/api/sessions/:sessionId", async (c) => {
+    const session = await loadBookSession(root, c.req.param("sessionId"));
+    if (!session) return c.json({ error: "Session not found" }, 404);
+    return c.json({ session });
+  });
+
+  app.post("/api/sessions", async (c) => {
+    const body = await c.req.json<{ bookId?: string | null }>().catch(() => ({}));
+    const bookId = (body as { bookId?: string | null }).bookId ?? null;
+    const session = await findOrCreateBookSession(root, bookId);
+    return c.json({ session });
+  });
+
   app.post("/api/agent", async (c) => {
-    const { instruction, activeBookId } = await c.req.json<{ instruction: string; activeBookId?: string }>();
+    const { instruction, activeBookId, sessionId } = await c.req.json<{ instruction: string; activeBookId?: string; sessionId?: string }>();
     if (!instruction?.trim()) {
       return c.json({ error: "No instruction provided" }, 400);
     }
@@ -596,7 +629,56 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
       const response = result.responseText ?? "Acknowledged.";
 
       broadcast("agent:complete", { instruction, activeBookId, response });
-      return c.json({ response, session: result.session, request: result.request });
+
+      // Dual-write to per-book BookSession
+      try {
+        let bookSession: BookSession;
+        if (sessionId) {
+          bookSession = await loadBookSession(root, sessionId) ?? await findOrCreateBookSession(root, activeBookId ?? null);
+        } else {
+          bookSession = await findOrCreateBookSession(root, activeBookId ?? null);
+        }
+
+        const userMsg = { role: "user" as const, content: instruction, timestamp: Date.now() };
+        bookSession = appendBookSessionMessage(bookSession, userMsg);
+
+        const responseText = result.responseText ?? "";
+        if (responseText) {
+          const assistantMsg = { role: "assistant" as const, content: responseText, timestamp: Date.now() + 1 };
+          bookSession = appendBookSessionMessage(bookSession, assistantMsg);
+        }
+
+        if (result.session?.currentExecution) {
+          bookSession = { ...bookSession, currentExecution: result.session.currentExecution };
+        }
+        if (result.session?.creationDraft) {
+          bookSession = { ...bookSession, creationDraft: result.session.creationDraft };
+        }
+
+        // If book was just created, update bookId on the session
+        const newBookId = result.session?.activeBookId;
+        if (newBookId && !bookSession.bookId) {
+          bookSession = { ...bookSession, bookId: newBookId };
+        }
+
+        await persistBookSession(root, bookSession);
+
+        // Include sessionId in response
+        return c.json({
+          response: result.responseText,
+          details: result.details,
+          session: { ...result.session, sessionId: bookSession.sessionId },
+          request: result.request,
+        });
+      } catch (e) {
+        // If dual-write fails, still return the original result
+        return c.json({
+          response: result.responseText,
+          details: result.details,
+          session: result.session,
+          request: result.request,
+        });
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       broadcast("agent:error", { instruction, activeBookId, error: msg });

--- a/packages/studio/src/hooks/use-hash-route.test.ts
+++ b/packages/studio/src/hooks/use-hash-route.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseHash, routeToHash } from "./use-hash-route";
+
+describe("hash route", () => {
+  describe("parseHash", () => {
+    it("parses empty hash as dashboard", () => {
+      expect(parseHash("")).toEqual({ page: "dashboard" });
+    });
+
+    it("parses #/ as dashboard", () => {
+      expect(parseHash("#/")).toEqual({ page: "dashboard" });
+    });
+
+    it("parses book route", () => {
+      expect(parseHash("#/book/my-novel")).toEqual({ page: "book", bookId: "my-novel" });
+    });
+
+    it("decodes encoded bookId", () => {
+      expect(parseHash("#/book/%E4%B9%9D%E9%BE%99")).toEqual({ page: "book", bookId: "九龙" });
+    });
+
+    it("parses book/new as book-create", () => {
+      expect(parseHash("#/book/new")).toEqual({ page: "book-create" });
+    });
+
+    it("parses config", () => {
+      expect(parseHash("#/config")).toEqual({ page: "config" });
+    });
+
+    it("falls back to dashboard for unknown hash", () => {
+      expect(parseHash("#/unknown/route")).toEqual({ page: "dashboard" });
+    });
+  });
+
+  describe("routeToHash", () => {
+    it("dashboard -> #/", () => {
+      expect(routeToHash({ page: "dashboard" })).toBe("#/");
+    });
+
+    it("book -> #/book/{id}", () => {
+      expect(routeToHash({ page: "book", bookId: "novel-1" })).toBe("#/book/novel-1");
+    });
+
+    it("encodes Chinese bookId", () => {
+      const hash = routeToHash({ page: "book", bookId: "九龙城夜行" });
+      expect(hash).toContain("#/book/");
+      expect(decodeURIComponent(hash)).toContain("九龙城夜行");
+    });
+
+    it("book-create -> #/book/new", () => {
+      expect(routeToHash({ page: "book-create" })).toBe("#/book/new");
+    });
+
+    it("config -> #/config", () => {
+      expect(routeToHash({ page: "config" })).toBe("#/config");
+    });
+
+    it("non-hash pages return empty string", () => {
+      expect(routeToHash({ page: "daemon" })).toBe("");
+      expect(routeToHash({ page: "logs" })).toBe("");
+    });
+  });
+});

--- a/packages/studio/src/hooks/use-hash-route.ts
+++ b/packages/studio/src/hooks/use-hash-route.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from "react";
+
+export type HashRoute =
+  | { page: "dashboard" }
+  | { page: "book"; bookId: string }
+  | { page: "book-create" }
+  | { page: "config" }
+  | { page: "chapter"; bookId: string; chapterNumber: number }
+  | { page: "analytics"; bookId: string }
+  | { page: "truth"; bookId: string }
+  | { page: "daemon" }
+  | { page: "logs" }
+  | { page: "genres" }
+  | { page: "style" }
+  | { page: "import" }
+  | { page: "radar" }
+  | { page: "doctor" };
+
+function parseHash(hash: string): HashRoute {
+  const path = hash.replace(/^#\/?/, "");
+
+  if (!path || path === "/") return { page: "dashboard" };
+  if (path === "config") return { page: "config" };
+  if (path === "book/new") return { page: "book-create" };
+
+  const bookMatch = path.match(/^book\/([^/]+)$/);
+  if (bookMatch) return { page: "book", bookId: decodeURIComponent(bookMatch[1]) };
+
+  return { page: "dashboard" };
+}
+
+function routeToHash(route: HashRoute): string {
+  switch (route.page) {
+    case "dashboard": return "#/";
+    case "book": return `#/book/${encodeURIComponent(route.bookId)}`;
+    case "book-create": return "#/book/new";
+    case "config": return "#/config";
+    default: return "";
+  }
+}
+
+const HASH_PAGES = new Set(["dashboard", "book", "book-create", "config"]);
+
+export function useHashRoute() {
+  const [route, setRouteState] = useState<HashRoute>(() => parseHash(window.location.hash));
+
+  useEffect(() => {
+    const onHashChange = () => setRouteState(parseHash(window.location.hash));
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
+  const setRoute = useCallback((newRoute: HashRoute) => {
+    if (HASH_PAGES.has(newRoute.page)) {
+      const hash = routeToHash(newRoute);
+      if (hash) {
+        window.location.hash = hash;
+        return;
+      }
+    }
+    setRouteState(newRoute);
+  }, []);
+
+  return { route, setRoute };
+}

--- a/packages/studio/src/hooks/use-hash-route.ts
+++ b/packages/studio/src/hooks/use-hash-route.ts
@@ -39,6 +39,8 @@ function routeToHash(route: HashRoute): string {
   }
 }
 
+export { parseHash, routeToHash }; // for testing
+
 const HASH_PAGES = new Set(["dashboard", "book", "book-create", "config"]);
 
 export function useHashRoute() {


### PR DESCRIPTION
## Summary
- add BookSession and GlobalSession core types plus per-book session storage
- add studio API endpoints for per-book session dual-write
- replace useState routing with URL hash persistence
- include phase 1a tests for session storage and hash routing

## Test Plan
- [ ] run core tests for book-session store and book-session types
- [ ] run studio test for use-hash-route