### PR TITLE
fix(cli): remove duplicate Anthropic env example

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -107,7 +107,6 @@ export const initCommand = new Command("init")
             "",
             "# Anthropic example:",
             "# INKOS_LLM_PROVIDER=anthropic",
-            "# INKOS_LLM_PROVIDER=anthropic",
             "# INKOS_LLM_BASE_URL=",
             "# INKOS_LLM_MODEL=",
           ].join("\n"),


### PR DESCRIPTION
## Summary
- remove the duplicated `# INKOS_LLM_PROVIDER=anthropic` line from the Anthropic example in `packages/cli/src/commands/init.ts`
- 中文：删除 `packages/cli/src/commands/init.ts` 中 Anthropic 示例里重复的一行 `# INKOS_LLM_PROVIDER=anthropic`。

## Testing
- `pnpm.cmd --filter @actalk/inkos build`