### PR TITLE
fix(cli): use file URLs for Windows Studio loader

### DIFF
--- a/packages/cli/src/__tests__/studio-runtime.test.ts
+++ b/packages/cli/src/__tests__/studio-runtime.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const accessMock = vi.fn();
 const testDir = dirname(fileURLToPath(import.meta.url));
@@ -52,7 +52,29 @@ describe("studio runtime resolution", () => {
     expect(launch).toEqual({
       studioEntry: tsSourceEntry,
       command: "node",
-      args: ["--import", tsxLoader, tsSourceEntry, "/repo/test-project"],
+      args: ["--import", pathToFileURL(tsxLoader).href, tsSourceEntry, "/repo/test-project"],
+    });
+  });
+
+  it("converts Windows tsx loader paths into file URLs", async () => {
+    const windowsRoot = "C:\\repo\\test-project";
+    const windowsSourceEntry = "C:\\repo\\packages\\studio\\src\\api\\index.ts";
+    const windowsTsxLoader = "C:\\repo\\packages\\studio\\node_modules\\tsx\\dist\\loader.mjs";
+
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === windowsSourceEntry || path === windowsTsxLoader) {
+        return;
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const { resolveStudioLaunch } = await import("../commands/studio.js");
+    const launch = await resolveStudioLaunch(windowsRoot);
+
+    expect(launch).toEqual({
+      studioEntry: windowsSourceEntry,
+      command: "node",
+      args: ["--import", pathToFileURL(windowsTsxLoader).href, windowsSourceEntry, windowsRoot],
     });
   });
 

--- a/packages/cli/src/__tests__/studio.test.ts
+++ b/packages/cli/src/__tests__/studio.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const accessMock = vi.fn();
 const spawnMock = vi.fn(() => ({
@@ -43,6 +44,30 @@ describe("studio command", () => {
     expect(spawnMock).toHaveBeenCalledWith(
       "npx",
       ["tsx", tsEntry, "/project"],
+      expect.objectContaining({
+        cwd: "/project",
+        stdio: "inherit",
+        env: expect.objectContaining({ INKOS_STUDIO_PORT: "9001" }),
+      }),
+    );
+  });
+
+  it("launches TypeScript sources through node --import when the local tsx loader is available", async () => {
+    const tsEntry = join("/project", "packages", "studio", "src", "api", "index.ts");
+    const tsxLoader = join("/project", "packages", "studio", "node_modules", "tsx", "dist", "loader.mjs");
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === tsEntry || path === tsxLoader) {
+        return;
+      }
+      throw new Error(`missing: ${path}`);
+    });
+
+    const { createStudioCommand } = await import("../commands/studio.js");
+    await createStudioCommand().parseAsync(["node", "studio", "--port", "9001"]);
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "node",
+      ["--import", pathToFileURL(tsxLoader).href, tsEntry, "/project"],
       expect.objectContaining({
         cwd: "/project",
         stdio: "inherit",

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -3,7 +3,7 @@ import { findProjectRoot, log, logError } from "../utils.js";
 import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { access } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export interface StudioLaunchSpec {
   readonly studioEntry: string;
@@ -34,6 +34,10 @@ async function firstAccessiblePath(paths: readonly string[]): Promise<string | u
 
 const cliPackageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
+function toNodeImportSpecifier(modulePath: string): string {
+  return pathToFileURL(modulePath).href;
+}
+
 export function resolveBrowserLaunch(
   platform: NodeJS.Platform,
   url: string,
@@ -62,7 +66,7 @@ export async function resolveStudioLaunch(root: string): Promise<StudioLaunchSpe
       return {
         studioEntry: sourceEntry,
         command: "node",
-        args: ["--import", localTsxLoader, sourceEntry, root],
+        args: ["--import", toNodeImportSpecifier(localTsxLoader), sourceEntry, root],
       };
     }
 


### PR DESCRIPTION
## Summary
- convert the local `tsx` loader path passed to `node --import` into a `file://` URL so Studio starts correctly on Windows absolute paths
- add runtime coverage for Windows drive-letter loader paths
- add command-level coverage for the `node --import` launch branch

## Testing
- `pnpm.cmd --filter @actalk/inkos exec vitest run src/__tests__/studio-runtime.test.ts src/__tests__/studio.test.ts`
- `pnpm.cmd --filter @actalk/inkos build`