### PR TITLE
fix: preserve existing .gitignore during init

### DIFF
--- a/packages/cli/src/__tests__/cli-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-integration.test.ts
@@ -119,6 +119,22 @@ describe("CLI integration", () => {
       expect(output).toContain("Project initialized");
     });
 
+    it("preserves existing .gitignore entries when initializing into an existing directory", async () => {
+      const existingDir = join(projectDir, "gitignore-preserve");
+      await mkdir(existingDir, { recursive: true });
+      await writeFile(join(existingDir, ".gitignore"), ["dist/", "custom.cache"].join("\n"), "utf-8");
+
+      const output = run(["init", "gitignore-preserve"]);
+      expect(output).toContain("Project initialized");
+
+      const gitignore = await readFile(join(existingDir, ".gitignore"), "utf-8");
+      expect(gitignore).toContain("dist/");
+      expect(gitignore).toContain("custom.cache");
+      expect(gitignore).toContain(".env");
+      expect(gitignore).toContain("node_modules/");
+      expect(gitignore).toContain(".DS_Store");
+    });
+
     it("creates inkos.json in subdirectory", async () => {
       const raw = await readFile(join(projectDir, "subproject", "inkos.json"), "utf-8");
       const config = JSON.parse(raw);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { access, readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, basename, resolve } from "node:path";
+import { ensureProjectGitignore } from "../project-files.js";
 import { log, logError, GLOBAL_ENV_PATH } from "../utils.js";
 
 async function hasGlobalConfig(): Promise<boolean> {
@@ -115,11 +116,7 @@ export const initCommand = new Command("init")
         );
       }
 
-      await writeFile(
-        join(projectDir, ".gitignore"),
-        [".env", "node_modules/", ".DS_Store"].join("\n"),
-        "utf-8",
-      );
+      await ensureProjectGitignore(projectDir);
 
       log(`Project initialized at ${projectDir}`);
       log("");

--- a/packages/cli/src/project-files.ts
+++ b/packages/cli/src/project-files.ts
@@ -1,0 +1,32 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const DEFAULT_GITIGNORE_ENTRIES = [".env", "node_modules/", ".DS_Store"] as const;
+
+export async function ensureProjectGitignore(projectRoot: string): Promise<void> {
+  const gitignorePath = join(projectRoot, ".gitignore");
+  let existingContent: string | undefined;
+
+  try {
+    existingContent = await readFile(gitignorePath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  if (existingContent === undefined) {
+    await writeFile(gitignorePath, DEFAULT_GITIGNORE_ENTRIES.join("\n"), "utf-8");
+    return;
+  }
+
+  const existingEntries = new Set(
+    existingContent.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0),
+  );
+  const missingEntries = DEFAULT_GITIGNORE_ENTRIES.filter((entry) => !existingEntries.has(entry));
+
+  if (missingEntries.length === 0) return;
+
+  const eol = existingContent.includes("\r\n") ? "\r\n" : "\n";
+  const needsSeparator = existingContent.length > 0 && !existingContent.endsWith("\n") && !existingContent.endsWith("\r\n");
+  const mergedContent = `${existingContent}${needsSeparator ? eol : ""}${missingEntries.join(eol)}`;
+  await writeFile(gitignorePath, mergedContent, "utf-8");
+}

--- a/packages/cli/src/tui/setup.ts
+++ b/packages/cli/src/tui/setup.ts
@@ -9,6 +9,7 @@ import {
   brightCyan, brightGreen, brightWhite,
 } from "./ansi.js";
 import { resolveTuiLocale, type TuiLocale } from "./i18n.js";
+import { ensureProjectGitignore } from "../project-files.js";
 import { GLOBAL_ENV_PATH } from "../utils.js";
 
 const PROVIDERS = ["openai", "anthropic", "custom"] as const;
@@ -268,11 +269,7 @@ async function autoInit(cwd: string): Promise<void> {
     );
   }
 
-  await writeFile(
-    join(cwd, ".gitignore"),
-    [".env", "node_modules/", ".DS_Store"].join("\n"),
-    "utf-8",
-  );
+  await ensureProjectGitignore(cwd);
 
   console.log(`  ${c("✓", brightGreen, bold)} ${c(messages.initialized, dim)}`);
 }


### PR DESCRIPTION
## Summary
- preserve existing `.gitignore` contents during `inkos init` instead of overwriting the file
- reuse the same merge helper for TUI auto-init so both initialization paths keep user ignore rules
- add a CLI integration regression test for initializing into a directory that already has a `.gitignore`

## Testing
- `pnpm --filter @actalk/inkos-core build`
- `pnpm --filter @actalk/inkos build`
- `pnpm --filter @actalk/inkos exec vitest run src/__tests__/cli-integration.test.ts --pool=threads`