### PR TITLE
feat(core): 每次 LLM 调用前自动注入书籍真相文件

### DIFF
--- a/packages/core/src/__tests__/context-transform.test.ts
+++ b/packages/core/src/__tests__/context-transform.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createBookContextTransform } from "../agent/context-transform.js";
+
+describe("createBookContextTransform", () => {
+  let projectRoot: string;
+  const bookId = "test-book";
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), "ctx-test-"));
+    const storyDir = join(projectRoot, "books", bookId, "story");
+    await mkdir(storyDir, { recursive: true });
+    await writeFile(join(storyDir, "story_bible.md"), "# Story Bible\nA hero's journey.");
+    await writeFile(join(storyDir, "current_focus.md"), "Focus on chapter 3.");
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it("returns messages unchanged when bookId is null", async () => {
+    const transform = createBookContextTransform(null, projectRoot);
+    const messages = [
+      { role: "user" as const, content: "hello", timestamp: Date.now() },
+    ];
+    const result = await transform(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("prepends a user message with truth file contents", async () => {
+    const transform = createBookContextTransform(bookId, projectRoot);
+    const original = [
+      { role: "user" as const, content: "写下一章", timestamp: Date.now() },
+    ];
+    const result = await transform(original);
+
+    expect(original).toHaveLength(1);
+    expect(result).toHaveLength(2);
+    const injected = result[0] as { role: string; content: string };
+    expect(injected.role).toBe("user");
+    expect(injected.content).toContain("story_bible.md");
+    expect(injected.content).toContain("A hero's journey.");
+    expect(injected.content).toContain("current_focus.md");
+    expect(injected.content).toContain("Focus on chapter 3.");
+    expect(result[1]).toBe(original[0]);
+  });
+
+  it("sorts truth files in priority order", async () => {
+    const storyDir = join(projectRoot, "books", bookId, "story");
+    await writeFile(join(storyDir, "volume_outline.md"), "# Volume Outline");
+    await writeFile(join(storyDir, "book_rules.md"), "# Book Rules");
+    await writeFile(join(storyDir, "extra_notes.md"), "# Extra");
+
+    const transform = createBookContextTransform(bookId, projectRoot);
+    const result = await transform([
+      { role: "user" as const, content: "test", timestamp: Date.now() },
+    ]);
+    const content = (result[0] as { content: string }).content;
+
+    const bibleIdx = content.indexOf("story_bible.md");
+    const outlineIdx = content.indexOf("volume_outline.md");
+    const rulesIdx = content.indexOf("book_rules.md");
+    const focusIdx = content.indexOf("current_focus.md");
+    const extraIdx = content.indexOf("extra_notes.md");
+
+    expect(bibleIdx).toBeLessThan(outlineIdx);
+    expect(outlineIdx).toBeLessThan(rulesIdx);
+    expect(rulesIdx).toBeLessThan(focusIdx);
+    expect(focusIdx).toBeLessThan(extraIdx);
+  });
+
+  it("returns original messages when story/ directory does not exist", async () => {
+    const transform = createBookContextTransform("nonexistent-book", projectRoot);
+    const original = [
+      { role: "user" as const, content: "test", timestamp: Date.now() },
+    ];
+    const result = await transform(original);
+    expect(result).toBe(original);
+  });
+});

--- a/packages/core/src/agent/agent-session.ts
+++ b/packages/core/src/agent/agent-session.ts
@@ -15,6 +15,7 @@ import {
   createLsTool,
   createWriteTruthFileTool,
 } from "./agent-tools.js";
+import { createBookContextTransform } from "./context-transform.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -245,6 +246,7 @@ export async function runAgentSession(
           createLsTool(projectRoot),
         ],
       },
+      transformContext: createBookContextTransform(bookId, projectRoot),
       streamFn: streamSimple,
       getApiKey: (provider: string) => {
         if (config.apiKey) return config.apiKey;

--- a/packages/core/src/agent/context-transform.ts
+++ b/packages/core/src/agent/context-transform.ts
@@ -1,0 +1,73 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { UserMessage } from "@mariozechner/pi-ai";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Files read in this order; anything else in story/ comes after, sorted alphabetically. */
+const PRIORITY_FILES = [
+  "story_bible.md",
+  "volume_outline.md",
+  "book_rules.md",
+  "current_focus.md",
+];
+
+export function createBookContextTransform(
+  bookId: string | null,
+  projectRoot: string,
+): (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]> {
+  if (bookId === null) {
+    return async (messages) => messages;
+  }
+
+  const storyDir = join(projectRoot, "books", bookId, "story");
+
+  return async (messages) => {
+    const sections = await readTruthFiles(storyDir);
+    if (sections.length === 0) return messages;
+
+    const body =
+      "[以下是当前书籍的真相文件，每次对话时自动从磁盘读取注入。请基于这些内容进行创作和判断。]\n\n" +
+      sections.map((s) => `=== ${s.name} ===\n${s.content}`).join("\n\n");
+
+    const injected: UserMessage = {
+      role: "user",
+      content: body,
+      timestamp: Date.now(),
+    };
+
+    return [injected, ...messages];
+  };
+}
+
+interface TruthFileSection {
+  name: string;
+  content: string;
+}
+
+async function readTruthFiles(storyDir: string): Promise<TruthFileSection[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(storyDir);
+  } catch {
+    return [];
+  }
+
+  const mdFiles = entries.filter((f) => f.endsWith(".md"));
+  if (mdFiles.length === 0) return [];
+
+  const prioritySet = new Set(PRIORITY_FILES);
+  const prioritized = PRIORITY_FILES.filter((f) => mdFiles.includes(f));
+  const rest = mdFiles.filter((f) => !prioritySet.has(f)).sort();
+  const ordered = [...prioritized, ...rest];
+
+  const sections: TruthFileSection[] = [];
+  for (const fileName of ordered) {
+    try {
+      const content = await readFile(join(storyDir, fileName), "utf-8");
+      sections.push({ name: fileName, content });
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return sections;
+}

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -11,3 +11,4 @@ export {
   createLsTool,
 } from "./agent-tools.js";
 export { runAgentSession, evictAgentCache, type AgentSessionConfig, type AgentSessionResult } from "./agent-session.js";
+export { createBookContextTransform } from "./context-transform.js";


### PR DESCRIPTION
## Summary

让 agent 每次调 LLM 之前，自动从磁盘读取 `books/{bookId}/story/` 下的真相文件（story_bible.md / volume_outline.md / book_rules.md / current_focus.md 等），包装成一条 user message 插到 messages 数组最前面。

**动机**：目前 agent 在写章节、审计、修订时，context 里不一定有真相文件的最新内容——要么靠 `read` 工具临时拉（浪费一轮调用），要么靠之前对话里的 toolResult（随对话增长被淹没）。这导致写作质量不稳定。

## 实现

通过 pi-agent-core 的 `transformContext` hook 注入，**返回的新数组只用于当次 LLM 调用，不会写回 Agent 内部 messages 历史**，所以不会随对话轮次累积多份。每次 LLM 调用都从磁盘重读，保证真相文件永远是最新版本。

- `bookId === null`（建书模式）：直接返回原始 messages，不注入
- `bookId !== null`：按优先级 `story_bible → volume_outline → book_rules → current_focus → 其余字母序` 读取并注入
- `story/` 目录不存在 / 文件读取失败 → 跳过，不影响其他文件

## 改动

- 新建 `packages/core/src/agent/context-transform.ts` — `createBookContextTransform` 工厂函数
- 新建 `packages/core/src/__tests__/context-transform.test.ts` — 4 个测试（null bookId、注入、优先级排序、目录不存在）
- 修改 `packages/core/src/agent/agent-session.ts` — `new Agent({...})` 里接入 transformContext
- 修改 `packages/core/src/agent/index.ts` — 导出 `createBookContextTransform`

## 不含

context 占用比例的前端 UI（SSE 广播 + 进度条组件）已拆到另一个分支 `feat/context-usage-ui`，后续单独提 PR（还需要补 inkos 自己的模型注册表来覆盖 pi-ai 没收录的模型，比如 moonshot-v1 系列）。

## Test plan

- [x] 4 个单元测试覆盖核心逻辑
- [x] 全量测试通过：core 752 / studio 137 / cli 169
- [ ] 手动验证：写章节前 agent 能正确参照 story_bible 的世界观细节

🤖 Generated with [Claude Code](https://claude.com/claude-code)