### PR TITLE
feat: Studio polish — Anthropic endpoints, model picker, sidebar, API key validation

### DIFF
--- a/packages/cli/src/__tests__/auto-init.test.ts
+++ b/packages/cli/src/__tests__/auto-init.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+// Mock readline to simulate user input
+const questionMock = vi.fn();
+const closeMock = vi.fn();
+vi.mock("node:readline", () => ({
+  createInterface: () => ({
+    question: questionMock,
+    close: closeMock,
+  }),
+}));
+
+// Mock loadProjectConfig from core
+const loadProjectConfigMock = vi.fn();
+vi.mock("@actalk/inkos-core", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loadProjectConfig: (...args: unknown[]) => loadProjectConfigMock(...args),
+  };
+});
+
+describe("loadConfig auto-init", () => {
+  let tmpDir: string;
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await mkdtemp(join(tmpdir(), "inkos-auto-init-"));
+  });
+
+  afterEach(async () => {
+    process.stdin.isTTY = originalIsTTY;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("prompts and auto-initializes when inkos.json is missing in TTY mode", async () => {
+    process.stdin.isTTY = true;
+
+    // First call: throw "not found"; second call after init: succeed
+    const fakeConfig = { llm: { provider: "openai", baseUrl: "", model: "", apiKey: "" } };
+    loadProjectConfigMock
+      .mockRejectedValueOnce(new Error(`inkos.json not found in ${tmpDir}.`))
+      .mockResolvedValueOnce(fakeConfig);
+
+    // Simulate user pressing Enter (empty = default Y)
+    questionMock.mockImplementation((_q: string, cb: (answer: string) => void) => cb(""));
+
+    const { loadConfig } = await import("../utils.js");
+    const result = await loadConfig({ projectRoot: tmpDir, requireApiKey: false });
+
+    expect(result).toEqual(fakeConfig);
+    expect(loadProjectConfigMock).toHaveBeenCalledTimes(2);
+
+    // Verify files were created
+    const inkosJson = JSON.parse(await readFile(join(tmpDir, "inkos.json"), "utf-8"));
+    expect(inkosJson.version).toBe("0.1.0");
+    expect(inkosJson.language).toBe("zh");
+    expect((await stat(join(tmpDir, "books"))).isDirectory()).toBe(true);
+  });
+
+  it("throws the original error when user declines init", async () => {
+    process.stdin.isTTY = true;
+
+    loadProjectConfigMock
+      .mockRejectedValue(new Error(`inkos.json not found in ${tmpDir}.`));
+
+    // Simulate user typing "n"
+    questionMock.mockImplementation((_q: string, cb: (answer: string) => void) => cb("n"));
+
+    const { loadConfig } = await import("../utils.js");
+
+    await expect(loadConfig({ projectRoot: tmpDir, requireApiKey: false }))
+      .rejects.toThrow(/inkos\.json not found/);
+  });
+
+  it("throws immediately in non-TTY mode without prompting", async () => {
+    process.stdin.isTTY = false;
+
+    loadProjectConfigMock
+      .mockRejectedValue(new Error(`inkos.json not found in ${tmpDir}.`));
+
+    const { loadConfig } = await import("../utils.js");
+
+    await expect(loadConfig({ projectRoot: tmpDir, requireApiKey: false }))
+      .rejects.toThrow(/inkos\.json not found/);
+
+    // Should not have prompted
+    expect(questionMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/__tests__/studio-runtime.test.ts
+++ b/packages/cli/src/__tests__/studio-runtime.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const accessMock = vi.fn();
 const testDir = dirname(fileURLToPath(import.meta.url));
@@ -52,7 +52,7 @@ describe("studio runtime resolution", () => {
     expect(launch).toEqual({
       studioEntry: tsSourceEntry,
       command: "node",
-      args: ["--import", tsxLoader, tsSourceEntry, "/repo/test-project"],
+      args: ["--import", pathToFileURL(tsxLoader).href, tsSourceEntry, "/repo/test-project"],
     });
   });
 

--- a/packages/cli/src/__tests__/studio-runtime.test.ts
+++ b/packages/cli/src/__tests__/studio-runtime.test.ts
@@ -110,6 +110,22 @@ describe("studio runtime resolution", () => {
     });
   });
 
+  it("emits a file:// URL for --import to prevent Windows ERR_UNSUPPORTED_ESM_URL_SCHEME", async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === tsSourceEntry || path === tsxLoader) {
+        return;
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const { resolveStudioLaunch } = await import("../commands/studio.js");
+    const launch = await resolveStudioLaunch("/repo/test-project");
+
+    const importArg = launch!.args[1]!;
+    expect(importArg).toMatch(/^file:\/\//);
+    expect(importArg).toBe(pathToFileURL(tsxLoader).href);
+  });
+
   it("returns a browser launch spec for macOS", async () => {
     const { resolveBrowserLaunch } = await import("../commands/studio.js");
     expect(resolveBrowserLaunch("darwin", "http://localhost:4567")).toEqual({

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -3,7 +3,7 @@ import { findProjectRoot, log, logError } from "../utils.js";
 import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { access } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export interface StudioLaunchSpec {
   readonly studioEntry: string;
@@ -62,7 +62,7 @@ export async function resolveStudioLaunch(root: string): Promise<StudioLaunchSpe
       return {
         studioEntry: sourceEntry,
         command: "node",
-        args: ["--import", localTsxLoader, sourceEntry, root],
+        args: ["--import", pathToFileURL(localTsxLoader).href, sourceEntry, root],
       };
     }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,6 @@
-import { readFile, stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { readFile, stat, writeFile, mkdir, access } from "node:fs/promises";
+import { join, resolve, basename } from "node:path";
+import { createInterface } from "node:readline";
 import { createLLMClient, StateManager, createLogger, createStderrSink, createJsonLineSink, loadProjectConfig, GLOBAL_CONFIG_DIR, GLOBAL_ENV_PATH, type ProjectConfig, type PipelineConfig, type LogSink } from "@actalk/inkos-core";
 import { formatSqliteMemorySupportWarning } from "./runtime-requirements.js";
 
@@ -32,7 +33,95 @@ export function findProjectRoot(): string {
 }
 
 export async function loadConfig(options?: { readonly requireApiKey?: boolean; readonly projectRoot?: string }): Promise<ProjectConfig> {
-  return loadProjectConfig(options?.projectRoot ?? findProjectRoot(), options);
+  const root = options?.projectRoot ?? findProjectRoot();
+  try {
+    return await loadProjectConfig(root, options);
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("inkos.json not found") && process.stdin.isTTY) {
+      const confirmed = await promptYesNo("当前目录还没有初始化 InkOS 项目，要在这里创建一个吗？");
+      if (confirmed) {
+        await autoInit(root);
+        return loadProjectConfig(root, options);
+      }
+    }
+    throw e;
+  }
+}
+
+async function promptYesNo(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(`${question} (Y/n) `, (answer) => {
+      rl.close();
+      resolve(!answer || answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+async function autoInit(root: string): Promise<void> {
+  await mkdir(join(root, "books"), { recursive: true });
+  await mkdir(join(root, "radar"), { recursive: true });
+
+  const config = {
+    name: basename(root),
+    version: "0.1.0",
+    language: "zh",
+    llm: {
+      provider: process.env.INKOS_LLM_PROVIDER ?? "openai",
+      baseUrl: process.env.INKOS_LLM_BASE_URL ?? "",
+      model: process.env.INKOS_LLM_MODEL ?? "",
+    },
+    notify: [],
+    daemon: {
+      schedule: {
+        radarCron: "0 */6 * * *",
+        writeCron: "*/15 * * * *",
+      },
+      maxConcurrentBooks: 3,
+    },
+  };
+
+  await writeFile(join(root, "inkos.json"), JSON.stringify(config, null, 2), "utf-8");
+
+  // 如果已有全局配置，项目 .env 只留注释；否则引导填写
+  let hasGlobal = false;
+  try {
+    const content = await readFile(join(GLOBAL_CONFIG_DIR, ".env"), "utf-8");
+    hasGlobal = content.includes("INKOS_LLM_API_KEY=") && !content.includes("your-api-key-here");
+  } catch { /* no global config */ }
+
+  const envContent = hasGlobal
+    ? [
+        "# 项目级 LLM 覆盖（可选）",
+        "# 全局配置 ~/.inkos/.env 会自动生效。",
+        "# 如需单独覆盖，取消下面的注释：",
+        "# INKOS_LLM_PROVIDER=openai",
+        "# INKOS_LLM_BASE_URL=",
+        "# INKOS_LLM_API_KEY=",
+        "# INKOS_LLM_MODEL=",
+      ].join("\n")
+    : [
+        "# LLM 配置",
+        "# 推荐：运行 inkos config set-global 一次性设好全局配置。",
+        "INKOS_LLM_PROVIDER=openai",
+        "INKOS_LLM_BASE_URL=",
+        "INKOS_LLM_API_KEY=",
+        "INKOS_LLM_MODEL=",
+      ].join("\n");
+
+  await writeFile(join(root, ".env"), envContent, "utf-8");
+
+  // 只在 .gitignore 不存在时写入
+  try {
+    await access(join(root, ".gitignore"));
+  } catch {
+    await writeFile(join(root, ".gitignore"), [".env", "node_modules/", ".DS_Store"].join("\n"), "utf-8");
+  }
+
+  log(`项目已初始化：${root}`);
+  if (!hasGlobal) {
+    log("下一步：运行 inkos config set-global 配置 LLM，或编辑 .env 文件。");
+  }
 }
 
 export function createClient(config: ProjectConfig) {

--- a/packages/core/src/__tests__/book-title-backfill.test.ts
+++ b/packages/core/src/__tests__/book-title-backfill.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Replicate the title extraction regex from agent-tools.ts architect branch.
+ * This tests the pattern matching logic independently.
+ */
+function extractTitleFromBible(bible: string): string | undefined {
+  const titleMatch = bible.match(/(?:书名|Title)\s*[:：]\s*[《「]?(.+?)[》」]?\s*(?:\n|$)/i)
+    ?? bible.match(/^#\s+(.+)/m);
+  return titleMatch?.[1]?.trim();
+}
+
+describe("book title backfill — extractTitleFromBible", () => {
+  it("extracts title from 书名: 格式", () => {
+    const bible = "## 基本信息\n\n书名：堕仙杀劫\n\n简介：...";
+    expect(extractTitleFromBible(bible)).toBe("堕仙杀劫");
+  });
+
+  it("extracts title from 书名：《书名》格式 (with brackets)", () => {
+    const bible = "书名：《九龙城夜行》\n简介：一个发生在...";
+    expect(extractTitleFromBible(bible)).toBe("九龙城夜行");
+  });
+
+  it("extracts title from Title: format (English)", () => {
+    const bible = "Title: The Last Dragon\nSynopsis: ...";
+    expect(extractTitleFromBible(bible)).toBe("The Last Dragon");
+  });
+
+  it("falls back to first heading if no 书名/Title line", () => {
+    const bible = "# 天道独行\n\n这是一个关于修仙的故事";
+    expect(extractTitleFromBible(bible)).toBe("天道独行");
+  });
+
+  it("returns undefined for empty content", () => {
+    expect(extractTitleFromBible("")).toBeUndefined();
+  });
+
+  it("returns undefined for content without title or heading", () => {
+    const bible = "这是世界观设定的详细描述，没有标题行。";
+    expect(extractTitleFromBible(bible)).toBeUndefined();
+  });
+
+  it("extracts title with「」brackets", () => {
+    const bible = "书名：「异常体」\n简介：...";
+    expect(extractTitleFromBible(bible)).toBe("异常体");
+  });
+
+  it("handles colon variants (English colon)", () => {
+    const bible = "书名: 废柴逆袭录\n简介：...";
+    expect(extractTitleFromBible(bible)).toBe("废柴逆袭录");
+  });
+});

--- a/packages/core/src/__tests__/service-presets-regression.test.ts
+++ b/packages/core/src/__tests__/service-presets-regression.test.ts
@@ -3,15 +3,15 @@ import { resolveServicePreset, listModelsForService } from "../llm/service-prese
 
 describe("service-presets regression", () => {
   describe("MiniMax preset", () => {
-    it("has correct OpenAI-compatible baseUrl (api.minimaxi.com, not api.minimax.chat)", () => {
+    it("has correct Anthropic-compatible baseUrl", () => {
       const preset = resolveServicePreset("minimax");
       expect(preset).toBeDefined();
-      expect(preset!.baseUrl).toBe("https://api.minimaxi.com/v1");
+      expect(preset!.baseUrl).toBe("https://api.minimaxi.com/anthropic");
     });
 
-    it("uses openai-completions api format", () => {
+    it("uses anthropic-messages api format", () => {
       const preset = resolveServicePreset("minimax");
-      expect(preset!.api).toBe("openai-completions");
+      expect(preset!.api).toBe("anthropic-messages");
     });
 
     it("has knownModels with all 7 MiniMax models", () => {

--- a/packages/core/src/__tests__/service-presets-regression.test.ts
+++ b/packages/core/src/__tests__/service-presets-regression.test.ts
@@ -66,4 +66,27 @@ describe("service-presets regression", () => {
       expect(SERVICE_TO_PI_PROVIDER.bailian).toBe("anthropic");
     });
   });
+
+  describe("modelsBaseUrl", () => {
+    it("百炼 uses modelsBaseUrl (OpenAI) for model listing, not baseUrl (Anthropic)", () => {
+      const preset = resolveServicePreset("bailian");
+      // modelsBaseUrl is the OpenAI-compatible endpoint that supports GET /models
+      expect(preset!.modelsBaseUrl).toContain("compatible-mode");
+      // baseUrl is the Anthropic endpoint for chat
+      expect(preset!.baseUrl).toContain("anthropic");
+      // They must differ
+      expect(preset!.modelsBaseUrl).not.toBe(preset!.baseUrl);
+    });
+
+    it("minimax has no modelsBaseUrl (uses knownModels instead)", () => {
+      const preset = resolveServicePreset("minimax");
+      expect(preset!.modelsBaseUrl).toBeUndefined();
+      expect(preset!.knownModels!.length).toBeGreaterThan(0);
+    });
+
+    it("openai has no modelsBaseUrl (baseUrl serves both)", () => {
+      const preset = resolveServicePreset("openai");
+      expect(preset!.modelsBaseUrl).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/__tests__/service-presets-regression.test.ts
+++ b/packages/core/src/__tests__/service-presets-regression.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveServicePreset, listModelsForService } from "../llm/service-presets.js";
+import { resolveServicePreset, listModelsForService, SERVICE_TO_PI_PROVIDER } from "../llm/service-presets.js";
 
 describe("service-presets regression", () => {
   describe("MiniMax preset", () => {
@@ -25,6 +25,25 @@ describe("service-presets regression", () => {
     });
   });
 
+  describe("百炼 preset", () => {
+    it("uses Anthropic-compatible endpoint for chat (tools+stream support)", () => {
+      const preset = resolveServicePreset("bailian");
+      expect(preset).toBeDefined();
+      expect(preset!.api).toBe("anthropic-messages");
+      expect(preset!.baseUrl).toBe("https://dashscope.aliyuncs.com/apps/anthropic");
+    });
+
+    it("has separate modelsBaseUrl for OpenAI-compatible /models endpoint", () => {
+      const preset = resolveServicePreset("bailian");
+      expect(preset!.modelsBaseUrl).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1");
+    });
+
+    it("modelsBaseUrl differs from baseUrl", () => {
+      const preset = resolveServicePreset("bailian");
+      expect(preset!.modelsBaseUrl).not.toBe(preset!.baseUrl);
+    });
+  });
+
   describe("listModelsForService", () => {
     it("returns knownModels immediately for minimax without calling /models API", async () => {
       const models = await listModelsForService("minimax");
@@ -35,6 +54,16 @@ describe("service-presets regression", () => {
     it("returns empty for custom service", async () => {
       const models = await listModelsForService("custom");
       expect(models).toEqual([]);
+    });
+  });
+
+  describe("SERVICE_TO_PI_PROVIDER mapping", () => {
+    it("maps minimax to anthropic provider", () => {
+      expect(SERVICE_TO_PI_PROVIDER.minimax).toBe("anthropic");
+    });
+
+    it("maps bailian to anthropic provider", () => {
+      expect(SERVICE_TO_PI_PROVIDER.bailian).toBe("anthropic");
     });
   });
 });

--- a/packages/core/src/__tests__/service-resolver-regression.test.ts
+++ b/packages/core/src/__tests__/service-resolver-regression.test.ts
@@ -47,15 +47,15 @@ describe("resolveServiceModel regression — preset baseUrl override", () => {
   it("uses preset baseUrl, not pi-ai built-in baseUrl", async () => {
     const result = await resolveServiceModel("minimax", "MiniMax-M2.7", root);
 
-    // Must use our preset (api.minimaxi.com), NOT pi-ai's (api.minimax.io/anthropic)
-    expect(result.model.baseUrl).toBe("https://api.minimaxi.com/v1");
+    // Must use our preset (domestic Anthropic endpoint), NOT pi-ai's (international)
+    expect(result.model.baseUrl).toBe("https://api.minimaxi.com/anthropic");
   });
 
   it("uses preset api format, not pi-ai built-in api format", async () => {
     const result = await resolveServiceModel("minimax", "MiniMax-M2.7", root);
 
-    // Must use openai-completions (our preset), NOT anthropic-messages (pi-ai)
-    expect(result.model.api).toBe("openai-completions");
+    // Must use anthropic-messages (our preset)
+    expect(result.model.api).toBe("anthropic-messages");
   });
 
   it("inherits metadata from pi-ai (reasoning, cost, contextWindow)", async () => {

--- a/packages/core/src/__tests__/service-resolver-regression.test.ts
+++ b/packages/core/src/__tests__/service-resolver-regression.test.ts
@@ -75,3 +75,38 @@ describe("resolveServiceModel regression — preset baseUrl override", () => {
     expect(result.model.baseUrl).toBe("https://custom-proxy.example.com/v1");
   });
 });
+
+describe("resolveServiceModel regression — 百炼 Anthropic endpoint", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "inkos-resolver-bailian-"));
+    await mkdir(join(root, ".inkos"), { recursive: true });
+    await writeFile(
+      join(root, ".inkos", "secrets.json"),
+      JSON.stringify({ services: { bailian: { apiKey: "sk-bailian-test" } } }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("uses Anthropic baseUrl from preset", async () => {
+    const result = await resolveServiceModel("bailian", "qwen-plus", root);
+
+    expect(result.model.baseUrl).toBe("https://dashscope.aliyuncs.com/apps/anthropic");
+  });
+
+  it("uses anthropic-messages api format", async () => {
+    const result = await resolveServiceModel("bailian", "qwen-plus", root);
+
+    expect(result.model.api).toBe("anthropic-messages");
+  });
+
+  it("uses anthropic as provider", async () => {
+    const result = await resolveServiceModel("bailian", "qwen-plus", root);
+
+    expect(result.model.provider).toBe("anthropic");
+  });
+});

--- a/packages/core/src/agent/agent-session.ts
+++ b/packages/core/src/agent/agent-session.ts
@@ -230,7 +230,7 @@ export async function runAgentSession(
         model,
         systemPrompt: buildAgentSystemPrompt(bookId, language),
         tools: [
-          createSubAgentTool(pipeline, bookId),
+          createSubAgentTool(pipeline, bookId, projectRoot),
           createReadTool(projectRoot),
           createEditTool(projectRoot),
           createGrepTool(projectRoot),

--- a/packages/core/src/agent/agent-tools.ts
+++ b/packages/core/src/agent/agent-tools.ts
@@ -41,7 +41,7 @@ const SubAgentParams = Type.Object({
   bookId: Type.Optional(Type.String({ description: "Book ID — required for all agents except architect" })),
 });
 
-export function createSubAgentTool(pipeline: PipelineRunner, activeBookId: string | null): AgentTool<typeof SubAgentParams> {
+export function createSubAgentTool(pipeline: PipelineRunner, activeBookId: string | null, projectRoot?: string): AgentTool<typeof SubAgentParams> {
   return {
     name: "sub_agent",
     description:
@@ -75,6 +75,23 @@ export function createSubAgentTool(pipeline: PipelineRunner, activeBookId: strin
               { id, genre: "general", title: "", language: "zh" } as any,
               { externalContext: instruction },
             );
+            // Extract title from story_bible.md and backfill into book.json
+            try {
+              if (!projectRoot) throw new Error("no projectRoot");
+              const booksRoot = join(projectRoot, "books");
+              const biblePath = join(booksRoot, id, "story", "story_bible.md");
+              const bible = await readFile(biblePath, "utf-8");
+              const titleMatch = bible.match(/(?:书名|Title)\s*[:：]\s*[《「]?(.+?)[》」]?\s*(?:\n|$)/i)
+                ?? bible.match(/^#\s+(.+)/m);
+              if (titleMatch?.[1]) {
+                const bookJsonPath = join(booksRoot, id, "book.json");
+                const config = JSON.parse(await readFile(bookJsonPath, "utf-8"));
+                if (!config.title) {
+                  config.title = titleMatch[1].trim();
+                  await writeFile(bookJsonPath, JSON.stringify(config, null, 2), "utf-8");
+                }
+              }
+            } catch { /* best-effort */ }
             progress(`Architect finished — book "${id}" foundation created.`);
             return textResult(`Book "${id}" initialised successfully. Foundation files are ready.`);
           }

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -16,7 +16,7 @@ export const SERVICE_PRESETS: Record<string, ServicePreset> = {
   deepseek:    { api: "openai-completions",  baseUrl: "https://api.deepseek.com",                          label: "DeepSeek",        temperatureRange: [0, 2], defaultTemperature: 1.0, writingTemperature: 1.5, temperatureHint: "创意写作推荐 1.5" },
   moonshot:    { api: "openai-completions",  baseUrl: "https://api.moonshot.cn/v1",                        label: "Moonshot (Kimi)", temperatureRange: [0, 1], defaultTemperature: 0.3, writingTemperature: 1.0, temperatureHint: "kimi-k2.5 推荐 temperature=1.0" },
   minimax:     { api: "anthropic-messages",  baseUrl: "https://api.minimaxi.com/anthropic",                label: "MiniMax",         temperatureRange: [0, 2], defaultTemperature: 0.9, writingTemperature: 0.9, knownModels: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2.1-highspeed", "MiniMax-M2"] },
-  bailian:     { api: "openai-completions",  baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", label: "百炼 (通义千问)", temperatureRange: [0, 2], defaultTemperature: 0.7, writingTemperature: 1.0 },
+  bailian:     { api: "anthropic-messages",  baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic",     label: "百炼 (通义千问)", temperatureRange: [0, 2], defaultTemperature: 0.7, writingTemperature: 1.0 },
   zhipu:       { api: "openai-completions",  baseUrl: "https://open.bigmodel.cn/api/paas/v4",              label: "智谱 GLM",        temperatureRange: [0, 1], defaultTemperature: 0.95, writingTemperature: 0.95 },
   siliconflow: { api: "openai-completions",  baseUrl: "https://api.siliconflow.cn/v1",                     label: "硅基流动" },
   ppio:        { api: "openai-completions",  baseUrl: "https://api.ppinfra.com/v3/openai",                 label: "PPIO" },
@@ -61,7 +61,7 @@ export const SERVICE_TO_PI_PROVIDER: Record<string, string> = {
   deepseek: "openai",         // OpenAI 兼容，pi-ai 无独立 provider
   moonshot: "openai",         // Moonshot API (api.moonshot.cn) 是 OpenAI 兼容，不是 kimi-coding (api.kimi.com)
   minimax: "anthropic",        // MiniMax 走 Anthropic 兼容端点，流式 tool calling 更稳定
-  bailian: "openai",          // 百炼走 OpenAI 兼容
+  bailian: "anthropic",        // 百炼走 Anthropic 兼容端点，OpenAI 兼容不支持 tools+stream
   zhipu: "zai",               // pi-ai 有 zai provider
   siliconflow: "openai",      // OpenAI 兼容
   ppio: "openai",             // OpenAI 兼容

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -8,6 +8,8 @@ export interface ServicePreset {
   readonly temperatureHint?: string;
   /** Hardcoded model list for services that don't support GET /models. */
   readonly knownModels?: readonly string[];
+  /** Separate baseUrl for GET /models when it differs from the chat endpoint (e.g. Anthropic endpoint has no /models). */
+  readonly modelsBaseUrl?: string;
 }
 
 export const SERVICE_PRESETS: Record<string, ServicePreset> = {
@@ -16,7 +18,7 @@ export const SERVICE_PRESETS: Record<string, ServicePreset> = {
   deepseek:    { api: "openai-completions",  baseUrl: "https://api.deepseek.com",                          label: "DeepSeek",        temperatureRange: [0, 2], defaultTemperature: 1.0, writingTemperature: 1.5, temperatureHint: "创意写作推荐 1.5" },
   moonshot:    { api: "openai-completions",  baseUrl: "https://api.moonshot.cn/v1",                        label: "Moonshot (Kimi)", temperatureRange: [0, 1], defaultTemperature: 0.3, writingTemperature: 1.0, temperatureHint: "kimi-k2.5 推荐 temperature=1.0" },
   minimax:     { api: "anthropic-messages",  baseUrl: "https://api.minimaxi.com/anthropic",                label: "MiniMax",         temperatureRange: [0, 2], defaultTemperature: 0.9, writingTemperature: 0.9, knownModels: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2.1-highspeed", "MiniMax-M2"] },
-  bailian:     { api: "anthropic-messages",  baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic",     label: "百炼 (通义千问)", temperatureRange: [0, 2], defaultTemperature: 0.7, writingTemperature: 1.0 },
+  bailian:     { api: "anthropic-messages",  baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic",     label: "百炼 (通义千问)", temperatureRange: [0, 2], defaultTemperature: 0.7, writingTemperature: 1.0, modelsBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
   zhipu:       { api: "openai-completions",  baseUrl: "https://open.bigmodel.cn/api/paas/v4",              label: "智谱 GLM",        temperatureRange: [0, 1], defaultTemperature: 0.95, writingTemperature: 0.95 },
   siliconflow: { api: "openai-completions",  baseUrl: "https://api.siliconflow.cn/v1",                     label: "硅基流动" },
   ppio:        { api: "openai-completions",  baseUrl: "https://api.ppinfra.com/v3/openai",                 label: "PPIO" },
@@ -91,10 +93,11 @@ export async function listModelsForService(service: string, apiKey?: string): Pr
     return preset.knownModels.map((id) => ({ id, name: id, reasoning: false, contextWindow: 0 }));
   }
 
-  // 2) 动态获取：调用 GET {baseUrl}/models
-  if (apiKey && preset.baseUrl) {
+  // 2) 动态获取：调用 GET {modelsBaseUrl || baseUrl}/models
+  const modelsBase = preset.modelsBaseUrl ?? preset.baseUrl;
+  if (apiKey && modelsBase) {
     try {
-      const modelsUrl = preset.baseUrl.replace(/\/$/, "") + "/models";
+      const modelsUrl = modelsBase.replace(/\/$/, "") + "/models";
       const res = await fetch(modelsUrl, {
         headers: { Authorization: `Bearer ${apiKey}` },
         signal: AbortSignal.timeout(10_000),

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -15,7 +15,7 @@ export const SERVICE_PRESETS: Record<string, ServicePreset> = {
   anthropic:   { api: "anthropic-messages",  baseUrl: "https://api.anthropic.com",                         label: "Anthropic",       temperatureRange: [0, 1], defaultTemperature: 1.0, writingTemperature: 1.0, temperatureHint: "不要同时改 temperature 和 top_p" },
   deepseek:    { api: "openai-completions",  baseUrl: "https://api.deepseek.com",                          label: "DeepSeek",        temperatureRange: [0, 2], defaultTemperature: 1.0, writingTemperature: 1.5, temperatureHint: "创意写作推荐 1.5" },
   moonshot:    { api: "openai-completions",  baseUrl: "https://api.moonshot.cn/v1",                        label: "Moonshot (Kimi)", temperatureRange: [0, 1], defaultTemperature: 0.3, writingTemperature: 1.0, temperatureHint: "kimi-k2.5 推荐 temperature=1.0" },
-  minimax:     { api: "openai-completions",  baseUrl: "https://api.minimaxi.com/v1",                       label: "MiniMax",         temperatureRange: [0, 2], defaultTemperature: 0.9, writingTemperature: 0.9, knownModels: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2.1-highspeed", "MiniMax-M2"] },
+  minimax:     { api: "anthropic-messages",  baseUrl: "https://api.minimaxi.com/anthropic",                label: "MiniMax",         temperatureRange: [0, 2], defaultTemperature: 0.9, writingTemperature: 0.9, knownModels: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2.1-highspeed", "MiniMax-M2"] },
   bailian:     { api: "openai-completions",  baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", label: "百炼 (通义千问)", temperatureRange: [0, 2], defaultTemperature: 0.7, writingTemperature: 1.0 },
   zhipu:       { api: "openai-completions",  baseUrl: "https://open.bigmodel.cn/api/paas/v4",              label: "智谱 GLM",        temperatureRange: [0, 1], defaultTemperature: 0.95, writingTemperature: 0.95 },
   siliconflow: { api: "openai-completions",  baseUrl: "https://api.siliconflow.cn/v1",                     label: "硅基流动" },
@@ -60,7 +60,7 @@ export const SERVICE_TO_PI_PROVIDER: Record<string, string> = {
   anthropic: "anthropic",
   deepseek: "openai",         // OpenAI 兼容，pi-ai 无独立 provider
   moonshot: "openai",         // Moonshot API (api.moonshot.cn) 是 OpenAI 兼容，不是 kimi-coding (api.kimi.com)
-  minimax: "minimax",
+  minimax: "anthropic",        // MiniMax 走 Anthropic 兼容端点，流式 tool calling 更稳定
   bailian: "openai",          // 百炼走 OpenAI 兼容
   zhipu: "zai",               // pi-ai 有 zai provider
   siliconflow: "openai",      // OpenAI 兼容

--- a/packages/studio/src/api/__tests__/sidebar-refresh-logic.test.ts
+++ b/packages/studio/src/api/__tests__/sidebar-refresh-logic.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Replicate the READ_ONLY_TOOLS logic from message/action.ts.
+ * Sidebar should only refresh for tools that may modify book data.
+ */
+const READ_ONLY_TOOLS = new Set(["read", "grep", "ls"]);
+
+function shouldRefreshSidebar(toolName: string): boolean {
+  return !READ_ONLY_TOOLS.has(toolName);
+}
+
+describe("sidebar refresh logic", () => {
+  it("does not refresh for read-only tools", () => {
+    expect(shouldRefreshSidebar("read")).toBe(false);
+    expect(shouldRefreshSidebar("grep")).toBe(false);
+    expect(shouldRefreshSidebar("ls")).toBe(false);
+  });
+
+  it("refreshes for write tools", () => {
+    expect(shouldRefreshSidebar("edit")).toBe(true);
+    expect(shouldRefreshSidebar("sub_agent")).toBe(true);
+  });
+
+  it("refreshes for unknown tools (safe default)", () => {
+    expect(shouldRefreshSidebar("some_new_tool")).toBe(true);
+  });
+});

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -128,6 +128,18 @@ vi.mock("@actalk/inkos-core", () => {
     persistBookSession: persistBookSessionMock,
     appendBookSessionMessage: appendBookSessionMessageMock,
     resolveServiceModel: resolveServiceModelMock,
+    resolveServicePreset: vi.fn((service: string) => {
+      const presets: Record<string, { api: string; baseUrl: string; label: string; modelsBaseUrl?: string; knownModels?: string[] }> = {
+        openai: { api: "openai-responses", baseUrl: "https://api.openai.com/v1", label: "OpenAI" },
+        moonshot: { api: "openai-completions", baseUrl: "https://api.moonshot.cn/v1", label: "Moonshot" },
+        minimax: { api: "anthropic-messages", baseUrl: "https://api.minimaxi.com/anthropic", label: "MiniMax", knownModels: ["MiniMax-M2.7"] },
+        bailian: { api: "anthropic-messages", baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic", label: "百炼", modelsBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" },
+        custom: { api: "openai-completions", baseUrl: "", label: "自定义" },
+      };
+      return presets[service];
+    }),
+    listModelsForService: vi.fn(async () => []),
+    listBookSessions: vi.fn(async () => []),
     loadSecrets: loadSecretsMock,
     saveSecrets: saveSecretsMock,
     getServiceApiKey: getServiceApiKeyMock,
@@ -1026,13 +1038,14 @@ describe("createStudioServer daemon lifecycle", () => {
     });
   });
 
-  it("falls back to plain chat when the tool-agent returns empty text", async () => {
+  it("probes upstream when the tool-agent returns empty text (no fallback to plain chat)", async () => {
     runAgentSessionMock.mockResolvedValueOnce({
       responseText: "",
       messages: [{ role: "user", content: "nihao" }],
     });
+    // Probe chatCompletion succeeds — means API works, but agent returned empty
     chatCompletionMock.mockResolvedValueOnce({
-      content: "你好！",
+      content: "pong",
       usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
     });
 
@@ -1045,11 +1058,10 @@ describe("createStudioServer daemon lifecycle", () => {
       body: JSON.stringify({ instruction: "nihao", activeBookId: "demo-book" }),
     });
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      response: "你好！",
-      session: { sessionId: "agent-session-1" },
-    });
+    // Probe succeeds → returns generic empty response error (not the probe content)
+    expect(response.status).toBe(502);
+    const body = await response.json() as { error: { code: string } };
+    expect(body.error.code).toBe("AGENT_EMPTY_RESPONSE");
   });
 
   it("returns the shared interaction session state", async () => {

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -801,7 +801,10 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     }
 
     // Try /models API — validates key + discovers models in one call
-    const modelsUrl = resolvedBaseUrl.replace(/\/$/, "") + "/models";
+    // Use modelsBaseUrl when the chat endpoint differs from the models endpoint (e.g. Anthropic endpoint)
+    const preset = resolveServicePreset(isCustomServiceId(service) ? "custom" : service);
+    const modelsBase = preset?.modelsBaseUrl ?? resolvedBaseUrl;
+    const modelsUrl = modelsBase.replace(/\/$/, "") + "/models";
     let models: Array<{ id: string; name: string }> = [];
     try {
       const res = await fetch(modelsUrl, {
@@ -869,9 +872,11 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     if (!resolvedBaseUrl) return c.json({ models: [] });
 
     // Call real /models API, fallback to pi-ai built-in list
+    const modelsPreset = resolveServicePreset(isCustomServiceId(service) ? "custom" : service);
+    const modelsBase = modelsPreset?.modelsBaseUrl ?? resolvedBaseUrl;
     let models: Array<{ id: string; name: string }> = [];
     try {
-      const modelsUrl = resolvedBaseUrl.replace(/\/$/, "") + "/models";
+      const modelsUrl = modelsBase.replace(/\/$/, "") + "/models";
       const res = await fetch(modelsUrl, {
         headers: { Authorization: `Bearer ${apiKey}` },
         signal: AbortSignal.timeout(10_000),

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -828,6 +828,8 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     }
 
     // /models unavailable (404 etc.) — fallback to pi-ai built-in model list
+    // But key has NOT been validated yet — need a probe.
+    let keyValidated = models.length > 0; // /models succeeded = key is valid
     if (models.length === 0) {
       const builtIn = await listModelsForService(service);
       models = builtIn.map((m) => ({ id: m.id, name: m.name }));
@@ -835,6 +837,37 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
     if (models.length === 0) {
       return c.json({ ok: false, error: "未找到可用模型" }, 400);
+    }
+
+    // If key was not validated via /models, do a lightweight chat probe
+    if (!keyValidated && models[0]) {
+      try {
+        const probeClient = createLLMClient({
+          provider: service === "anthropic" ? "anthropic" : "openai",
+          service: isCustomServiceId(service) ? "custom" : service,
+          configSource: "studio",
+          baseUrl: resolvedBaseUrl,
+          apiKey: apiKey.trim(),
+          model: models[0].id,
+          temperature: 0.7,
+          maxTokens: 8,
+          thinkingBudget: 0,
+          apiFormat: apiFormat ?? "chat",
+          stream: false,
+        } as ProjectConfig["llm"]);
+        await chatCompletion(
+          probeClient,
+          models[0].id,
+          [{ role: "user", content: "hi" }],
+          { maxTokens: 1 },
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (/401|403|unauthorized|invalid.*key/i.test(msg)) {
+          return c.json({ ok: false, error: "API Key 无效，请检查后重试" }, 400);
+        }
+        return c.json({ ok: false, error: `连接失败：${msg}` }, 400);
+      }
     }
 
     return c.json({ ok: true, modelCount: models.length, models: models.slice(0, 50) });

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -1309,41 +1309,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
         });
       }
       if (!result.responseText) {
-        try {
-          const fallbackClient = createLLMClient({
-            ...config.llm,
-            service: configuredEntry?.service ?? reqService ?? config.llm.service,
-            model: reqModel ?? config.llm.model,
-            apiKey: agentApiKey ?? config.llm.apiKey,
-            baseUrl: configuredEntry?.baseUrl ?? "",
-            ...(configuredEntry?.apiFormat ? { apiFormat: configuredEntry.apiFormat } : {}),
-            ...(configuredEntry?.stream !== undefined ? { stream: configuredEntry.stream } : {}),
-          } as ProjectConfig["llm"]);
-          const fallback = await chatCompletion(
-            fallbackClient,
-            reqModel ?? config.llm.model,
-            [
-              { role: "system", content: buildAgentSystemPrompt(activeBookId ?? null, config.language ?? "zh") },
-              { role: "user", content: instruction },
-            ],
-            { maxTokens: 256 },
-          );
-          if (fallback.content?.trim()) {
-            bookSession = appendBookSessionMessage(bookSession, {
-              role: "assistant",
-              content: fallback.content,
-              timestamp: Date.now() + 1,
-            });
-            await persistBookSession(root, bookSession);
-            return c.json({
-              response: fallback.content,
-              session: { sessionId: bookSession.sessionId },
-            });
-          }
-        } catch {
-          // fall through to probe-based diagnosis below
-        }
-
+        // Agent returned empty text — probe to check if the API key / model is working
         try {
           const probeClient = createLLMClient({
             ...config.llm,

--- a/packages/studio/src/components/chat/BookSidebar.tsx
+++ b/packages/studio/src/components/chat/BookSidebar.tsx
@@ -155,6 +155,13 @@ function ArtifactView({ bookId }: { readonly bookId: string }) {
 
 function PanelView({ bookId, theme: _theme, t, sse }: BookSidebarProps) {
   const isZh = t("nav.connected") === "\u5DF2\u8FDE\u63A5";
+  const [bookTitle, setBookTitle] = useState<string>("");
+
+  useEffect(() => {
+    fetchJson<{ book: { title?: string } }>(`/books/${bookId}`)
+      .then((data) => setBookTitle(data.book?.title ?? bookId))
+      .catch(() => setBookTitle(bookId));
+  }, [bookId]);
 
   // Show writing indicator only during pipeline operations (write/audit/revise)
   const [activeOp, setActiveOp] = useState<string | null>(null);
@@ -184,6 +191,9 @@ function PanelView({ bookId, theme: _theme, t, sse }: BookSidebarProps) {
 
   return (
     <div className="flex flex-col gap-2 p-3">
+      <div className="px-1 pb-1">
+        <h2 className="font-serif text-base font-medium truncate">{bookTitle}</h2>
+      </div>
       {activeOp && (
         <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/10">
           <Loader2 size={12} className="text-primary animate-spin shrink-0" />

--- a/packages/studio/src/components/sidebar/ChaptersSection.tsx
+++ b/packages/studio/src/components/sidebar/ChaptersSection.tsx
@@ -31,7 +31,7 @@ export function ChaptersSection({ bookId, isZh }: ChaptersSectionProps) {
   useEffect(() => {
     fetchJson<{ chapters: ChapterMeta[] }>(`/books/${bookId}`)
       .then((data) => setChapters(data.chapters))
-      .catch(() => setChapters([]));
+      .catch(() => {});  // keep old data on error
   }, [bookId, bookDataVersion]);
 
   return (

--- a/packages/studio/src/components/sidebar/CharacterSection.tsx
+++ b/packages/studio/src/components/sidebar/CharacterSection.tsx
@@ -112,7 +112,7 @@ export function CharacterSection({ bookId }: CharacterSectionProps) {
           setCharacters([]);
         }
       })
-      .catch(() => setCharacters([]));
+      .catch(() => {});  // keep old data on error
   }, [bookId, bookDataVersion]);
 
   if (characters.length === 0) return null;

--- a/packages/studio/src/components/sidebar/FoundationSection.tsx
+++ b/packages/studio/src/components/sidebar/FoundationSection.tsx
@@ -32,7 +32,7 @@ export function FoundationSection({ bookId }: FoundationSectionProps) {
   useEffect(() => {
     fetchJson<{ files: TruthFileInfo[] }>(`/books/${bookId}/truth`)
       .then((data) => setFiles(data.files))
-      .catch(() => setFiles([]));
+      .catch(() => {});  // keep old data on error
   }, [bookId, bookDataVersion]);
 
   const available = FOUNDATION_FILES.filter((f) =>

--- a/packages/studio/src/components/sidebar/SummarySection.tsx
+++ b/packages/studio/src/components/sidebar/SummarySection.tsx
@@ -33,10 +33,9 @@ export function SummarySection({ bookId }: SummarySectionProps) {
   const bookDataVersion = useChatStore((s) => s.bookDataVersion);
 
   useEffect(() => {
-    setBookSummary(null);
     fetchJson<{ content: string | null }>(`/books/${bookId}/truth/story_bible.md`)
       .then((data) => {
-        if (data.content) setBookSummary(parseStoryBible(data.content));
+        setBookSummary(data.content ? parseStoryBible(data.content) : null);
       })
       .catch(() => {});
   }, [bookId, bookDataVersion, setBookSummary]);

--- a/packages/studio/src/pages/ChatPage.tsx
+++ b/packages/studio/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo } from "react";
+import { useRef, useEffect, useMemo, useState } from "react";
 import type { Theme } from "../hooks/use-theme";
 import type { TFunction } from "../hooks/use-i18n";
 import type { SSEMessage } from "../hooks/use-sse";
@@ -398,35 +398,13 @@ export function ChatPage({ activeBookId, nav, theme, t, sse: _sse }: ChatPagePro
                       </span>
                       <ChevronDown size={14} className="text-muted-foreground" />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent side="top" align="start" className="w-60 max-h-72 overflow-y-auto">
-                      {groupedModels.map((group) => (
-                        <div key={group.service}>
-                          <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                            {group.label}
-                          </div>
-                          {group.models.map((m) => {
-                            const isSelected = selectedModel === m.id && selectedService === group.service;
-                            return (
-                              <DropdownMenuItem
-                                key={`${group.service}:${m.id}`}
-                                onClick={() => setSelectedModel(m.id, group.service)}
-                                className={isSelected ? "bg-muted/50" : ""}
-                              >
-                                <div className="flex flex-1 items-center justify-between">
-                                  <span className="text-sm">{m.name ?? m.id}</span>
-                                  {isSelected && <Check size={14} className="text-primary shrink-0" />}
-                                </div>
-                              </DropdownMenuItem>
-                            );
-                          })}
-                        </div>
-                      ))}
-                      <div className="border-t border-border/30 mt-1">
-                        <DropdownMenuItem onClick={() => nav.toServices()} className="text-primary">
-                          管理服务商
-                        </DropdownMenuItem>
-                      </div>
-                    </DropdownMenuContent>
+                    <ModelPickerContent
+                      groupedModels={groupedModels}
+                      selectedModel={selectedModel}
+                      selectedService={selectedService}
+                      onSelect={setSelectedModel}
+                      onManage={() => nav.toServices()}
+                    />
                   </DropdownMenu>
                 ) : (
                   <button
@@ -442,5 +420,84 @@ export function ChatPage({ activeBookId, nav, theme, t, sse: _sse }: ChatPagePro
         </div>
       </div>
     </div>
+  );
+}
+
+function ModelPickerContent({
+  groupedModels,
+  selectedModel,
+  selectedService,
+  onSelect,
+  onManage,
+}: {
+  groupedModels: ReadonlyArray<{ service: string; label: string; models: ReadonlyArray<{ id: string; name?: string }> }>;
+  selectedModel: string | null;
+  selectedService: string | null;
+  onSelect: (model: string, service: string) => void;
+  onManage: () => void;
+}) {
+  const [search, setSearch] = useState("");
+  const q = search.toLowerCase();
+
+  const filtered = useMemo(() => {
+    if (!q) return groupedModels;
+    return groupedModels
+      .map((g) => ({
+        ...g,
+        models: g.models.filter((m) =>
+          (m.name ?? m.id).toLowerCase().includes(q) || g.label.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((g) => g.models.length > 0);
+  }, [groupedModels, q]);
+
+  return (
+    <DropdownMenuContent side="top" align="start" className="w-64 max-h-80 flex flex-col">
+      <div className="px-2 py-1.5 border-b border-border/30">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="搜索模型..."
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground/40"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        />
+      </div>
+      <div className="overflow-y-auto flex-1">
+        {filtered.map((group) => (
+          <div key={group.service}>
+            <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider sticky top-0 bg-popover">
+              {group.label}
+            </div>
+            {group.models.map((m) => {
+              const isSelected = selectedModel === m.id && selectedService === group.service;
+              return (
+                <DropdownMenuItem
+                  key={`${group.service}:${m.id}`}
+                  onClick={() => onSelect(m.id, group.service)}
+                  className={isSelected ? "bg-muted/50" : ""}
+                >
+                  <div className="flex flex-1 items-center justify-between">
+                    <span className="text-sm">{m.name ?? m.id}</span>
+                    {isSelected && <Check size={14} className="text-primary shrink-0" />}
+                  </div>
+                </DropdownMenuItem>
+              );
+            })}
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="px-3 py-4 text-xs text-muted-foreground/50 text-center italic">
+            无匹配模型
+          </div>
+        )}
+      </div>
+      <div className="border-t border-border/30">
+        <DropdownMenuItem onClick={onManage} className="text-primary">
+          管理服务商
+        </DropdownMenuItem>
+      </div>
+    </DropdownMenuContent>
   );
 }

--- a/packages/studio/src/pages/ChatPage.tsx
+++ b/packages/studio/src/pages/ChatPage.tsx
@@ -467,7 +467,7 @@ function ModelPickerContent({
       <div className="overflow-y-auto flex-1">
         {filtered.map((group) => (
           <div key={group.service}>
-            <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider sticky top-0 bg-popover">
+            <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
               {group.label}
             </div>
             {group.models.map((m) => {

--- a/packages/studio/src/pages/ChatPage.tsx
+++ b/packages/studio/src/pages/ChatPage.tsx
@@ -153,10 +153,29 @@ export function ChatPage({ activeBookId, nav, theme, t, sse: _sse }: ChatPagePro
     return () => { es.close(); };
   }, [bookCreating, setCreateProgress]);
 
-  // Load session messages on mount or when activeBookId changes
+  // Load session messages on mount or when activeBookId changes.
+  // For book-create (no activeBookId), always start a fresh session.
   useEffect(() => {
-    useChatStore.getState().loadSession(activeBookId);
+    if (!activeBookId) {
+      useChatStore.setState({ currentSessionId: null, messages: [], input: "", _activeStream: null });
+    } else {
+      useChatStore.getState().loadSession(activeBookId);
+    }
   }, [activeBookId]);
+
+  // Auto-navigate to new book after agent-driven creation
+  useEffect(() => {
+    if (activeBookId) return; // only in book-create mode
+    const es = new EventSource("/api/v1/events");
+    const handler = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data);
+        if (data?.bookId) nav.toBook(data.bookId);
+      } catch { /* ignore */ }
+    };
+    es.addEventListener("book:created", handler);
+    return () => { es.close(); };
+  }, [activeBookId, nav]);
 
   const onSend = (text: string) => {
     void sendMessage(text, activeBookId);

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -199,12 +199,24 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         }),
       });
       if (trimmedKey) {
+        // Validate key via test endpoint (same as "测试连接" button)
         try {
-          const data = await fetchJson<{ models: ModelInfo[] }>(`/services/${encodeURIComponent(effectiveServiceId)}/models`);
-          const m = data.models ?? [];
-          if (m.length > 0) {
-            setStoreModels(effectiveServiceId, m);
-            setStatus({ state: "connected", models: m });
+          const result = await fetchJson<{ ok: boolean; models?: ModelInfo[]; error?: string }>(
+            `/services/${encodeURIComponent(effectiveServiceId)}/test`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                apiKey: trimmedKey,
+                apiFormat,
+                stream,
+                ...(isCustom ? { baseUrl: baseUrl.trim() } : {}),
+              }),
+            },
+          );
+          if (result.ok && result.models) {
+            setStoreModels(effectiveServiceId, result.models);
+            setStatus({ state: "connected", models: result.models });
           } else {
             setStatus({ state: "saved" });
           }

--- a/packages/studio/src/store/chat/slices/message/action.ts
+++ b/packages/studio/src/store/chat/slices/message/action.ts
@@ -347,7 +347,11 @@ export const createMessageSlice: StateCreator<ChatStore, [], [], MessageActions>
           return { messages: replaceLast(msgs, { ...stream, ...flat, parts }) };
         });
 
-        get().bumpBookDataVersion();
+        // Only refresh sidebar for tools that may modify book data
+        const READ_ONLY_TOOLS = new Set(["read", "grep", "ls"]);
+        if (!READ_ONLY_TOOLS.has(d.tool)) {
+          get().bumpBookDataVersion();
+        }
       } catch { /* ignore */ }
     });
 


### PR DESCRIPTION
## Summary

### LLM Provider Fixes
- **MiniMax → Anthropic 兼容端点**: OpenAI-compatible streaming tool_calls 解析失败, 切到 Anthropic endpoint (`api.minimaxi.com/anthropic`), 流式 tool calling 正常
- **百炼 → Anthropic 兼容端点**: OpenAI-compatible 不支持 `tools+stream=true`, 切到 Anthropic endpoint (`dashscope.aliyuncs.com/apps/anthropic`)
- **modelsBaseUrl 分离**: 百炼 chat 走 Anthropic, model listing 走 OpenAI `/models` — 新增 `modelsBaseUrl` 字段
- **API Key 验证修复**: `/models` 不可用时 (Anthropic/MiniMax), 通过 chat probe 验证 key, 防止假阳性 "连接成功"
- **保存时也验证 key**: 保存按钮调用 `/test` 端点而非直接获取模型列表

### Studio UX
- **模型选择器搜索框**: 输入关键词过滤模型列表
- **新建书籍 session 隔离**: 每次点"新建书籍"清空 session, 建书完成自动跳转
- **书名回填**: architect 建书后从 story_bible.md 提取书名写入 book.json
- **右侧侧边栏显示书名**
- **侧边栏刷新优化**: read/grep/ls 不触发刷新, 只有写操作刷新; 刷新时保留旧数据防止闪烁
- **移除 no-tools fallback**: 防止 session 被假工具调用文本污染

### Tests
- service-presets: MiniMax/百炼 Anthropic 端点, modelsBaseUrl, knownModels, provider 映射
- service-resolver: preset baseUrl/api 覆盖 pi-ai, 百炼 resolver
- book-title-backfill: 8 种 story_bible 书名提取模式
- sidebar-refresh-logic: READ_ONLY_TOOLS 不触发刷新
- server.test: mock 更新, fallback→probe 行为

## Test plan

- [x] `pnpm test` — core 716, studio 117, all pass
- [x] MiniMax tool calling works via Anthropic endpoint (verified with curl)
- [x] 百炼 model list from OpenAI endpoint, chat via Anthropic endpoint
- [x] Invalid Anthropic API key correctly rejected on test + save
- [x] Model picker search filters by name and service label
- [x] New book creation clears session, auto-navigates after architect completes
- [x] Sidebar doesn't flash on read-only tool execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)