### PR TITLE
fix(deps): pin pi-mono versions to avoid npm mirror lag breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,11 @@
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=9.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@mariozechner/pi-ai": "0.67.1",
+      "@mariozechner/pi-agent-core": "0.67.1"
+    }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,5 +61,9 @@
     "ink-testing-library": "^4.0.0",
     "typescript": "^5.8.0",
     "vitest": "^3.0.0"
+  },
+  "overrides": {
+    "@mariozechner/pi-ai": "0.67.1",
+    "@mariozechner/pi-agent-core": "0.67.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@mariozechner/pi-ai': 0.67.1
+  '@mariozechner/pi-agent-core': 0.67.1
+
 importers:
 
   .: {}
@@ -63,10 +67,10 @@ importers:
   packages/core:
     dependencies:
       '@mariozechner/pi-agent-core':
-        specifier: ^0.67.1
+        specifier: 0.67.1
         version: 0.67.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
       '@mariozechner/pi-ai':
-        specifier: ^0.67.1
+        specifier: 0.67.1
         version: 0.67.1(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
       '@sinclair/typebox':
         specifier: ^0.34.49


### PR DESCRIPTION
## 问题

Windows 用户跑 \`npm install -g @actalk/inkos@latest\` 时报：

\`\`\`
npm error code ETARGET
npm error notarget No matching version found for @mariozechner/pi-ai@^0.67.4.
\`\`\`

## 根因

不是某个 commit 引入的，是 caret range + 上游发布节奏 + 国内 npm 镜像同步延迟叠出来的：

| 步骤 | 实际发生 |
|---|---|
| inkos-core 写 | \`@mariozechner/pi-ai: ^0.67.1\` |
| caret 解析 | \`^0.67.1\` = \`>=0.67.1 <0.68.0\` → 拿最新匹配 \`pi-agent-core@0.67.4\` |
| 传递依赖 | \`pi-agent-core@0.67.4\` 自己写 \`pi-ai: ^0.67.4\` |
| npm 找 | \`pi-ai@^0.67.4\` → 国内镜像还没同步（4-16 当天发布）→ ETARGET |

\`pi-mono\` 每个 patch 版本都把对 \`pi-ai\` 的依赖跟自己版本一起提（\`0.67.1→0.67.2→0.67.3→0.67.4\`），任何一环镜像没同步整条链就断。

## 改动

加 npm \`overrides\` 到 \`packages/cli/package.json\`（发布给最终用户的入口），加 \`pnpm.overrides\` 到根 \`package.json\`（本地 monorepo 一致），都锁到 \`0.67.1\`。

## Trade-off

升级 pi-mono 从「caret 自动跟」变成「显式手改 overrides」，但避免了 mirror lag 导致的 install 失败。

## 验证

- \`pnpm install\` 干净通过，只装 pi-ai/pi-agent-core 0.67.1
- \`pnpm --filter @actalk/inkos-core test\` 728 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)