### PR TITLE
docs: add experimental structured render schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,14 @@ autoresearch/
 .superpowers/
 _*.md
 
-# 用户运行时数据（会话记录、书籍内容、项目密钥、提示词模板不属于项目代码）
+# 鐢ㄦ埛杩愯鏃舵暟鎹紙浼氳瘽璁板綍銆佷功绫嶅唴瀹广€侀」鐩瘑閽ャ€佹彁绀鸿瘝妯℃澘涓嶅睘浜庨」鐩唬鐮侊級
 .inkos/
 books/
 inkos.json
 prompt/
 CLAUDE.md
+
+# Structured render local validation artifacts
+
+# Local PR helper files
+.pr/

--- a/docs/structured-render-schemas/active_entity_cards_schema.md
+++ b/docs/structured-render-schemas/active_entity_cards_schema.md
@@ -1,0 +1,829 @@
+# Active Entity Cards / 活跃实体卡 Schema 与模板 v0.2
+
+## 1. 用途
+
+`Active Entity Cards` 用于描述目标章节开始前，当前故事世界中有哪些正在起作用的实体，以及这些实体的状态、边界和叙事功能。
+
+它回答的问题是：
+
+- 当前有哪些可操作实体？
+- 每个实体在目标章节开始前是什么状态？
+- 目标章节中允许这个实体发生什么变化？
+- 不允许发生什么变化？
+- 这个实体承担什么叙事功能？
+- 它和其他实体有什么约束关系？
+- 哪些实体信息只能给 Renderer 看，不能显性写进正文？
+
+
+本文件不是章节大纲。
+事件顺序属于 `Render Event Log`。
+
+本文件不是世界观百科。
+通用世界规则属于 `Worldbuilding / World Mechanics`。
+
+本文件不是作者风格指南。
+写法、节奏和角色声音属于 `Author Fingerprint`。
+
+---
+
+## 2. Source Boundary / 来源边界
+
+每个实体卡文件必须声明来源边界，避免模型把未来章节、推断内容或 benchmark_reference 信息误当成 canon。
+
+建议字段：
+
+```yaml
+target_chapter: "<目标章节>"
+input_chapters: "<作为来源的章节范围>"
+source_mode: "clean | benchmark_reference | hybrid | manual | model_hypothesis"
+forbidden_sources:
+  - "<禁止读取或引用的章节 / 文件>"
+notes: "<简短说明>"
+```
+
+### 示例
+
+```yaml
+target_chapter: "<target_chapter>"
+input_chapters: "<pre_target_chapters>"
+source_mode: "hybrid"
+forbidden_sources:
+  - "ch0012+"
+notes: "主实体卡来自 <pre_target_chapters> clean 抽取；目标章临时实体如果使用 benchmark_reference 信息，必须单独标记。"
+```
+
+### source_mode 定义
+
+- `clean`：只使用目标章节之前的文本。
+- `benchmark_reference`：使用真实目标章节作为参考。
+- `hybrid`：同时包含 clean 信息和 benchmark-reference 临时信息。
+- `manual`：包含人工指定或人工覆盖。
+- `model_hypothesis`：模型推断，尚未确认。
+
+禁止把 clean 信息和 benchmark_reference 信息混在一起却不标注来源。
+
+---
+
+## 3. 推荐文件结构
+
+```markdown
+# 01 Active Entity Cards for <target_chapter>
+
+## Source Boundary
+...
+
+## Global Entity Rules / 全局实体规则
+...
+
+## Active Entity Cards / 活跃实体卡
+- EC-001
+- EC-002
+- ...
+
+## Target-Chapter Transient Entities / 目标章临时实体
+- EC-T001
+- EC-T002
+- ...
+
+## Global Forbidden Drift / 全局禁止漂移
+...
+
+## Validation Checklist / 校验清单
+...
+```
+
+---
+
+## 4. 实体 ID 规则
+
+普通活跃实体建议使用稳定编号：
+
+```text
+EC-001
+EC-002
+EC-003
+...
+```
+
+目标章节临时实体建议使用单独前缀：
+
+```text
+EC-T001
+EC-T002
+...
+```
+
+如果是 benchmark-reference 临时实体，也可以使用：
+
+```text
+EC-O001
+EC-O002
+...
+```
+
+规则：
+
+- 不要把同一个 ID 用给不同实体。
+- 如果实体类型发生变化，优先更新原卡，不要重复创建新卡。
+- 如果某实体只在目标章节中短暂出现，用 `Target-Chapter Transient Entities`，不要混入主实体卡。
+
+---
+
+## 5. entity_type / 实体类型
+
+实体不只包括人物。
+
+允许的实体类型包括：
+
+```text
+character
+equipment
+location
+organization
+threat
+resource
+social_rule
+world_rule
+magic_rule
+mechanical_rule
+knowledge_asset
+task_pressure
+relationship_state
+secret
+mystery
+tactical_problem
+chapter_closing_mechanism
+internal_constraint
+```
+
+可以使用复合标签：
+
+```yaml
+entity_type: "equipment / magic_weapon / price_constraint"
+entity_type: "world_rule / tactical_ecology"
+entity_type: "character / ally / technical_support"
+entity_type: "tactical_problem / chapter_closing_mechanism"
+```
+
+中文说明可以写在值里，但建议保留一部分英文分类，方便后续程序处理。
+
+---
+
+
+## 6. source_label / provenance 字段
+
+### 6.1 source_label
+
+允许值：
+
+```text
+canon_confirmed
+inferred
+benchmark_reference
+human_override
+model_hypothesis
+```
+
+定义：
+
+- `canon_confirmed`：由允许来源直接支持。
+- `inferred`：由允许来源推断，但不是直接明说。
+- `benchmark_reference`：来自真实目标章、目标章 trace、后续章节或反推信息。
+- `human_override`：人工指定或覆盖。
+- `model_hypothesis`：模型猜测，尚未确认。
+
+clean mode 下主实体卡不得出现 `benchmark_reference`。
+若出现 `benchmark_reference`，pack 的 `source_mode` 不得为纯 `clean`。
+
+### 6.2 推荐可选 provenance 字段
+
+以下字段为 v0.2 新增的向后兼容字段，建议 compiler 输出。
+
+```yaml
+confidence: "high | medium | low"
+compiled_from: "truth_state | story_frame | hooks | chapter_summaries | emotional_arcs | book_rules | raw_chapters | event_log | benchmark_reference | human_override | mixed"
+evidence_granularity: "state_json | state_markdown | hook_json | chapter_summary | emotional_arc_summary | world_rules | raw_line | manual_note | mixed"
+```
+
+用途：
+
+- `confidence`：标记该实体卡整体可靠度。
+- `compiled_from`：标记编译来源类型。
+- `evidence_granularity`：标记证据粒度，便于 audit。
+- 这些字段不替代 `source_basis`；`source_basis` 仍必须保留。
+
+---
+
+## 7. render_visibility / 渲染可见性字段
+
+有些实体或规则可以给 Renderer 看，但不能显性写进正文。例如主角秘密、金手指、内部反馈机制、作者为防漂移加入的内部约束。
+
+这类实体必须使用 `render_visibility`。
+
+```yaml
+render_visibility:
+  prompt_visible: true
+  prose_visible: false
+  allowed_surface_form:
+    - "<允许在正文中间接表现的形式>"
+  forbidden_surface_form:
+    - "<正文中绝对不能出现的词、句式、解释或机制外显>"
+  notes: "<可选说明>"
+```
+
+字段含义：
+
+- `prompt_visible`: 是否允许写入给 Renderer 的结构化输入。
+- `prose_visible`: 是否允许以明示形式出现在小说正文。
+- `allowed_surface_form`: 允许的间接表现方式。
+- `forbidden_surface_form`: 禁止正文出现的显性形式。
+- `notes`: 给审计器或 compiler 的补充说明。
+
+### 示例：内部秘密机制
+
+```yaml
+entity_id: "EC-007"
+entity_name: "秘密反馈机制 / 金手指"
+entity_type: "secret / internal_constraint / protagonist-bound"
+source_label: "canon_confirmed"
+confidence: "high"
+compiled_from: "hooks / truth_state / story_frame"
+evidence_granularity: "hook_json + state_json + story_frame"
+
+render_visibility:
+  prompt_visible: true
+  prose_visible: false
+  allowed_surface_form:
+    - "<protagonist>含混的内心压力"
+    - "<protagonist>对姿态、胆量、实战动作的执念"
+    - "<protagonist>对纯打靶无效的模糊经验判断"
+  forbidden_surface_form:
+    - "系统"
+    - "金手指"
+    - "进度条"
+    - "面板"
+    - "反馈机制"
+    - "刷经验"
+  notes: "只作为 Renderer 内部约束；不得被 NPC 发现、命名、讨论或利用。"
+```
+
+规则：
+
+- 任何 `entity_type` 含 `secret`、`internal_constraint`、`protagonist-bound hidden rule` 的实体，建议显式填写 `render_visibility`。
+- 如果 `prose_visible: false`，正文中不得出现该实体名、机制名或解释性标签。
+- 允许用行为、犹豫、执念、误判、内心含混压力间接表现。
+- 审计时必须检查 forbidden_surface_form 是否泄漏进正文。
+
+---
+
+## 8. 主实体卡完整 Schema
+
+重要实体使用完整实体卡。
+
+```yaml
+entity_id: "EC-001"
+entity_name: "<实体名称>"
+entity_type: "<类别 / 角色 / 子类型>"
+
+source_label: "canon_confirmed | inferred | benchmark_reference | human_override | model_hypothesis"
+source_basis:
+  - "<支持该实体状态的章节、场景、文件或备注>"
+
+confidence: "high | medium | low"
+compiled_from: "<来源类型，可用 / 连接多个来源>"
+evidence_granularity: "<证据粒度，可用 + 连接多个粒度>"
+
+current_state_at_context_boundary: >
+  <目标章节开始前，该实体当前的具体状态。>
+
+known_history_relevant_to_target: >
+  <只写和目标章节有关的历史，不要复述完整传记。>
+
+allowed_changes_in_target_chapter:
+  - "<目标章节中允许发生的变化或用途>"
+  - "<目标章节中允许发生的变化或用途>"
+
+forbidden_changes_in_target_chapter:
+  - "<禁止发生的漂移、矛盾、升级、暴露或误用>"
+  - "<禁止发生的漂移、矛盾、升级、暴露或误用>"
+
+narrative_functions:
+  - "<该实体在目标章节中的结构功能>"
+  - "<例如：压力源、降压角色、技术解释者、战术限制、交易摩擦>"
+
+relationships_to_other_entities:
+  - entity_id: "<相关实体 ID>"
+    relationship: "<关系或约束>"
+
+rendering_notes:
+  - "<给正文渲染模型的具体提醒>"
+  - "<该实体在正文中应该如何出现或避免如何出现>"
+
+render_visibility:
+  prompt_visible: true
+  prose_visible: true
+  allowed_surface_form:
+    - "<可选：允许正文表现形式>"
+  forbidden_surface_form:
+    - "<可选：禁止正文显性形式>"
+  notes: "<可选：内部可见性说明>"
+
+uncertainty_or_missing_info:
+  - "<当前未知的信息，模型不得擅自补全>"
+  - "<开放问题或待确认信息>"
+```
+
+说明：
+
+- `confidence`、`compiled_from`、`evidence_granularity` 是推荐字段。
+- `render_visibility` 是条件字段；涉及秘密、内部机制、不可明示设定时必须写。
+- 普通人物、装备、地点如果可以正常出现在正文中，可省略 `render_visibility`，或写 `prose_visible: true`。
+
+---
+
+## 9. 目标章临时实体最小 Schema
+
+目标章临时实体用于控制目标章节中新出现的道具、地点、机制、威胁或战术问题。
+
+它们不是完整实体卡，只负责防止正文渲染时漂移。
+
+```yaml
+entity_id: "EC-T001"
+entity_name: "<临时实体名称>"
+entity_type: "<类别 / 功能>"
+source_label: "benchmark_reference | inferred | human_override | model_hypothesis"
+source_basis:
+  - "<支持该临时实体的 Event Log、人工备注或 benchmark_reference reference>"
+confidence: "high | medium | low"
+compiled_from: "event_log | benchmark_reference | human_override | model_hypothesis | mixed"
+evidence_granularity: "event_summary | manual_note | benchmark_reference | mixed"
+render_boundary: >
+  <渲染正文时，该临时实体必须保持的边界。>
+related_events:
+  - "<关联 event id>"
+  - "<关联 event id>"
+```
+
+可选字段：
+
+```yaml
+must_render:
+  - "<必须在正文中出现的内容>"
+
+must_not_render:
+  - "<正文中不得发生的漂移或误用>"
+```
+
+规则：
+
+- clean compiler 不应自动生成目标章临时实体。
+- benchmark_reference/manual Event Log 引入的临时实体必须与主实体卡分开。
+- 临时实体不得覆盖已确认 canon。
+- 临时实体不得代替 World Mechanics 或 Render Event Log。
+
+---
+
+## 10. 字段填写规则
+
+### 8.1 current_state_at_context_boundary
+
+该字段必须描述目标章节开始前的具体状态。
+
+好例子：
+
+```yaml
+current_state_at_context_boundary: >
+  主角刚离开裁缝铺，披着新买的披风，正被同伴带向<equipment_shop>更换不可靠的旧左轮。
+```
+
+坏例子：
+
+```yaml
+current_state_at_context_boundary: >
+  主角勇敢、聪明、有潜力。
+```
+
+原因：
+“勇敢、聪明”是性格或作者指纹相关信息，不是当前状态。
+
+---
+
+### 8.2 known_history_relevant_to_target
+
+只写和目标章节有关的历史。
+
+好例子：
+
+```yaml
+known_history_relevant_to_target: >
+  旧左轮是此前缴获的战利品，有纪念意义，但已经多次表现出精度不可靠。
+```
+
+坏例子：
+
+```yaml
+known_history_relevant_to_target: >
+  从第一章开始完整复述主角经历。
+```
+
+---
+
+### 8.3 allowed_changes_in_target_chapter
+
+写目标章节中允许实体发生的变化或被使用的方式。
+
+示例：
+
+```yaml
+allowed_changes_in_target_chapter:
+  - "可以被试用、替换、折价、保留为纪念物或作为新武器对照。"
+  - "可以通过实际使用暴露限制。"
+```
+
+---
+
+### 8.4 forbidden_changes_in_target_chapter
+
+写具体禁止事项，防止模型漂移。
+
+示例：
+
+```yaml
+forbidden_changes_in_target_chapter:
+  - "不能突然变成魔法武器。"
+  - "不能让主角立刻变成神枪手。"
+  - "不能让 NPC 知道主角隐藏秘密。"
+```
+
+不要写空泛禁令。
+
+坏例子：
+
+```yaml
+forbidden_changes_in_target_chapter:
+  - "不要写坏。"
+```
+
+---
+
+### 8.5 narrative_functions
+
+说明该实体为什么在目标章节中重要。
+
+示例：
+
+```yaml
+narrative_functions:
+  - "装备更新触发器"
+  - "身份压力锚点"
+  - "战术限制"
+  - "世界规则展示物"
+  - "带出笑点同时暴露限制的装置"
+```
+
+---
+
+### 8.6 relationships_to_other_entities
+
+当实体关系会影响正文渲染时，必须写清楚。
+
+示例：
+
+```yaml
+relationships_to_other_entities:
+  - entity_id: "EC-003"
+    relationship: "该角色可以解释装备的机械限制，但不能解决所有问题。"
+
+  - entity_id: "EC-011"
+    relationship: "该未解决威胁推动队伍更新装备。"
+```
+
+---
+
+### 8.7 uncertainty_or_missing_info
+
+用于阻止模型擅自补全未知信息。
+
+示例：
+
+```yaml
+uncertainty_or_missing_info:
+  - "当前剩余现金数量未知；不得写成无限资金。"
+  - "敌人身份未知；除非 Event Log 要求，不得提前揭示。"
+```
+
+---
+
+## 11. 全局实体规则
+
+每个实体卡文件都应该包含全局漂移约束。
+
+模板：
+
+```markdown
+## Global Entity Rules / 全局实体规则
+
+- 除非 Event Log 明确要求，不得揭示秘密。
+- 不得把任何实体升级成万能解法。
+- 不得在没有因果 beat 的情况下移除既有限制。
+- 目标章节临时实体不得覆盖已经确认的 canon。
+- 如果 Entity Cards 与 Event Log 冲突，应优先保留已确认 canon，并在审计阶段标记冲突。
+- 如果某个细节不在 Entity Cards、World Mechanics 或 Event Log 中，应视为未知，而不是为了方便剧情擅自发明。
+- `prose_visible: false` 的实体只能作为内部约束，不得显性进入正文。
+```
+
+---
+
+## 12. 通用模板
+
+下面模板可直接复制到新项目或新章节。
+
+```markdown
+# 01 Active Entity Cards for <target_chapter>
+
+## Source Boundary
+
+~~~yaml
+target_chapter: "<目标章节>"
+input_chapters: "<来源章节范围>"
+source_mode: "clean"
+forbidden_sources:
+  - "<未来章节或禁止来源>"
+notes: "<简短说明>"
+```
+
+---
+
+## Global Entity Rules / 全局实体规则
+
+- 除非 Event Log 明确要求，不得揭示秘密。
+- 不得在没有因果 beat 的情况下移除既有限制。
+- 不得把任何实体变成万能解法。
+- 不得为了方便剧情发明资金、能力、装备或知识。
+- 未知信息应保持未知。
+
+---
+
+## Active Entity Cards / 活跃实体卡
+
+### EC-001
+
+```yaml
+entity_id: "EC-001"
+entity_name: "<实体名称>"
+entity_type: "<类别 / 角色 / 子类型>"
+source_label: "canon_confirmed"
+source_basis:
+  - "<来源章节或文件>"
+
+confidence: "high"
+compiled_from: "<来源类型>"
+evidence_granularity: "<证据粒度>"
+
+current_state_at_context_boundary: >
+  <目标章节开始前的当前状态。>
+
+known_history_relevant_to_target: >
+  <只写与目标章节有关的历史。>
+
+allowed_changes_in_target_chapter:
+  - "<允许变化或用途>"
+
+forbidden_changes_in_target_chapter:
+  - "<禁止漂移或误用>"
+
+narrative_functions:
+  - "<叙事功能>"
+
+relationships_to_other_entities:
+  - entity_id: "<相关实体 ID>"
+    relationship: "<关系或约束>"
+
+rendering_notes:
+  - "<给正文渲染模型的提醒>"
+
+render_visibility:
+  prompt_visible: true
+  prose_visible: true
+  allowed_surface_form: []
+  forbidden_surface_form: []
+  notes: ""
+
+uncertainty_or_missing_info:
+  - "<未知信息>"
+```
+
+### EC-002
+
+```yaml
+entity_id: "EC-002"
+entity_name: "<实体名称>"
+entity_type: "<类别 / 角色 / 子类型>"
+source_label: "canon_confirmed | inferred | benchmark_reference | human_override | model_hypothesis"
+source_basis:
+  - "<来源章节或文件>"
+
+current_state_at_context_boundary: >
+  <目标章节开始前的当前状态。>
+
+known_history_relevant_to_target: >
+  <只写与目标章节有关的历史。>
+
+allowed_changes_in_target_chapter:
+  - "<允许变化或用途>"
+
+forbidden_changes_in_target_chapter:
+  - "<禁止漂移或误用>"
+
+narrative_functions:
+  - "<叙事功能>"
+
+relationships_to_other_entities:
+  - entity_id: "<相关实体 ID>"
+    relationship: "<关系或约束>"
+
+rendering_notes:
+  - "<给正文渲染模型的提醒>"
+
+uncertainty_or_missing_info:
+  - "<未知信息>"
+```
+
+---
+
+## Target-Chapter Transient Entities / 目标章临时实体
+
+### EC-T001
+
+```yaml
+entity_id: "EC-T001"
+entity_name: "<临时实体名称>"
+entity_type: "<类别 / 功能>"
+source_label: "benchmark_reference | inferred | human_override | model_hypothesis"
+render_boundary: >
+  <渲染正文时必须保持的边界。>
+related_events:
+  - "<event id>"
+must_render:
+  - "<可选：必须渲染内容>"
+must_not_render:
+  - "<可选：禁止内容>"
+```
+
+---
+
+## Validation Checklist / 校验清单
+
+- [ ] 每个主要活跃实体都有稳定的 `entity_id`。
+- [ ] 每个实体都有 `entity_type`。
+- [ ] 每个实体都有 `source_label`。
+- [ ] 每个实体都有 `source_basis`。
+- [ ] 每个实体都有 `confidence`、`compiled_from`、`evidence_granularity`。
+- [ ] 每个实体都有目标章节开始前的当前状态。
+- [ ] 每个主要实体都有 allowed / forbidden 变化。
+- [ ] 携带秘密的实体明确写出不得暴露的内容。
+- [ ] `secret` / `internal_constraint` 实体有 `render_visibility`。
+- [ ] `prose_visible: false` 的实体有 `forbidden_surface_form`。
+- [ ] 有能力限制的实体明确写出不能解决什么问题。
+- [ ] 目标章节临时实体与 clean 来源实体分开。
+- [ ] benchmark-reference 实体已明确标记。
+- [ ] clean mode 下没有 `benchmark_reference` 主实体卡。
+- [ ] 除非 source_mode 明确允许，否则没有使用未来章节信息。
+
+  ```
+
+  ```
+
+---
+
+## 13. 推荐 JSON 结构
+
+如果 InkOS 后续希望将本文件编译成机器可读状态，可使用类似 JSON 结构：
+
+```json
+{
+  "target_chapter": "<target_chapter>",
+  "input_chapters": "<pre_target_chapters>",
+  "source_mode": "hybrid",
+  "forbidden_sources": ["ch0012+"],
+  "global_entity_rules": [
+    "除非 Event Log 明确要求，不得揭示秘密。",
+    "不得把任何实体变成万能解法。"
+  ],
+  "entities": [
+    {
+      "entity_id": "EC-001",
+      "entity_name": "<实体名称>",
+      "entity_type": ["character", "protagonist", "secret-holder"],
+      "source_label": "canon_confirmed",
+      "source_basis": ["ch0001", "ch0002"],
+      "current_state_at_context_boundary": "<当前状态>",
+      "known_history_relevant_to_target": "<相关历史>",
+      "allowed_changes_in_target_chapter": ["<允许变化>"],
+      "forbidden_changes_in_target_chapter": ["<禁止变化>"],
+      "narrative_functions": ["<叙事功能>"],
+      "relationships_to_other_entities": [
+        {
+          "entity_id": "EC-002",
+          "relationship": "<关系>"
+        }
+      ],
+      "rendering_notes": ["<渲染提醒>"],
+      "uncertainty_or_missing_info": ["<未知信息>"]
+    }
+  ],
+  "transient_entities": [
+    {
+      "entity_id": "EC-T001",
+      "entity_name": "<临时实体名称>",
+      "entity_type": ["equipment", "magic_weapon"],
+      "source_label": "benchmark_reference",
+      "render_boundary": "<渲染边界>",
+      "related_events": ["O-E003", "O-E005"],
+      "must_render": ["<必须渲染>"],
+      "must_not_render": ["<不得渲染>"]
+    }
+  ]
+}
+```
+
+---
+
+
+## 14. Structural Validator 建议
+
+建议为 Active Entity Cards 增加一个轻量 structural validator。它只检查结构和来源边界，不生成小说正文，不调用外部 LLM。
+
+建议检查项：
+
+```text
+1. 每张主实体卡必须有 entity_id / entity_name / entity_type。
+2. 每张主实体卡必须有 source_label / source_basis。
+3. 每张主实体卡建议有 confidence / compiled_from / evidence_granularity。
+4. clean mode 下不得出现 source_label: benchmark_reference。
+5. source_basis 不得包含 forbidden_sources 中的路径或章节。
+6. clean mode 下不得生成目标章节 transient/benchmark_reference entity。
+7. secret / internal_constraint 实体必须有 render_visibility。
+8. prose_visible: false 的实体必须有 forbidden_surface_form。
+9. forbidden_surface_form 中的词不得出现在最终正文。
+10. Target-Chapter Transient Entities 必须有 related_events 或 render_boundary。
+11. 不得把 Entity Cards 当成 Event Log 使用；不得出现事件顺序字段如 next_event、previous_event、target_length。
+12. 不得把 Entity Cards 当成 World Mechanics 使用；通用世界规则应移入 Worldbuilding / World Mechanics。
+```
+
+validator 输出建议：
+
+```text
+creative_layer/docs/<local_validation_outputs>/active_entity_cards_validation_<target_chapter>.md
+```
+
+---
+
+## 15. PR 定位
+
+本 schema 应定位为：
+
+```text
+Active Entity Cards = 渲染时使用的操作性状态包
+```
+
+它不替代 InkOS 既有 truth files。
+
+它可以由以下来源编译生成：
+
+```text
+current_state
+character_matrix
+particle_ledger
+pending_hooks
+chapter_summaries
+subplot_board
+emotional_arcs
+manual overrides
+benchmark_reference 或 clean 目标章节规划
+```
+
+它在管线中的位置建议为：
+
+```text
+InkOS truth files
+→ Active Entity Cards
+→ Render Event Log + World Mechanics + Author Fingerprint
+→ Renderer LLM
+→ Event-level Auditor
+```
+
+
+---
+
+## 16. v0.2 修改摘要
+
+相对 v0.1，本版只增加必要字段，不改变 schema 定位：
+
+- 新增 `confidence`。
+- 新增 `compiled_from`。
+- 新增 `evidence_granularity`。
+- 新增 `render_visibility`，用于处理内部秘密和不可显性渲染机制。
+- 明确 `secret` / `internal_constraint` 实体必须防止正文泄漏。
+- 明确 clean mode 下不得出现 `benchmark_reference` 主实体卡。
+- 新增 structural validator 建议。

--- a/docs/structured-render-schemas/author_fingerprint_schema.md
+++ b/docs/structured-render-schemas/author_fingerprint_schema.md
@@ -1,0 +1,1816 @@
+# Author Fingerprint Schema v0.3 中文主版
+
+## 1. 用途
+
+`Author Fingerprint` 用于描述目标章节渲染时应遵守的作者风格、叙事节奏、角色声音、说明方式、转场方式、笑点功能和禁止漂移。
+
+它只回答一个问题：
+
+> Renderer 应该如何把结构化事件、实体状态和世界机制渲染成接近目标作者风格的自然小说正文？
+
+本文件不是 Entity Cards schema。
+实体当前状态、人物关系、装备归属、秘密边界属于 `Active Entity Cards`。
+
+本文件不是 Worldbuilding / World Mechanics schema。
+世界规则、技术规则、魔法规则、经济规则、战术机制属于 `Worldbuilding / World Mechanics`。
+
+本文件不是 Render Event Log schema。
+事件顺序、章节 beat、转场链、目标字数、event-level must render 属于 `Render Event Log`。
+
+本文件不是某本书、某一章或某个项目的专用 instance。
+具体作品、具体角色、具体章节事件、具体测试答案应放入 instance 文件或 test output，不应写入 schema。
+
+---
+
+## 2. 通用性原则
+
+Schema 必须保持项目无关。
+
+本文件中不得包含：
+
+- 具体书名；
+- 具体角色名；
+- 具体章节剧情；
+- 具体项目路径；
+- 某次 benchmark 的答案；
+- 某个目标章真实正文内容；
+- 某个测试 instance 中的专有术语；
+- 真实续写时不该提前知道的信息。
+
+允许出现：
+
+- 占位符；
+- 泛化示例；
+- 字段定义；
+- 校验规则；
+- 类型枚举；
+- 通用模板；
+- 不绑定具体作品的说明。
+
+具体项目内容必须放入 instance 文件，而不是 schema 文件。
+
+推荐区分：
+
+```text
+author_fingerprint_schema.md
+  -> 通用 schema，只定义结构和规则
+
+author_fingerprint_<target_chapter>_from_<source_range>.md
+  -> 某目标章节的 production-clean / continuation-safe instance
+
+author_fingerprint_<target_chapter>_planned.md
+  -> 某目标章节的 planned instance
+
+author_fingerprint_<target_chapter>_benchmark_reference.md
+  -> benchmark / 回放测试 instance，不用于真实续写
+
+author_fingerprint_schema_test_report_<target_chapter>.md
+  -> schema fit 测试报告
+```
+
+---
+
+## 3. 核心边界
+
+Author Fingerprint 可以包含：
+
+- InkOS 原生 style profile 统计；
+- 句长、段长、词汇多样性等统计；
+- 对白比例、叙述比例等样本计算统计；
+- 标点使用画像；
+- 高频句首模式；
+- 修辞特征；
+- 作者叙事机制；
+- Renderer 可执行风格规则；
+- 节奏约束；
+- 转场模式；
+- 角色声音 profile；
+- 禁止文风漂移；
+- 审计检查项。
+
+Author Fingerprint 不应包含：
+
+- 完整实体状态；
+- 人物长期关系；
+- 世界规则百科；
+- 事件顺序；
+- 章节 beat sequence；
+- 目标章真实正文；
+- 后续章节信息；
+- benchmark reference；
+- 目标章 benchmark_reference / benchmark 事件内容；
+- 最终小说正文。
+
+---
+
+## 4. Source Mode / 来源模式
+
+每个 Author Fingerprint pack 必须声明来源模式。
+
+合法 `source_mode`：
+
+```yaml
+source_mode: production_clean | planned | manual | hybrid_planned | model_hypothesis | benchmark_reference
+```
+
+推荐真实续写使用：
+
+```yaml
+source_mode: production_clean
+clean_forward_safe: true
+continuation_safe: true
+```
+
+或：
+
+```yaml
+source_mode: planned
+clean_forward_safe: true
+continuation_safe: true
+```
+
+---
+
+## 5. source_mode 定义
+
+### `production_clean`
+
+只使用目标章节之前已经可用的 style profile、style guide、样本文本、truth/state/rules 信息。
+
+适合真实续写。
+
+```yaml
+source_mode: production_clean
+clean_forward_safe: true
+continuation_safe: true
+```
+
+---
+
+### `planned`
+
+使用目标章节之前的信息，加上用户、作者或人工写作计划提供的风格目标。
+
+适合真实续写。
+
+```yaml
+source_mode: planned
+clean_forward_safe: true
+continuation_safe: true
+```
+
+注意：`planned` 可以包含“作者希望本章采用的风格策略”，但不能伪装成已观测作者统计。
+
+---
+
+### `manual`
+
+主要由人工指定风格规则。
+
+适合真实续写、人工控制测试或编辑流程。
+
+```yaml
+source_mode: manual
+continuation_safe: true
+```
+
+---
+
+### `hybrid_planned`
+
+production-clean 信息、人工计划、少量模型推断混合，但不使用目标章真实正文或后续章节。
+
+适合真实续写，但需要更强审计。
+
+```yaml
+source_mode: hybrid_planned
+continuation_safe: true
+```
+
+---
+
+### `model_hypothesis`
+
+模型推断的风格规则，尚未确认。
+
+适合探索，不应直接作为最终写作依据。
+
+```yaml
+source_mode: model_hypothesis
+continuation_safe: true
+```
+
+前提：模型推断没有使用目标章真实正文、后续章节、benchmark reference 或外部 LLM 已生成目标章正文。
+
+---
+
+### `benchmark_reference`
+
+仅用于测试 schema 表达能力、回放对照、评估上限或分析真实目标章。
+
+不得用于真实续写生产路径。
+
+```yaml
+source_mode: benchmark_reference
+clean_forward_safe: false
+continuation_safe: false
+```
+
+---
+
+## 6. continuation_safe / clean_forward_safe 规则
+
+真实续写可用的 Author Fingerprint pack 应写：
+
+```yaml
+continuation_safe: true
+```
+
+如果该 pack 完全来自目标章节之前的 clean 来源，也应写：
+
+```yaml
+clean_forward_safe: true
+```
+
+出现以下情况必须写：
+
+```yaml
+continuation_safe: false
+clean_forward_safe: false
+```
+
+- 使用目标章节真实正文；
+- 使用目标章节真实 trace；
+- 使用后续章节；
+- 使用 benchmark reference；
+- 使用回放答案；
+- 使用外部 LLM 已经生成的目标章正文；
+- 使用任何会让真实续写“偷看答案”的材料。
+
+---
+
+## 7. LLM-native but validator-gated 原则
+
+Author Fingerprint 可以由 LLM 生成 draft，但不能直接把裸 LLM 输出当成可信作者指纹。
+
+推荐原则：
+
+```text
+LLM may draft, validators must gate.
+LLM may interpret metrics, but must not invent metrics.
+LLM may infer style rules, but provenance must label inference.
+LLM may propose character voices, but sample_count and source range must be exposed.
+Renderer input must be accepted packet, not raw LLM draft.
+```
+
+中文原则：
+
+```text
+LLM 可以生成草稿，但 validator 决定是否放行。
+LLM 可以解释统计，但不能伪造统计。
+LLM 可以推断风格规则，但必须标明推断来源。
+LLM 可以提出角色声音，但必须暴露样本数量和样本来源范围。
+Renderer 只能吃通过校验的 packet，不能直接吃裸 LLM 输出。
+```
+
+---
+
+## 8. 顶层对象：`AuthorFingerprintPack`
+
+```yaml
+schema_version: "author_fingerprint.v0.3"
+pack_id: "author_fingerprint_<target_chapter>_<source_range>"
+target_chapter: "<target_chapter>"
+
+source_mode: production_clean
+clean_forward_safe: true
+continuation_safe: true
+
+source_boundary:
+  allowed_sources:
+    - "<style_profile.json>"
+    - "<style_guide.md>"
+    - "<author_intent.md>"
+    - "<pre-target chapter samples>"
+    - "<pre-target truth/state files>"
+    - "<clean Active Entity Cards>"
+  excluded_sources:
+    - "<target chapter real manuscript>"
+    - "<target chapter real trace>"
+    - "<later chapter prose>"
+    - "<benchmark reference>"
+    - "<external LLM target-chapter prose>"
+    - "<uncertain generated artifacts>"
+  contamination_note: "Production-clean pack compiled only from pre-target style/statistical sources."
+
+inkos_style_profile:
+  metrics_status: partial
+  source_files:
+    - "<style_profile.json>"
+    - "<style_guide.md>"
+  quantitative_metrics: {}
+  sentence_opening_patterns: []
+  punctuation_profile: {}
+  rhetorical_features: []
+  character_dialogue_fingerprints: []
+
+creative_mechanics_profile:
+  source_file: "<style guide or author mechanics file>"
+  source_status: original | equivalent_summary | missing
+  source_note: "<说明机制来源>"
+  sample_count: null
+  category_coverage: []
+  emergent_rules: []
+  mechanism_rules: []
+
+render_execution_rules: []
+
+rhythm_constraints: {}
+
+transition_patterns: []
+
+character_voice_profiles: []
+
+chapter_specific_style_constraints: []
+
+forbidden_style_drifts: []
+
+audit:
+  required_checks: []
+```
+
+---
+
+## 9. 顶层字段说明
+
+### `schema_version`
+
+类型：string
+必填：是
+
+推荐值：
+
+```yaml
+schema_version: "author_fingerprint.v0.3"
+```
+
+---
+
+### `pack_id`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+pack_id: "author_fingerprint_<target_chapter>_from_<source_range>"
+```
+
+用途：给当前 Author Fingerprint pack 一个稳定 ID。
+
+---
+
+### `target_chapter`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+target_chapter: "<target_chapter>"
+```
+
+---
+
+### `source_mode`
+
+类型：enum
+必填：是
+
+允许值：
+
+```yaml
+production_clean
+planned
+manual
+hybrid_planned
+model_hypothesis
+benchmark_reference
+```
+
+---
+
+### `clean_forward_safe`
+
+类型：boolean
+必填：是
+
+规则：
+
+- 完全由目标章节之前的来源支持时为 `true`。
+- 使用目标章真实正文、真实 trace、后续章节、benchmark reference 时为 `false`。
+
+---
+
+### `continuation_safe`
+
+类型：boolean
+必填：是
+
+规则：
+
+- 可用于真实续写时为 `true`。
+- 只适合 benchmark / 回放 / 答案分析时为 `false`。
+
+---
+
+### `source_boundary`
+
+类型：object
+必填：是
+
+结构：
+
+```yaml
+source_boundary:
+  allowed_sources:
+    - string
+  excluded_sources:
+    - string
+  contamination_note: string
+```
+
+规则：
+
+- production-clean pack 必须排除目标章正文、目标章真实 trace、后续章节、benchmark reference、外部 LLM 目标章正文、不确定生成产物。
+- benchmark_reference pack 可以使用目标章真实信息，但必须明确 `continuation_safe: false`。
+- 不得把 benchmark_reference 伪装成 production_clean。
+
+---
+
+## 10. `inkos_style_profile`
+
+该部分用于承接 InkOS 原生作者指纹统计和本地可复现样本统计。
+
+结构：
+
+```yaml
+inkos_style_profile:
+  metrics_status: complete | partial | missing | unknown
+
+  source_files:
+    - string
+
+  quantitative_metrics:
+    avg_sentence_length:
+      value: number | null
+      unit: chars | words | tokens | sentences | percent | fraction | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+
+    sentence_length_stddev:
+      value: number | null
+      unit: chars | words | tokens | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+
+    avg_paragraph_length:
+      value: number | null
+      unit: chars | words | tokens | sentences | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+
+    paragraph_length_range:
+      min: number | null
+      max: number | null
+      unit: chars | words | tokens | sentences | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+
+    dialogue_ratio:
+      value: number | null
+      unit: percent | fraction | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+
+    narration_ratio:
+      value: number | null
+      unit: percent | fraction | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+
+    type_token_ratio:
+      value: number | null
+      unit: ratio | unknown
+      source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+```
+
+---
+
+## 11. 数值统计规则
+
+### 11.1 不得伪造统计
+
+如果某项 InkOS 原生统计不存在，不要猜数字。
+
+必须写：
+
+```yaml
+value: null
+unit: unknown
+source_label: unknown
+confidence: unknown
+```
+
+---
+
+### 11.2 样本计算必须标注
+
+如果某项来自本地章节样本计算，而不是 InkOS 原生统计，必须明确标注：
+
+```yaml
+source_label: computed_from_chapters
+confidence: medium
+```
+
+或：
+
+```yaml
+source_label: computed_sample
+confidence: medium
+```
+
+---
+
+### 11.3 单位不明不得强解释
+
+如果 InkOS 原生统计存在但未声明单位，应写：
+
+```yaml
+unit: unknown
+confidence: medium
+```
+
+Renderer / Assembly 不得把 `unit: unknown` 的数值当成强硬字数规则。
+
+错误用法：
+
+```text
+avg_paragraph_length: 1600，因此每段必须写 1600 字。
+```
+
+正确用法：
+
+```text
+该数值只作为节奏诊断，不作为硬性段落长度。
+```
+
+---
+
+### 11.4 LLM 不得发明 metrics
+
+LLM 可以解释统计含义，但不能创造不存在的统计。
+
+允许：
+
+```text
+根据 avg_sentence_length 和 qualitative fallback，建议避免长篇连续说明。
+```
+
+禁止：
+
+```text
+模型自行估算 dialogue_ratio 为 43%。
+```
+
+---
+
+## 12. `sentence_opening_patterns`
+
+用于记录高频句首模式。
+
+结构：
+
+```yaml
+sentence_opening_patterns:
+  - pattern: string
+    frequency: number | null
+    source_label: inkos_style_profile | computed_from_chapters | computed_sample | manual_estimate | unknown
+    usage_note: string
+```
+
+规则：
+
+- 高频句首只能作为诊断信号，不应强迫 Renderer 重复特定词。
+- 如果 pattern 是具体角色名，在通用 schema 中用占位符；具体角色名只应出现在 instance 文件中。
+- 不要为了模仿风格而机械复读 top pattern。
+
+示例：
+
+```yaml
+sentence_opening_patterns:
+  - pattern: "<high-frequency opening pattern>"
+    frequency: null
+    source_label: inkos_style_profile
+    usage_note: "Use as rhythm signal, not as phrase to force into prose."
+```
+
+---
+
+## 13. `punctuation_profile`
+
+用于描述标点节奏。
+
+结构：
+
+```yaml
+punctuation_profile:
+  question_mark_usage: low | medium | high | unknown
+  exclamation_usage: low | medium | high | unknown
+  dash_usage: low | medium | high | unknown
+  ellipsis_usage: low | medium | high | unknown
+  quote_density: low | medium | high | unknown
+  notes:
+    - string
+```
+
+规则：
+
+- 如果标点画像来自样本计算，notes 中应说明 `source_label: computed_from_chapters` 或等价说明。
+- 标点画像用于节奏控制，不用于强迫机械插入标点。
+- 不要把破折号、感叹号、省略号用于过度戏剧化。
+
+---
+
+## 14. `rhetorical_features`
+
+用于记录修辞特征和作者常见表达机制。
+
+结构：
+
+```yaml
+rhetorical_features:
+  - feature: string
+    observed_strength: weak | medium | strong | unknown
+    usage_note: string
+    source_label: inkos_style_profile | style_guide | computed_from_chapters | manual_note | model_hypothesis | unknown
+```
+
+规则：
+
+- `inkos_style_profile` 来源用于原生统计或分析结果。
+- `style_guide` 来源用于 InkOS 风格指南。
+- `computed_from_chapters` 来源用于脚本从样本计算或抽取的特征。
+- `model_hypothesis` 必须谨慎，不能伪装成观测事实。
+
+---
+
+## 15. `character_dialogue_fingerprints`
+
+用于记录角色对白统计，不替代完整角色声音 profile。
+
+结构：
+
+```yaml
+character_dialogue_fingerprints:
+  - character_id: string
+    source_status: extracted | manual | mixed | missing | unknown
+    sample_count: number | null
+    sample_source_range: string | null
+    average_line_length:
+      value: number | null
+      unit: chars | words | tokens | unknown
+      source_label: computed_from_chapters | computed_sample | inkos_style_profile | manual_estimate | unknown
+      confidence: high | medium | low | unknown
+    diction_traits:
+      - string
+    rhythm_traits:
+      - string
+    taboo_drifts:
+      - string
+```
+
+规则：
+
+- `sample_count` 必须说明样本数量。
+- `sample_source_range` 必须说明样本来源范围。
+- 样本少的角色应降低 confidence 或在 notes 中说明。
+- 该部分只记录统计摘要；可执行角色声音规则应写入 `character_voice_profiles`。
+
+---
+
+## 16. `creative_mechanics_profile`
+
+该部分用于承接作者创作机制、风格机制、叙事习惯和等价机制摘要。
+
+结构：
+
+```yaml
+creative_mechanics_profile:
+  source_file: string | null
+  source_status: original | equivalent_summary | missing
+  source_note: string
+  sample_count: number | null
+
+  category_coverage:
+    - category_id: string
+      category_name: string
+      evidence_count: number | null
+      strength: weak | medium | strong | unknown
+      render_use: string
+
+  emergent_rules:
+    - rule_id: string
+      title: string
+      description: string
+      coverage: weak | medium | strong | universal | unknown
+      render_implication: string
+
+  mechanism_rules:
+    - rule_id: string
+      title: string
+      pattern:
+        - string
+      allowed_use:
+        - string
+      forbidden_use:
+        - string
+      example_function:
+        - string
+      confidence: high | medium | low | unknown
+```
+
+---
+
+## 17. creative_mechanics_profile.source_status
+
+合法值：
+
+```yaml
+source_status: original | equivalent_summary | missing
+```
+
+含义：
+
+- `original`：找到原始 author creative mechanics 文件。
+- `equivalent_summary`：未找到原始文件，但使用 style guide、style profile、作者意图或等价摘要。
+- `missing`：没有找到可用机制文件或摘要。
+
+规则：
+
+- 不得把 `_quarantine` 或不确定生成产物伪装成原始机制文件。
+- 如果只使用等价摘要，必须写：
+
+  ```yaml
+  source_status: equivalent_summary
+  ```
+- 如果缺失，不要伪造机制文件路径。
+
+---
+
+## 18. `render_execution_rules`
+
+该部分是 Author Fingerprint 最关键的可执行层。
+它把统计和风格观察转成 Renderer 可遵守的写作规则。
+
+结构：
+
+```yaml
+render_execution_rules:
+  - rule_id: string
+    priority: critical | high | medium | low
+    rule_statement: string
+    applies_to:
+      - string
+    allowed_rendering:
+      - string
+    forbidden_rendering:
+      - string
+    audit_question: string
+    source_label: inkos_mechanic | style_guide | computed_from_chapters | manual_style_rule | model_hypothesis | benchmark_reference
+    confidence: high | medium | low | unknown
+```
+
+推荐至少覆盖：
+
+```yaml
+recommended_render_execution_rules:
+  - event_not_outline
+  - object_triggered_exposition
+  - exposition_with_friction
+  - novelty_limited
+  - multi_function_event
+  - comedy_with_function
+  - concrete_closure
+  - character_voice_separation
+  - no_prompt_language_leak
+```
+
+---
+
+## 19. 推荐 render_execution_rules
+
+### 19.1 event_not_outline
+
+```yaml
+rule_id: style_rule_event_not_outline
+priority: critical
+rule_statement: "不要把 Event Log 渲染成 checklist；每个重要 event 必须变成可见动作、物件、对白或场景移动。"
+applies_to:
+  - prose_rendering
+  - event_transition
+allowed_rendering:
+  - "Use object handling, dialogue interruption, physical movement, or consequence to move between events."
+forbidden_rendering:
+  - "Do not write 'they discussed X' as a substitute for scene."
+  - "Do not expose event IDs or schema terms."
+audit_question: "Can the reader see the event happening rather than being told it happened?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+### 19.2 object_triggered_exposition
+
+```yaml
+rule_id: style_rule_object_triggered_exposition
+priority: high
+rule_statement: "设定应从物件、动作、交易、试用、误解、价格或风险中冒出。"
+applies_to:
+  - world_mechanic_release
+  - dialogue
+allowed_rendering:
+  - "Let concrete objects, physical action, price, failure, risk, or character reaction trigger explanation."
+forbidden_rendering:
+  - "Do not paste a detached worldbuilding paragraph into narration."
+audit_question: "Does the rule emerge from something visible?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+### 19.3 exposition_with_friction
+
+```yaml
+rule_id: style_rule_exposition_with_friction
+priority: high
+rule_statement: "说明必须有摩擦：动作打断、吐槽、成本、权限、危险、误会或现实反压。"
+applies_to:
+  - mechanism_explanation
+allowed_rendering:
+  - "Break explanations with action, testing, correction, price, awkwardness, danger, or role-specific reaction."
+forbidden_rendering:
+  - "Do not allow uninterrupted lecture blocks when a scene action can carry the same information."
+audit_question: "Is exposition resisted by scene pressure?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+### 19.4 novelty_limited
+
+```yaml
+rule_id: style_rule_novelty_limited
+priority: high
+rule_statement: "新奇素材必须立刻带限制。"
+applies_to:
+  - new_weapon
+  - magic
+  - machine
+  - technology
+  - new_information
+allowed_rendering:
+  - "Attach price, rarity, skill, permission, risk, uncertainty, or tactical cost to every cool option."
+forbidden_rendering:
+  - "Do not let a new tool, spell, machine, or idea solve the chapter by itself."
+audit_question: "Does every cool thing meet a limit quickly?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+### 19.5 multi_function_event
+
+```yaml
+rule_id: style_rule_multi_function_event
+priority: medium
+rule_statement: "每个重要 event 尽量承担两个以上功能。"
+applies_to:
+  - scene_building
+allowed_rendering:
+  - "Combine plot movement with joke, relationship, mechanism, cost, danger, or transition."
+forbidden_rendering:
+  - "Avoid single-purpose summary paragraphs."
+audit_question: "Does the event do more than one job?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+### 19.6 comedy_with_function
+
+```yaml
+rule_id: style_rule_comedy_with_function
+priority: medium
+rule_statement: "笑点必须有结构功能。"
+applies_to:
+  - comedy
+  - banter
+allowed_rendering:
+  - "Use jokes to reveal character voice, social pressure, equipment limits, danger, embarrassment, or transition."
+forbidden_rendering:
+  - "Do not insert detachable gag lines that stall the scene."
+audit_question: "Does the joke reveal or move something?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+### 19.7 concrete_closure
+
+```yaml
+rule_id: style_rule_concrete_closure
+priority: high
+rule_statement: "场景收束落在物件、动作、对白、沉默或反差上，不要抽象总结。"
+applies_to:
+  - scene_closure
+  - chapter_ending
+allowed_rendering:
+  - "End on a physical object, action, deadpan line, embarrassed reaction, silence, or unresolved practical problem."
+forbidden_rendering:
+  - "Do not end with abstract growth, destiny, theme, or moral summary."
+audit_question: "Does the ending land on something concrete?"
+source_label: style_guide
+confidence: high
+```
+
+---
+
+## 20. `rhythm_constraints`
+
+用于把统计和 qualitative fallback 合并成节奏约束。
+
+结构：
+
+```yaml
+rhythm_constraints:
+  source_status: metric_backed | qualitative_only | mixed | unknown
+
+  sentence_length:
+    metric:
+      avg_sentence_length: number | null
+      sentence_length_stddev: number | null
+      unit: chars | words | tokens | unknown
+    qualitative_fallback:
+      - string
+
+  paragraph_length:
+    metric:
+      avg_paragraph_length: number | null
+      paragraph_length_range:
+        min: number | null
+        max: number | null
+      unit: chars | words | tokens | sentences | unknown
+    qualitative_fallback:
+      - string
+
+  dialogue_narration_balance:
+    metric:
+      dialogue_ratio: number | null
+      narration_ratio: number | null
+      unit: percent | fraction | unknown
+    qualitative_fallback:
+      - string
+
+  punctuation_rhythm:
+    metric_status: complete | partial | missing | unknown
+    qualitative_fallback:
+      - string
+```
+
+规则：
+
+- 统计单位不明时，不得作为硬性长度规则。
+- fallback 应告诉 Renderer 如何控制节奏，而不是写泛泛“写得好”。
+- 避免长篇连续说明。
+- 对话和叙述应交错，避免纯对白清单或纯说明段落。
+
+---
+
+## 21. `transition_patterns`
+
+用于描述作者常见或推荐转场模式。
+
+结构：
+
+```yaml
+transition_patterns:
+  - pattern_id: string
+    pattern_steps:
+      - string
+    use_when:
+      - string
+    avoid_when:
+      - string
+    audit_question: string
+```
+
+推荐至少包含：
+
+```yaml
+transition_patterns:
+  - pattern_id: object_to_problem_to_next_action
+    pattern_steps:
+      - "object/action appears or is handled"
+      - "character jokes, misunderstands, asks, tests, or corrects"
+      - "rule/cost/permission/danger emerges"
+      - "limitation forces next action"
+    use_when:
+      - "moving between equipment, test, social pressure, mechanism release, and task risk"
+    avoid_when:
+      - "external interruption should carry the transition"
+    audit_question: "Did the transition arise from scene pressure rather than 'then'?"
+```
+
+---
+
+## 22. `character_voice_profiles`
+
+用于描述角色声音、句式、用词、风格功能和禁止漂移。
+
+结构：
+
+```yaml
+character_voice_profiles:
+  - character_id: string
+    display_name: string
+
+    source_status: inkos_dialogue_fingerprint | extracted | manual_profile | mixed | missing | unknown
+    sample_count: number | null
+    sample_source_range: string | null
+
+    core_voice:
+      - string
+
+    sentence_shape:
+      average_line_length:
+        value: number | null
+        unit: chars | words | tokens | unknown
+        source_label: computed_from_chapters | computed_sample | inkos_style_profile | manual_estimate | unknown
+        confidence: high | medium | low | unknown
+      rhythm_note: string
+
+    diction:
+      preferred:
+        - string
+      avoid:
+        - string
+
+    functional_role_in_style:
+      - string
+
+    allowed_moves:
+      - string
+
+    forbidden_drifts:
+      - string
+
+    audit_questions:
+      - string
+
+    source_label: canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference
+    confidence: high | medium | low | unknown
+```
+
+规则：
+
+- 每个主要角色应有单独 profile。
+- `sample_count` 和 `sample_source_range` 必须暴露。
+- 样本少时应降低 confidence，或在 `source_status` 中写 `mixed` / `manual_profile`。
+- 角色声音只控制写法，不新增剧情事实。
+- 不要让所有角色共享同一种中性说明腔。
+- 不要让角色突然知道不该知道的信息。
+- 不要让角色声音 profile 取代 Entity Cards。
+
+---
+
+## 23. `chapter_specific_style_constraints`
+
+用于目标章节的局部风格约束。
+
+结构：
+
+```yaml
+chapter_specific_style_constraints:
+  - constraint_id: string
+    target_chapter: string
+    rule_statement: string
+    allowed_rendering:
+      - string
+    forbidden_rendering:
+      - string
+    source_label: canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference
+    clean_forward_safe: boolean
+    continuation_safe: boolean
+    confidence: high | medium | low | unknown
+```
+
+规则：
+
+- 只能约束“怎么写”，不能规定“发生什么”。
+- 不得包含目标章真实正文或 benchmark reference。
+- 如果来自人工计划，应标 `human_planned`。
+- 如果来自模型假设，应标 `model_hypothesis`。
+- 如果来自 benchmark/reference，必须 `continuation_safe: false`。
+
+可接受示例：
+
+```yaml
+rule_statement: "测试、交易、机制释放类段落必须通过物件、动作、对白或反应可见化；不要压成摘要。"
+```
+
+不可接受示例：
+
+```yaml
+rule_statement: "第七个事件必须发生某具体剧情反转。"
+```
+
+原因：这是 Render Event Log，不是 Author Fingerprint。
+
+---
+
+## 24. `forbidden_style_drifts`
+
+用于全局禁止文风漂移。
+
+结构：
+
+```yaml
+forbidden_style_drifts:
+  - drift_id: string
+    description: string
+    examples:
+      - string
+    audit_question: string
+    severity: low | medium | high | critical
+```
+
+推荐至少包含：
+
+```yaml
+recommended_forbidden_style_drifts:
+  - checklist_expansion
+  - encyclopedia_exposition
+  - all_characters_same_voice
+  - new_cool_thing_without_limitation
+  - abstract_conceptual_ending
+  - prompt_or_schema_language_leak
+  - event_id_leak
+  - internal_only_leak
+  - future_source_contamination
+```
+
+---
+
+## 25. `audit.required_checks`
+
+用于给 Auditor 提供检查项。
+
+结构：
+
+```yaml
+audit:
+  required_checks:
+    - check_id: string
+      question: string
+      severity: low | medium | high | critical
+```
+
+推荐检查项：
+
+```yaml
+audit:
+  required_checks:
+    - check_id: metrics_used_or_marked_unknown
+      question: "Were metrics filled from real data or explicitly marked as sample-computed/unknown?"
+      severity: high
+
+    - check_id: event_log_hidden
+      question: "Does the prose hide the Event Log skeleton?"
+      severity: critical
+
+    - check_id: exposition_has_friction
+      question: "Does mechanism explanation meet resistance through action, joke, misunderstanding, cost, permission, danger, or interruption?"
+      severity: high
+
+    - check_id: multi_function_events
+      question: "Do major events perform at least two functions where possible?"
+      severity: medium
+
+    - check_id: character_voices_separated
+      question: "Do character lines sound differentiated?"
+      severity: high
+
+    - check_id: concrete_closure
+      question: "Do scene endings land on object/action/dialogue/silence/reversal rather than concept summary?"
+      severity: high
+
+    - check_id: no_new_plot_from_style
+      question: "Did Author Fingerprint avoid inventing event content?"
+      severity: critical
+
+    - check_id: no_future_source_contamination
+      question: "Did the render avoid target-chapter real prose, runtime trace, later chapters, benchmark reference, generated benchmark_reference render, and quarantine-derived style leakage?"
+      severity: critical
+```
+
+---
+
+## 26. 最小验证规则
+
+生成的 Author Fingerprint pack 至少需要通过以下检查：
+
+1. 声明 `schema_version`。
+2. 声明 `target_chapter`。
+3. 声明 `source_mode`。
+4. 声明 `clean_forward_safe`。
+5. 声明 `continuation_safe`。
+6. 声明 `source_boundary`。
+7. 有 `inkos_style_profile`。
+8. 有 `creative_mechanics_profile`。
+9. 有 `render_execution_rules`。
+10. 有 `rhythm_constraints`。
+11. 有 `transition_patterns`。
+12. 主要角色有 `character_voice_profiles`。
+13. 有 `forbidden_style_drifts`。
+14. 有 `audit.required_checks`。
+15. InkOS 原生缺失统计不得伪造。
+16. 本地样本计算统计必须标 `computed_from_chapters` 或 `computed_sample`。
+17. 单位不明的数值必须标 `unit: unknown`。
+18. 角色 voice profile 必须包含 `sample_count` 和 `sample_source_range`。
+19. 不得包含目标章真实正文。
+20. 不得包含后续章节信息。
+21. 不得包含 benchmark reference，除非 `source_mode: benchmark_reference` 且 `continuation_safe: false`。
+22. 不得替代 Entity Cards。
+23. 不得替代 World Mechanics。
+24. 不得替代 Render Event Log。
+25. 不得生成小说正文。
+
+---
+
+## 27. Production-clean instance 最小模板
+
+```yaml
+schema_version: "author_fingerprint.v0.3"
+pack_id: "author_fingerprint_<target_chapter>_from_<source_range>"
+target_chapter: "<target_chapter>"
+
+source_mode: production_clean
+clean_forward_safe: true
+continuation_safe: true
+
+source_boundary:
+  allowed_sources:
+    - "<style_profile.json>"
+    - "<style_guide.md>"
+    - "<author_intent.md>"
+    - "<pre-target chapter samples>"
+    - "<pre-target truth/state files>"
+    - "<clean Active Entity Cards>"
+  excluded_sources:
+    - "<target chapter real manuscript>"
+    - "<target chapter real trace>"
+    - "<later chapter prose>"
+    - "<benchmark reference>"
+    - "<external LLM target-chapter prose>"
+    - "<uncertain generated artifacts>"
+  contamination_note: "No target-chapter real prose, real trace, later chapter, benchmark reference, external LLM target-chapter prose, or uncertain generated artifact was read."
+
+inkos_style_profile:
+  metrics_status: partial
+  source_files:
+    - "<style_profile.json>"
+    - "<style_guide.md>"
+
+  quantitative_metrics:
+    avg_sentence_length:
+      value: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+    sentence_length_stddev:
+      value: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+    avg_paragraph_length:
+      value: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+    paragraph_length_range:
+      min: null
+      max: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+    dialogue_ratio:
+      value: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+    narration_ratio:
+      value: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+    type_token_ratio:
+      value: null
+      unit: unknown
+      source_label: unknown
+      confidence: unknown
+
+  sentence_opening_patterns: []
+
+  punctuation_profile:
+    question_mark_usage: unknown
+    exclamation_usage: unknown
+    dash_usage: unknown
+    ellipsis_usage: unknown
+    quote_density: unknown
+    notes: []
+
+  rhetorical_features: []
+
+  character_dialogue_fingerprints: []
+
+creative_mechanics_profile:
+  source_file: "<style guide or author mechanics file>"
+  source_status: original | equivalent_summary | missing
+  source_note: "<说明机制来源。>"
+  sample_count: null
+  category_coverage: []
+  emergent_rules: []
+  mechanism_rules: []
+
+render_execution_rules:
+  - rule_id: style_rule_event_not_outline
+    priority: critical
+    rule_statement: "不要把 Event Log 渲染成 checklist；每个重要 event 必须变成可见动作、物件、对白或场景移动。"
+    applies_to:
+      - prose_rendering
+      - event_transition
+    allowed_rendering:
+      - "Use object handling, dialogue interruption, physical movement, or consequence to move between events."
+    forbidden_rendering:
+      - "Do not write 'they discussed X' as a substitute for scene."
+      - "Do not expose event IDs or schema terms."
+    audit_question: "Can the reader see the event happening rather than being told it happened?"
+    source_label: style_guide
+    confidence: high
+
+  - rule_id: style_rule_object_triggered_exposition
+    priority: high
+    rule_statement: "设定应从物件、动作、交易、试用、误解、价格或风险中冒出。"
+    applies_to:
+      - world_mechanic_release
+      - dialogue
+    allowed_rendering:
+      - "Let concrete objects, physical action, price, failure, risk, or character reaction trigger explanation."
+    forbidden_rendering:
+      - "Do not paste a detached worldbuilding paragraph into narration."
+    audit_question: "Does the rule emerge from something visible?"
+    source_label: style_guide
+    confidence: high
+
+  - rule_id: style_rule_exposition_with_friction
+    priority: high
+    rule_statement: "说明必须有摩擦：动作打断、吐槽、成本、权限、危险、误会或现实反压。"
+    applies_to:
+      - mechanism_explanation
+    allowed_rendering:
+      - "Break explanations with action, testing, correction, price, awkwardness, danger, or role-specific reaction."
+    forbidden_rendering:
+      - "Do not allow uninterrupted lecture blocks when a scene action can carry the same information."
+    audit_question: "Is exposition resisted by scene pressure?"
+    source_label: style_guide
+    confidence: high
+
+  - rule_id: style_rule_novelty_limited
+    priority: high
+    rule_statement: "新奇素材必须立刻带限制。"
+    applies_to:
+      - new_weapon
+      - magic
+      - machine
+      - technology
+      - new_information
+    allowed_rendering:
+      - "Attach price, rarity, skill, permission, risk, uncertainty, or tactical cost to every cool option."
+    forbidden_rendering:
+      - "Do not let a new tool, spell, machine, or idea solve the chapter by itself."
+    audit_question: "Does every cool thing meet a limit quickly?"
+    source_label: style_guide
+    confidence: high
+
+  - rule_id: style_rule_multi_function_event
+    priority: medium
+    rule_statement: "每个重要 event 尽量承担两个以上功能。"
+    applies_to:
+      - scene_building
+    allowed_rendering:
+      - "Combine plot movement with joke, relationship, mechanism, cost, danger, or transition."
+    forbidden_rendering:
+      - "Avoid single-purpose summary paragraphs."
+    audit_question: "Does the event do more than one job?"
+    source_label: style_guide
+    confidence: high
+
+  - rule_id: style_rule_comedy_with_function
+    priority: medium
+    rule_statement: "笑点必须有结构功能。"
+    applies_to:
+      - comedy
+      - banter
+    allowed_rendering:
+      - "Use jokes to reveal character voice, social pressure, equipment limits, danger, embarrassment, or transition."
+    forbidden_rendering:
+      - "Do not insert detachable gag lines that stall the scene."
+    audit_question: "Does the joke reveal or move something?"
+    source_label: style_guide
+    confidence: high
+
+  - rule_id: style_rule_concrete_closure
+    priority: high
+    rule_statement: "场景收束落在物件、动作、对白、沉默或反差上，不要抽象总结。"
+    applies_to:
+      - scene_closure
+      - chapter_ending
+    allowed_rendering:
+      - "End on a physical object, action, deadpan line, embarrassed reaction, silence, or unresolved practical problem."
+    forbidden_rendering:
+      - "Do not end with abstract growth, destiny, theme, or moral summary."
+    audit_question: "Does the ending land on something concrete?"
+    source_label: style_guide
+    confidence: high
+
+rhythm_constraints:
+  source_status: mixed
+  sentence_length:
+    metric:
+      avg_sentence_length: null
+      sentence_length_stddev: null
+      unit: unknown
+    qualitative_fallback:
+      - "Short sentences are preferred for punchlines, action landings, awkward pauses, and dry retorts."
+      - "Medium-long sentences may carry mechanism explanation, but should be broken by action or dialogue."
+
+  paragraph_length:
+    metric:
+      avg_paragraph_length: null
+      paragraph_length_range:
+        min: null
+        max: null
+      unit: unknown
+    qualitative_fallback:
+      - "Avoid long uninterrupted exposition blocks."
+      - "Paragraph endings should land on object, action, dialogue, silence, or reversal more often than abstract summary."
+
+  dialogue_narration_balance:
+    metric:
+      dialogue_ratio: null
+      narration_ratio: null
+      unit: unknown
+    qualitative_fallback:
+      - "Dialogue and narration should interleave."
+      - "Avoid pure dialogue checklist and pure expository narration."
+
+  punctuation_rhythm:
+    metric_status: missing
+    qualitative_fallback:
+      - "Question marks and short quoted retorts may support banter and confusion."
+      - "Avoid stacked exclamation marks."
+      - "Avoid overusing dramatic dashes."
+
+transition_patterns:
+  - pattern_id: object_to_problem_to_next_action
+    pattern_steps:
+      - "object/action appears or is handled"
+      - "character jokes, misunderstands, asks, tests, or corrects"
+      - "rule/cost/permission/danger emerges"
+      - "limitation forces next action"
+    use_when:
+      - "moving between equipment, test, social pressure, mechanism release, and task risk"
+    avoid_when:
+      - "external interruption should carry the transition"
+    audit_question: "Did the transition arise from scene pressure rather than 'then'?"
+
+character_voice_profiles:
+  - character_id: "<character_id>"
+    display_name: "<character_display_name>"
+    source_status: extracted
+    sample_count: null
+    sample_source_range: "<pre-target dialogue sample range>"
+    core_voice:
+      - "<core voice trait>"
+    sentence_shape:
+      average_line_length:
+        value: null
+        unit: unknown
+        source_label: unknown
+        confidence: unknown
+      rhythm_note: "<sentence rhythm note>"
+    diction:
+      preferred:
+        - "<preferred diction>"
+      avoid:
+        - "<diction to avoid>"
+    functional_role_in_style:
+      - "<style function>"
+    allowed_moves:
+      - "<allowed voice move>"
+    forbidden_drifts:
+      - "<forbidden drift>"
+    audit_questions:
+      - "Does this character's voice remain distinct?"
+      - "Does this character voice avoid adding new plot facts?"
+    source_label: inferred
+    confidence: medium
+
+chapter_specific_style_constraints: []
+
+forbidden_style_drifts:
+  - drift_id: checklist_expansion
+    description: "Prose visibly follows Event Log bullets instead of becoming a scene."
+    examples:
+      - "They discussed event A, then event B, then event C."
+    audit_question: "Are events rendered as scene actions rather than checklist paraphrase?"
+    severity: critical
+
+  - drift_id: encyclopedia_exposition
+    description: "World rules are copied as detached explanation instead of emerging from action."
+    examples:
+      - "A full lecture on the setting with no object, interruption, joke, cost, or scene pressure."
+    audit_question: "Does exposition have friction?"
+    severity: high
+
+  - drift_id: all_characters_same_voice
+    description: "Characters speak in the same neutral explanatory voice."
+    examples:
+      - "Every character sounds like a rulebook narrator."
+    audit_question: "Are character voices separated?"
+    severity: high
+
+  - drift_id: new_cool_thing_without_limitation
+    description: "A weapon, spell, machine, idea, or new information appears without price, scarcity, skill, permission, uncertainty, or risk."
+    examples:
+      - "A new tool solves the scene without tradeoff."
+    audit_question: "Does each novelty meet a limit?"
+    severity: high
+
+  - drift_id: abstract_conceptual_ending
+    description: "Scene or chapter closes with abstract lesson rather than concrete anchor."
+    examples:
+      - "They finally understood the cost of growth."
+    audit_question: "Does closure land on object/action/dialogue/silence/reversal?"
+    severity: high
+
+  - drift_id: prompt_or_schema_language_leak
+    description: "Prompt, schema, event id, field name, audit language, or internal instruction leaks into prose."
+    examples:
+      - "REL-E001's must_render is..."
+    audit_question: "Does the prose hide all schema/prompt language?"
+    severity: critical
+
+audit:
+  required_checks:
+    - check_id: metrics_used_or_marked_unknown
+      question: "Were sentence/paragraph/dialogue metrics filled from real data or explicitly marked as sample-computed/unknown?"
+      severity: high
+    - check_id: event_log_hidden
+      question: "Does the prose hide the Event Log skeleton?"
+      severity: critical
+    - check_id: exposition_has_friction
+      question: "Does mechanism explanation meet resistance through action, joke, misunderstanding, cost, permission, danger, or interruption?"
+      severity: high
+    - check_id: multi_function_events
+      question: "Do major events perform at least two functions where possible?"
+      severity: medium
+    - check_id: character_voices_separated
+      question: "Do character lines sound differentiated?"
+      severity: high
+    - check_id: concrete_closure
+      question: "Do scene endings land on object/action/dialogue/silence/reversal rather than concept summary?"
+      severity: high
+    - check_id: no_new_plot_from_style
+      question: "Did Author Fingerprint avoid inventing event content?"
+      severity: critical
+    - check_id: no_future_source_contamination
+      question: "Did the render avoid target-chapter real prose, runtime trace, later chapters, benchmark reference, generated benchmark_reference render, and quarantine-derived style leakage?"
+      severity: critical
+```
+
+---
+
+## 28. Benchmark reference 指南
+
+如果某些风格判断来自真实目标章、目标章 trace、后续章节、benchmark reference 或回放答案，应使用：
+
+```yaml
+source_mode: benchmark_reference
+clean_forward_safe: false
+continuation_safe: false
+source_label: benchmark_reference
+```
+
+规则：
+
+- 只能用于 schema fit test、回放、分析、upper-bound 对照。
+- 不得用于真实续写。
+- 不得回写 production-clean instance。
+- 不得伪装成 pre-target author fingerprint。
+
+---
+
+## 29. 常见失败模式
+
+### 29.1 checklist expansion
+
+错误：
+
+```text
+他们做了事件 A。然后做了事件 B。然后讨论了事件 C。
+```
+
+问题：正文暴露 Event Log 骨架。
+
+修正：每个 event 必须通过动作、对白、物件、反应或场景变化发生。
+
+---
+
+### 29.2 encyclopedia exposition
+
+错误：
+
+```text
+本世界的完整机制如下……
+```
+
+问题：设定说明脱离场景。
+
+修正：说明必须由物件、动作、价格、失败、误会、风险或角色反应触发。
+
+---
+
+### 29.3 all characters same voice
+
+错误：
+
+```text
+所有角色都用同一种清晰、理性、中性说明腔说话。
+```
+
+问题：角色声音丢失。
+
+修正：每个主要角色必须遵守独立 `character_voice_profiles`。
+
+---
+
+### 29.4 novelty without limitation
+
+错误：
+
+```text
+新工具、新法术、新技术或新信息出现后立刻解决所有问题。
+```
+
+问题：新奇素材外挂化。
+
+修正：新奇素材必须立刻遇到价格、稀缺、技能、权限、风险、误解或信息差。
+
+---
+
+### 29.5 abstract closure
+
+错误：
+
+```text
+他们终于明白了成长的意义。
+```
+
+问题：抽象感悟收尾。
+
+修正：收束应落在物件、动作、对白、沉默、反差或未解决的具体问题上。
+
+---
+
+### 29.6 prompt/schema language leak
+
+错误：
+
+```text
+这个事件的 must_render 是……
+```
+
+问题：schema 语言泄漏进正文。
+
+修正：Renderer 不得输出 event id、schema 字段名、audit question、prompt 术语或内部说明。
+
+---
+
+### 29.7 metric hallucination
+
+错误：
+
+```yaml
+dialogue_ratio:
+  value: 0.42
+  source_label: inkos_style_profile
+```
+
+但 InkOS 原生 profile 没有该项。
+
+问题：伪造统计。
+
+修正：缺失项写 `null + unknown`；样本计算项写 `computed_from_chapters` 或 `computed_sample`。
+
+---
+
+### 29.8 future-source contamination
+
+错误：
+
+```yaml
+source_mode: production_clean
+source_basis:
+  - "<target chapter real manuscript>"
+```
+
+问题：真实续写偷看答案。
+
+修正：使用目标章真实正文或 benchmark reference 时必须 `source_mode: benchmark_reference`，并 `continuation_safe: false`。
+
+---
+
+## 30. PR 定位
+
+本 schema 应定位为：
+
+```text
+Author Fingerprint = 作者风格与 Renderer 执行规则包
+```
+
+它不替代 InkOS 既有 style profile，也不替代 truth files。
+
+建议管线位置：
+
+```text
+InkOS style_profile / style_guide / chapter samples
+→ Author Fingerprint
+→ Active Entity Cards + Worldbuilding / World Mechanics + Render Event Log
+→ Structured Render Assembly
+→ Renderer LLM
+→ Event-level Auditor
+```
+
+---
+
+##  31. v0.3 修改摘要
+
+相对 v0.2，本版做了以下修改：
+
+- 移除具体作品、具体角色、具体章节、具体项目实例。
+- 增加 `source_mode`：
+  - `production_clean`
+  - `planned`
+  - `manual`
+  - `hybrid_planned`
+  - `model_hypothesis`
+  - `benchmark_reference`
+- 增加 `continuation_safe`。
+- 明确真实续写不得使用 benchmark / target real prose / future chapter。
+- 增加 metrics `source_label`：
+  - `inkos_style_profile`
+  - `computed_from_chapters`
+  - `computed_sample`
+  - `manual_estimate`
+  - `unknown`
+- 增加 `creative_mechanics_profile.source_status`：
+  - `original`
+  - `equivalent_summary`
+  - `missing`
+- 正式加入 `sample_count` 和 `sample_source_range`。
+- 明确样本计算统计不能伪装成 InkOS 原生统计。
+- 明确单位 unknown 的统计不能当成硬性字数规则。
+- 保留 LLM-native but validator-gated 原则。
+- 强化 Author Fingerprint 不接管 Entity Cards / World Mechanics / Render Event Log 的边界。
+- 保留中文主说明和英文字段名，便于人读和程序处理。

--- a/docs/structured-render-schemas/render_event_log_schema.md
+++ b/docs/structured-render-schemas/render_event_log_schema.md
@@ -1,0 +1,1916 @@
+# Render Event Log / 渲染事件日志 Schema v0.4
+
+## 1. 用途
+
+`Render Event Log` 用于描述目标章节中：
+
+- 发生什么；
+- 按什么顺序发生；
+- 每个事件进入时必须满足什么状态；
+- 每个事件必须渲染哪些动作、对白、物件、信息或情绪变化；
+- 每个事件禁止出现哪些漂移、压缩、越权、泄密或错误解决；
+- 每个事件如何自然衔接到下一个事件；
+- 每个事件引用哪些 Entity Cards、World Mechanics 和 Author Fingerprint 约束；
+- 后续 Auditor 应该检查什么。
+
+它是给 Renderer 使用的 **事件级渲染蓝图**。
+
+
+本文件不是 Entity Cards。
+本文件不是 Worldbuilding / World Mechanics。
+本文件不是 Author Fingerprint。
+
+
+---
+
+## 2. 通用性原则
+
+Schema 必须保持项目无关。
+
+本文件中不得包含：
+
+- 具体书名；
+- 具体角色名；
+- 具体章节剧情；
+- 具体项目路径；
+- 某次 benchmark 的答案；
+- 某个目标章真实正文内容；
+- 某个测试实例中的专有术语；
+- 真实续写时不该提前知道的信息。
+
+允许出现：
+
+- 占位符；
+- 泛化示例；
+- 字段定义；
+- 校验规则；
+- 类型枚举；
+- 通用模板；
+- 不绑定具体作品的说明。
+
+具体项目内容必须放入 instance 文件，而不是 schema 文件。
+
+推荐区分：
+
+```text
+render_event_log_schema.md
+  -> 通用 schema，只定义结构和规则
+
+render_event_log_<target_chapter>_planned.md
+  -> 某目标章节的真实续写事件日志 instance
+
+render_event_log_<target_chapter>_benchmark_reference.md
+  -> benchmark / 回放测试 instance，不用于真实续写
+
+render_event_log_schema_test_report_<target_chapter>.md
+  -> schema fit 测试报告
+```
+
+---
+
+## 3. 真实续写原则
+
+真实续写场景中，Render Event Log 不应依赖：
+
+- 目标章节真实正文；
+- 目标章节真实 trace；
+- 后续章节正文；
+- benchmark reference；
+- 回放答案；
+- 外部 LLM 已经生成的目标章正文。
+
+真实续写可使用：
+
+- 目标章节之前的 truth/state files；
+- 已确认的 story bible / book rules；
+- 已确认的 outline / human plan；
+- 用户或作者手工指定的目标章事件计划；
+- clean Active Entity Cards；
+- Worldbuilding / World Mechanics；
+- Author Fingerprint；
+- 人工写作意图和章节目标；
+- 明确标记为假设的模型推断。
+
+因此，本 schema 默认服务：
+
+```text
+real continuation / production continuation / planned continuation
+```
+
+而不是答案回放或 benchmark 对照。
+
+---
+
+## 4. 层级边界
+
+### 4.1 Render Event Log 负责
+
+Render Event Log 可以包含：
+
+- 事件顺序；
+- 单事件目标；
+- 单事件入口条件；
+- 单事件核心动作；
+- 单事件内部小 beat；
+- 单事件必须渲染内容；
+- 单事件禁止漂移；
+- 单事件转场钩子；
+- 单事件目标长度；
+- 单事件张力变化；
+- 单事件笑点功能；
+- 单事件机制释放方式；
+- 单事件正文可见性；
+- 单事件引用的 Entity Cards；
+- 单事件引用的 World Mechanics；
+- 单事件引用的 Author Fingerprint；
+- event-level audit questions。
+
+### 4.2 Render Event Log 不负责
+
+Render Event Log 不应承担：
+
+- 完整实体状态；
+- 人物长期关系；
+- 世界规则百科；
+- 枪械、魔法、科技、经济等机制完整解释；
+- 作者风格统计；
+- 句长、段长、对白比例；
+- 最终小说正文；
+- clean truth files 的回写；
+- validator 或完整写作管线的执行。
+
+职责划分：
+
+```text
+Active Entity Cards
+  -> 谁/什么存在，当前状态，关系，禁止漂移
+
+Worldbuilding / World Mechanics
+  -> 世界、装置、经济、科技、魔法、战术约束如何运作
+
+Render Event Log
+  -> 发生什么，按什么顺序发生，每个 event 有哪些渲染约束
+
+Author Fingerprint
+  -> 正文听起来、流动起来应该像什么
+
+Auditor
+  -> 检查 render 是否遵守所有层，并避免未来信息 / internal-only 信息泄漏
+```
+
+---
+
+## 5. Source Boundary / 来源边界
+
+每份 Render Event Log 文件必须声明来源边界。
+
+```yaml
+target_chapter: "<目标章节>"
+input_scope: "<来源章节或来源文件范围>"
+source_mode: "production_clean | planned | manual | hybrid_planned | model_hypothesis | benchmark_reference"
+continuation_safe: true | false
+source_label: "canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference"
+forbidden_sources:
+  - "<禁止读取或引用的章节 / 文件>"
+purpose: "<本 event log 的用途>"
+```
+
+---
+
+## 6. source_mode 定义
+
+### `production_clean`
+
+只使用目标章节之前已经可用的 truth/state/rules 信息。
+
+适合真实续写。
+
+```yaml
+source_mode: "production_clean"
+continuation_safe: true
+```
+
+---
+
+### `planned`
+
+使用目标章节之前的信息，加上用户、作者或人工计划指定的目标章事件计划。
+
+适合真实续写。
+
+```yaml
+source_mode: "planned"
+continuation_safe: true
+```
+
+---
+
+### `manual`
+
+主要由人工指定事件结构。
+
+适合真实续写或人工控制测试。
+
+```yaml
+source_mode: "manual"
+continuation_safe: true
+```
+
+---
+
+### `hybrid_planned`
+
+clean 信息、人工计划和少量模型推断混合，但不使用目标章真实正文或后续章节。
+
+适合真实续写，但需要审计模型推断部分。
+
+```yaml
+source_mode: "hybrid_planned"
+continuation_safe: true
+```
+
+---
+
+### `model_hypothesis`
+
+模型推断事件结构，尚未确认。
+
+适合探索，不应直接作为最终写作依据。
+
+```yaml
+source_mode: "model_hypothesis"
+continuation_safe: true
+```
+
+前提：模型推断没有使用目标章真实正文、后续章节或 benchmark reference。
+
+---
+
+### `benchmark_reference`
+
+仅用于测试 schema 表达能力、回放对照、评估上限或分析真实目标章。
+
+不得用于真实续写生产路径。
+
+```yaml
+source_mode: "benchmark_reference"
+continuation_safe: false
+```
+
+---
+
+## 7. continuation_safe 规则
+
+真实续写可用的 Event Log 应写：
+
+```yaml
+continuation_safe: true
+```
+
+出现以下情况必须写：
+
+```yaml
+continuation_safe: false
+```
+
+- 使用目标章节真实正文；
+- 使用目标章节真实 trace；
+- 使用后续章节；
+- 使用 benchmark reference；
+- 使用回放答案；
+- 使用外部 LLM 已经生成的目标章正文；
+- 使用任何会让真实续写“偷看答案”的材料。
+
+---
+
+## 8. source_label 定义
+
+允许值：
+
+```yaml
+canon_confirmed
+inferred
+human_planned
+human_override
+model_hypothesis
+benchmark_reference
+```
+
+含义：
+
+- `canon_confirmed`：由目标章之前的 canon/truth files 直接支持。
+- `inferred`：由目标章之前的 canon/truth files 推断。
+- `human_planned`：来自用户、作者或人工写作计划。
+- `human_override`：人工覆盖或修正。
+- `model_hypothesis`：模型推断，尚未确认。
+- `benchmark_reference`：来自答案回放、真实目标章或对照测试；真实续写中不得使用。
+
+---
+
+## 9. 推荐文件结构
+
+```markdown
+# Render Event Log for <target_chapter>
+
+## Source Boundary
+...
+
+## Metadata
+...
+
+## Global Rendering Requirements
+...
+
+## Global Must Render Summary
+...
+
+## Global Must Not Render Summary
+...
+
+## Events
+### REL-E001 — <事件标题>
+...
+### REL-E002 — <事件标题>
+...
+
+## Audit Plan
+...
+
+## Validation Checklist
+...
+```
+
+---
+
+## 10. Event ID 规则
+
+普通事件建议使用稳定编号：
+
+```text
+REL-E001
+REL-E002
+REL-E003
+...
+```
+
+可选分类前缀：
+
+```text
+REL-C001   # production clean event
+REL-P001   # planned event
+REL-M001   # manual event
+REL-H001   # hybrid planned event
+REL-B001   # benchmark reference event, not for production continuation
+```
+
+规则：
+
+- 同一份 Event Log 中 `event_id` 必须唯一。
+- 不要复用已经代表其他事件的 ID。
+- 如果只是修正事件内容，不要随意改 event_id。
+- 如果事件被拆分，应保留原事件关系说明。
+- 如果事件被合并，应在 audit 中标记。
+- structured render 测试阶段通常不建议合并核心事件。
+
+---
+
+## 11. 顶层对象：`RenderEventLog`
+
+```yaml
+schema_version: "render_event_log.v0.4"
+log_id: "render_event_log_<target_chapter>_planned"
+target_chapter: "<target_chapter>"
+
+source_boundary:
+  target_chapter: "<target_chapter>"
+  input_scope: "<pre-target truth/state files + human target-chapter plan>"
+  source_mode: "planned"
+  continuation_safe: true
+  source_label: "human_planned"
+  forbidden_sources:
+    - "<target chapter real manuscript>"
+    - "<target chapter real trace>"
+    - "<later chapter prose>"
+    - "<benchmark reference>"
+    - "<external LLM target-chapter prose>"
+  purpose: "真实续写用事件级渲染蓝图。"
+
+metadata:
+  event_count: 0
+  granularity: "coarse | medium | fine"
+  target_total_length_cn: "<约 xxxx-xxxx 字>"
+  rendering_mode: "prose_rendering_from_event_skeleton"
+  intended_renderer: "model_agnostic"
+  allow_event_merge: false
+  allow_event_reorder: false
+
+global_rendering_requirements:
+  - "不要合并、压缩或跳过核心 event。"
+  - "每个 event 至少要在正文中形成可识别的具体场景、动作、对白或物件锚点。"
+  - "不得把 Event Log 的字段名、event_id 或 audit question 写进正文。"
+
+global_must_render:
+  - "<全局必须渲染的章节骨架>"
+
+global_must_not_render:
+  - "<全局禁止漂移>"
+
+events:
+  - event_id: "REL-E001"
+    writing_order: 1
+    event_title: "<事件标题>"
+    ...
+
+audit_plan:
+  event_level_audit_required: true
+  allow_event_merge: false
+  allow_event_reorder: false
+  terminology_lock_required: true
+  ending_landing_check_required: true
+  future_source_leak_check_required: true
+  internal_only_leak_check_required: true
+```
+
+---
+
+## 12. 顶层字段说明
+
+### `schema_version`
+
+类型：string
+必填：是
+
+推荐值：
+
+```yaml
+schema_version: "render_event_log.v0.4"
+```
+
+---
+
+### `log_id`
+
+类型：string
+必填：推荐
+
+示例：
+
+```yaml
+log_id: "render_event_log_<target_chapter>_planned"
+```
+
+用途：给当前 Event Log 一个稳定 ID。
+
+---
+
+### `target_chapter`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+target_chapter: "<target_chapter>"
+```
+
+---
+
+### `source_boundary`
+
+类型：object
+必填：是
+
+必须包含：
+
+```yaml
+source_boundary:
+  target_chapter: "<target_chapter>"
+  input_scope: "..."
+  source_mode: "production_clean | planned | manual | hybrid_planned | model_hypothesis | benchmark_reference"
+  continuation_safe: true | false
+  source_label: "canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference"
+  forbidden_sources:
+    - string
+  purpose: string
+```
+
+---
+
+### `metadata`
+
+类型：object
+必填：推荐
+
+建议字段：
+
+```yaml
+metadata:
+  event_count: number
+  granularity: "coarse | medium | fine"
+  target_total_length_cn: string
+  rendering_mode: string
+  intended_renderer: string
+  allow_event_merge: boolean
+  allow_event_reorder: boolean
+```
+
+说明：
+
+- `granularity: coarse` 适合粗略章节规划。
+- `granularity: medium` 适合普通 structured render。
+- `granularity: fine` 适合高约束 structured render。
+- `allow_event_merge: false` 用于测试 event 覆盖能力。
+- `allow_event_reorder: false` 用于保持章节顺序。
+
+---
+
+### `global_rendering_requirements`
+
+类型：list[string]
+必填：推荐
+
+用途：给所有事件的全局渲染要求。
+
+示例：
+
+```yaml
+global_rendering_requirements:
+  - "不要合并、压缩或跳过核心 event。"
+  - "每个 event 至少要形成可识别的动作、对白、物件或场景锚点。"
+  - "不得把 event_id 或 schema 字段写进正文。"
+```
+
+---
+
+### `global_must_render`
+
+类型：list[string]
+必填：推荐
+
+用途：列出整章必须保留的核心事件链。
+
+---
+
+### `global_must_not_render`
+
+类型：list[string]
+必填：推荐
+
+用途：列出整章禁止漂移。
+
+---
+
+## 13. 单事件对象：`RenderEvent`
+
+每个 event 建议使用以下结构：
+
+```yaml
+event_id: "REL-E001"
+writing_order: 1
+event_title: "<事件标题>"
+
+source_label: "canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference"
+source_basis:
+  - "<event-level 来源>"
+event_confidence: "high | medium | low"
+continuation_safe: true | false
+
+relative_time: "<相对时间或章节顺序>"
+location: "<具体地点>"
+
+event_purpose: "<事件的结构目的>"
+entry_condition: "<事件开始时必须成立的状态>"
+core_event: "<事件核心动作，不写成小说正文>"
+event_summary: "<事件摘要，可以与 core_event 接近，但更偏审计摘要>"
+
+sub_beats:
+  - "<可选：事件内部小 beat>"
+
+dialogue_intent: "<本事件中的对白功能，不写具体长对白>"
+
+must_render:
+  - "<必须渲染的动作、对白、物件、信息或情绪转折>"
+
+must_not_render:
+  - "<禁止漂移、禁止解决、禁止泄密、禁止替换术语>"
+
+render_priority: "blocking | high | medium | low"
+target_length_cn: "约 xxx-xxx 字"
+
+prose_visibility: "explicit_scene | light_touch | internal_only | transition_only | audit_only"
+
+tension_delta:
+  from: "light | neutral | tense | danger | unresolved"
+  to: "light | neutral | tense | danger | unresolved"
+  note: "<张力变化说明>"
+
+comedy_function:
+  type: "none | relief | misdirection | character_voice | setting_delivery | backpressure | transition"
+  note: "<笑点结构功能>"
+
+mechanism_reveal:
+  type: "none | introduce | clarify | test | limit | reverse | unresolved"
+  mechanic_ids:
+    - "<world mechanic id>"
+  note: "<机制释放方式>"
+
+entity_refs:
+  - "EC-C001"
+  - "EC-C002"
+
+transient_entity_refs:
+  - "planned_transient:<临时实体名>"
+
+world_mechanic_refs:
+  - "WM-xxx"
+
+author_fingerprint_refs:
+  - "AF-xxx"
+
+transition:
+  in: "<进入该 event 的自然钩子>"
+  out: "<离开该 event 的自然钩子>"
+  hook_to_next: "<接到下一 event 的具体物件、动作、问题或对白>"
+
+render_constraints:
+  - "<给 Renderer 的事件级限制>"
+
+audit_questions:
+  - "<Auditor 检查问题>"
+```
+
+---
+
+## 14. 单事件字段说明
+
+### `event_id`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+event_id: "REL-E001"
+```
+
+规则：
+
+- 稳定、唯一。
+- 不要在正文中出现。
+- 后续 audit、validator、assembly 都应通过 event_id 定位事件。
+
+---
+
+### `writing_order`
+
+类型：number
+必填：是
+
+用途：强约束事件顺序。
+
+规则：
+
+- 从 1 开始递增。
+- 不应跳号。
+- 不应让 Renderer 自行重排，除非 metadata 明确允许。
+
+---
+
+### `event_title`
+
+类型：string
+必填：是
+
+用途：人类可读的事件标题。
+
+示例：
+
+```yaml
+event_title: "<事件标题>"
+```
+
+---
+
+### `source_label`
+
+类型：enum
+必填：是
+
+允许值：
+
+```yaml
+canon_confirmed
+inferred
+human_planned
+human_override
+model_hypothesis
+benchmark_reference
+```
+
+含义：
+
+- `canon_confirmed`：由允许来源直接支持。
+- `inferred`：由允许来源推断。
+- `human_planned`：由用户、作者或人工计划指定。
+- `human_override`：人工覆盖或修正。
+- `model_hypothesis`：模型猜测，尚未确认。
+- `benchmark_reference`：答案回放/测试来源；真实续写中不得使用。
+
+---
+
+### `source_basis`
+
+类型：list[string]
+必填：是
+
+用途：记录 event-level 来源。
+
+示例：
+
+```yaml
+source_basis:
+  - "<pre-target truth file>#<section>"
+  - "<active entity cards file>#<entity_id>"
+  - "<human plan file>#<event_id>"
+```
+
+规则：
+
+- 不要粘贴大量原文。
+- 真实续写 event 不得引用目标章真实正文或后续章节。
+- 人工计划必须标记为 `human_planned` 或 `human_override`。
+- benchmark / 回放来源必须标记为 `benchmark_reference` 且 `continuation_safe: false`。
+
+---
+
+### `event_confidence`
+
+类型：enum
+必填：推荐
+
+允许值：
+
+```yaml
+high
+medium
+low
+```
+
+用途：标记该 event 的可靠度。
+
+建议：
+
+- 人工明确指定的 planned event 通常为 `high`。
+- clean 推断 event 可为 `medium` 或 `low`。
+- model_hypothesis 通常不能高于 `medium`。
+- benchmark_reference 可为 `high`，但不得用于真实续写。
+
+---
+
+### `continuation_safe`
+
+类型：boolean
+必填：推荐
+
+规则：
+
+- 真实续写可用 event 为 `true`。
+- 使用 benchmark reference、目标章真实正文、真实 trace 或后续章节时必须为 `false`。
+
+---
+
+### `relative_time`
+
+类型：string
+必填：推荐
+
+用途：描述事件相对位置。
+
+示例：
+
+```yaml
+relative_time: "<target_chapter> writing order 001"
+```
+
+---
+
+### `location`
+
+类型：string
+必填：推荐
+
+用途：标记事件发生地点。
+
+建议写具体地点，不要过泛。
+
+好例子：
+
+```yaml
+location: "<具体地点 A>"
+location: "<具体地点 B>"
+location: "<具体地点 C>"
+```
+
+不推荐：
+
+```yaml
+location: "<地点 A / 地点 B / 地点 C>"
+```
+
+除非该 event 确实跨越多个地点。
+
+---
+
+### `event_purpose`
+
+类型：string
+必填：是
+
+说明这个 event 的结构功能。
+
+示例：
+
+```yaml
+event_purpose: "把上一个场景留下的物件或问题转化为当前行动。"
+```
+
+---
+
+### `entry_condition`
+
+类型：string
+必填：是
+
+说明进入该 event 前必须已经成立的状态。
+
+示例：
+
+```yaml
+entry_condition: "上一事件已经留下某个未解决问题，角色必须在本事件中采取下一步行动。"
+```
+
+---
+
+### `core_event`
+
+类型：string
+必填：是
+
+说明这个 event 的核心动作链。
+它不是正文，不应写成小说段落。
+
+好例子：
+
+```yaml
+core_event: "角色 A 处理上一个事件留下的问题，并把行动推进到下一个具体选择。"
+```
+
+坏例子：
+
+```yaml
+core_event: "风穿过窗缝，角色 A 的手指微微颤抖，仿佛命运的齿轮终于开始转动……"
+```
+
+原因：这是正文风格，不是 event skeleton。
+
+---
+
+### `event_summary`
+
+类型：string
+必填：推荐
+
+用途：给 audit 和快速阅读使用。
+可以和 `core_event` 接近，但应更偏摘要。
+
+---
+
+### `sub_beats`
+
+类型：list[string]
+必填：可选
+
+用于拆解 event 内部小动作。
+
+示例：
+
+```yaml
+sub_beats:
+  - "角色 A 做出具体动作。"
+  - "角色 B 通过短对白回应。"
+  - "某个物件、信息或限制把事件推向下一步。"
+```
+
+如果不需要，可写：
+
+```yaml
+sub_beats: []
+```
+
+不要写 `none` 字符串，建议用空数组。
+
+---
+
+### `dialogue_intent`
+
+类型：string
+必填：推荐
+
+说明对白承担什么功能，不写具体长对白。
+
+示例：
+
+```yaml
+dialogue_intent: "用短对白揭示误解、限制或下一步行动，不写成长篇说明。"
+```
+
+---
+
+### `must_render`
+
+类型：list[string]
+必填：是
+
+列出正文中必须出现的内容。
+
+示例：
+
+```yaml
+must_render:
+  - "必须出现一个具体动作。"
+  - "必须出现一个可审计的物件、对白或信息锚点。"
+  - "必须把事件推进到下一选择。"
+```
+
+---
+
+### `must_not_render`
+
+类型：list[string]
+必填：是
+
+列出正文中不能出现的漂移。
+
+示例：
+
+```yaml
+must_not_render:
+  - "不得跳过上一个事件留下的问题。"
+  - "不得让新信息直接解决所有冲突。"
+  - "不得暴露 internal-only 信息。"
+```
+
+---
+
+### `render_priority`
+
+类型：enum
+必填：推荐
+
+允许值：
+
+```yaml
+blocking
+high
+medium
+low
+```
+
+含义：
+
+- `blocking`：如果漏掉，该章结构失败。
+- `high`：强烈建议保留，漏掉会明显削弱章节。
+- `medium`：可压缩但不应完全消失。
+- `low`：轻量辅助。
+
+示例：
+
+```yaml
+render_priority: "blocking"
+```
+
+适合 blocking 的内容：
+
+- 章末核心问题；
+- 关键威胁揭示；
+- 关键机制限制；
+- 关键转场；
+- 决定性物件动作；
+- 主线选择。
+
+---
+
+### `target_length_cn`
+
+类型：string
+必填：推荐
+
+示例：
+
+```yaml
+target_length_cn: "约 180-260 字"
+```
+
+用途：
+
+- 防止 event 被压成摘要；
+- 防止普通 event 过度扩写；
+- 给 assembly prompt 分配篇幅。
+
+---
+
+### `prose_visibility`
+
+类型：enum
+必填：推荐
+
+允许值：
+
+```yaml
+explicit_scene
+light_touch
+internal_only
+transition_only
+audit_only
+```
+
+含义：
+
+- `explicit_scene`：必须显性渲染成可见场景。
+- `light_touch`：轻触即可，不能扩写。
+- `internal_only`：只允许作为内部约束，正文不能显性写出。
+- `transition_only`：只服务转场。
+- `audit_only`：只用于审计，不给正文直接渲染。
+
+示例：
+
+```yaml
+prose_visibility: "explicit_scene"
+```
+
+内部秘密、系统类约束如果出现在 event 中，应使用：
+
+```yaml
+prose_visibility: "internal_only"
+```
+
+并在 `must_not_render` 中列出禁止词。
+
+---
+
+### `tension_delta`
+
+类型：object
+必填：推荐
+
+结构：
+
+```yaml
+tension_delta:
+  from: "light | neutral | tense | danger | unresolved"
+  to: "light | neutral | tense | danger | unresolved"
+  note: "<张力变化说明>"
+```
+
+用途：标记事件如何改变章节压力。
+
+示例：
+
+```yaml
+tension_delta:
+  from: "neutral"
+  to: "tense"
+  note: "本事件将轻松互动转为现实压力。"
+```
+
+---
+
+### `comedy_function`
+
+类型：object
+必填：推荐
+
+结构：
+
+```yaml
+comedy_function:
+  type: "none | relief | misdirection | character_voice | setting_delivery | backpressure | transition"
+  note: "<笑点结构功能>"
+```
+
+含义：
+
+- `none`：无笑点功能。
+- `relief`：缓解说明密度或危险压力。
+- `misdirection`：先轻松再反压。
+- `character_voice`：强化角色声音。
+- `setting_delivery`：用笑点承载设定。
+- `backpressure`：用笑点后立刻现实反压。
+- `transition`：用笑点转到下一事件。
+
+示例：
+
+```yaml
+comedy_function:
+  type: "backpressure"
+  note: "笑点之后立刻让现实限制重新压回场景。"
+```
+
+---
+
+### `mechanism_reveal`
+
+类型：object
+必填：推荐
+
+结构：
+
+```yaml
+mechanism_reveal:
+  type: "none | introduce | clarify | test | limit | reverse | unresolved"
+  mechanic_ids:
+    - "<world mechanic id>"
+  note: "<机制释放方式>"
+```
+
+含义：
+
+- `introduce`：首次引入机制。
+- `clarify`：澄清机制。
+- `test`：通过行动验证机制。
+- `limit`：揭示机制限制。
+- `reverse`：反转之前的理解。
+- `unresolved`：留下未解决机制矛盾。
+- `none`：本 event 不承担机制释放。
+
+示例：
+
+```yaml
+mechanism_reveal:
+  type: "limit"
+  mechanic_ids:
+    - "<world_mechanic_id>"
+  note: "本事件揭示某个方案只能解决一部分问题。"
+```
+
+---
+
+### `entity_refs`
+
+类型：list[string]
+必填：推荐
+
+引用 Active Entity Cards。
+
+示例：
+
+```yaml
+entity_refs:
+  - "EC-C001"
+  - "EC-C002"
+```
+
+规则：
+
+- 只引用实体 ID。
+- 不复制完整实体状态。
+- 不把 transient entity 混入 clean Active Entity Cards。
+
+---
+
+### `transient_entity_refs`
+
+类型：list[string]
+必填：可选
+
+用于引用目标章临时实体。
+
+示例：
+
+```yaml
+transient_entity_refs:
+  - "planned_transient:<临时实体名>"
+```
+
+规则：
+
+- planned transient 必须明确标记。
+- 不得回写 clean Active Entity Cards。
+- 若后续建立 Target-Chapter Transient Entities，可替换为 `EC-Txxx`。
+- benchmark/reference transient 不得用于真实续写生产路径。
+
+---
+
+### `world_mechanic_refs`
+
+类型：list[string]
+必填：推荐
+
+引用 Worldbuilding / World Mechanics 中的机制 ID。
+
+示例：
+
+```yaml
+world_mechanic_refs:
+  - "<world_mechanic_id>"
+```
+
+规则：
+
+- 只引用机制 ID。
+- 不把世界观百科复制进 event。
+- event 中只保留与当前事件相关的简短约束。
+
+---
+
+### `author_fingerprint_refs`
+
+类型：list[string]
+必填：推荐
+
+引用 Author Fingerprint 中的规则 ID。
+
+示例：
+
+```yaml
+author_fingerprint_refs:
+  - "<author_fingerprint_rule_id>"
+```
+
+规则：
+
+- 只引用作者风格目标。
+- 不在 Event Log 里重写完整作者风格指南。
+
+---
+
+### `transition`
+
+类型：object
+必填：推荐
+
+统一替代旧字段：
+
+- `transition_in`
+- `transition_out`
+- `transition_hook_to_next_event`
+
+推荐结构：
+
+```yaml
+transition:
+  in: "<进入该 event 的自然钩子>"
+  out: "<离开该 event 的自然钩子>"
+  hook_to_next: "<接到下一 event 的具体物件、动作、问题或对白>"
+```
+
+示例：
+
+```yaml
+transition:
+  in: "上一事件留下的物件或问题触发本事件。"
+  out: "本事件的新限制或新选择推动下一事件。"
+  hook_to_next: "具体物件、动作、问题或对白作为下一事件钩子。"
+```
+
+向后兼容规则：
+
+- 旧字段 `transition_in` / `transition_out` / `transition_hook_to_next_event` 可继续读取。
+- 新输出建议统一写入 `transition` 对象。
+- 不建议同时输出两套，避免冗余。
+
+---
+
+### `render_constraints`
+
+类型：list[string]
+必填：推荐
+
+给 Renderer 的 event-level 限制。
+
+示例：
+
+```yaml
+render_constraints:
+  - "不要写成长篇心理总结。"
+  - "不要出现 event_id 或 schema 术语。"
+```
+
+---
+
+### `audit_questions`
+
+类型：list[string]
+必填：是
+
+给 Auditor 的 event-level 检查问题。
+
+示例：
+
+```yaml
+audit_questions:
+  - "正文是否能识别出该 event？"
+  - "must_render 是否被覆盖？"
+  - "must_not_render 是否被违反？"
+```
+
+向后兼容：
+
+- 旧字段 `audit_checks` 可继续读取。
+- 新输出建议统一写 `audit_questions`。
+- 不建议同时输出 `audit_checks` 和 `audit_questions`。
+
+---
+
+## 15. 推荐枚举值
+
+### 15.1 source_mode
+
+```yaml
+production_clean
+planned
+manual
+hybrid_planned
+model_hypothesis
+benchmark_reference
+```
+
+---
+
+### 15.2 source_label
+
+```yaml
+canon_confirmed
+inferred
+human_planned
+human_override
+model_hypothesis
+benchmark_reference
+```
+
+---
+
+### 15.3 event_confidence
+
+```yaml
+high
+medium
+low
+```
+
+---
+
+### 15.4 render_priority
+
+```yaml
+blocking
+high
+medium
+low
+```
+
+---
+
+### 15.5 prose_visibility
+
+```yaml
+explicit_scene
+light_touch
+internal_only
+transition_only
+audit_only
+```
+
+---
+
+### 15.6 tension_delta.from / tension_delta.to
+
+```yaml
+light
+neutral
+tense
+danger
+unresolved
+```
+
+---
+
+### 15.7 comedy_function.type
+
+```yaml
+none
+relief
+misdirection
+character_voice
+setting_delivery
+backpressure
+transition
+```
+
+---
+
+### 15.8 mechanism_reveal.type
+
+```yaml
+none
+introduce
+clarify
+test
+limit
+reverse
+unresolved
+```
+
+---
+
+## 16. 完整事件模板
+
+```yaml
+event_id: "REL-E001"
+writing_order: 1
+event_title: "<事件标题>"
+
+source_label: "human_planned"
+source_basis:
+  - "<event-level 来源>"
+event_confidence: "high"
+continuation_safe: true
+
+relative_time: "<target_chapter> writing order 001"
+location: "<具体地点>"
+
+event_purpose: >
+  <该事件的结构目的。>
+
+entry_condition: >
+  <进入该事件前必须成立的状态。>
+
+core_event: >
+  <事件核心动作链。不是小说正文。>
+
+event_summary: >
+  <给 audit 使用的事件摘要。>
+
+sub_beats:
+  - "<可选：事件内部小 beat>"
+
+dialogue_intent: >
+  <该事件中的对白功能。>
+
+must_render:
+  - "<必须渲染内容>"
+
+must_not_render:
+  - "<禁止漂移内容>"
+
+render_priority: "blocking"
+target_length_cn: "约 180-260 字"
+prose_visibility: "explicit_scene"
+
+tension_delta:
+  from: "neutral"
+  to: "tense"
+  note: "<张力变化说明>"
+
+comedy_function:
+  type: "none"
+  note: ""
+
+mechanism_reveal:
+  type: "none"
+  mechanic_ids: []
+  note: ""
+
+entity_refs:
+  - "EC-C001"
+
+transient_entity_refs: []
+
+world_mechanic_refs:
+  - "<world mechanic id>"
+
+author_fingerprint_refs:
+  - "<author fingerprint rule id>"
+
+transition:
+  in: "<进入该 event 的自然钩子>"
+  out: "<离开该 event 的自然钩子>"
+  hook_to_next: "<接到下一 event 的具体钩子>"
+
+render_constraints:
+  - "<事件级渲染限制>"
+
+audit_questions:
+  - "<审计问题>"
+```
+
+---
+
+## 17. 顶层模板
+
+```markdown
+# Render Event Log for <target_chapter>
+
+## Source Boundary
+
+```yaml
+target_chapter: "<target_chapter>"
+input_scope: "<pre-target truth/state files + human target-chapter plan>"
+source_mode: "planned"
+continuation_safe: true
+source_label: "human_planned"
+forbidden_sources:
+  - "<target chapter real manuscript>"
+  - "<target chapter real trace>"
+  - "<later chapter prose>"
+  - "<benchmark reference>"
+  - "<external LLM target-chapter prose>"
+purpose: "真实续写用事件级渲染蓝图。"
+```
+
+## Metadata
+
+```yaml
+schema_version: "render_event_log.v0.4"
+log_id: "render_event_log_<target_chapter>_planned"
+target_chapter: "<target_chapter>"
+event_count: 0
+granularity: "medium"
+target_total_length_cn: "约 xxxx-xxxx 字"
+rendering_mode: "prose_rendering_from_event_skeleton"
+intended_renderer: "model_agnostic"
+allow_event_merge: false
+allow_event_reorder: false
+```
+
+## Global Rendering Requirements
+
+- 不要合并、压缩或跳过核心 event。
+- 每个 event 至少要在正文中形成可识别的具体场景、动作、对白或物件锚点。
+- 不得把 Event Log 的字段名、event_id、audit question 或 schema 术语写进正文。
+- 不得把 Event Log 写成章节小标题列表。
+- 不得把 Event Log 原句机械改写成正文。
+- 不得替换 terminology lock 中的关键术语。
+- 结尾必须落在具体问题、对白、物件或角色反应上，不得抽象总结。
+
+## Global Must Render Summary
+
+- <必须保留的核心事件链 1>
+- <必须保留的核心事件链 2>
+- <必须保留的核心事件链 3>
+
+## Global Must Not Render Summary
+
+- 不得生成小说正文或把此文件当正文。
+- 不得让新信息、新道具、新能力或新机制变成万能解法。
+- 不得让任何角色知道 internal-only 信息。
+- 不得读取、引用或暗示目标章真实正文、真实 trace、后续章节或 benchmark reference。
+- 不得把作者风格、世界规则或实体状态百科塞进 Event Log。
+- 不得把 event_id、字段名或 audit question 写进正文。
+
+## Events
+
+### REL-E001 — <事件标题>
+
+```yaml
+event_id: "REL-E001"
+writing_order: 1
+event_title: "<事件标题>"
+
+source_label: "human_planned"
+source_basis:
+  - "<event-level 来源>"
+event_confidence: "high"
+continuation_safe: true
+
+relative_time: "<target_chapter> writing order 001"
+location: "<具体地点>"
+
+event_purpose: >
+  <该事件的结构目的。>
+
+entry_condition: >
+  <进入该事件前必须成立的状态。>
+
+core_event: >
+  <事件核心动作链。不是小说正文。>
+
+event_summary: >
+  <给 audit 使用的事件摘要。>
+
+sub_beats:
+  - "<可选：事件内部小 beat>"
+
+dialogue_intent: >
+  <该事件中的对白功能。>
+
+must_render:
+  - "<必须渲染内容>"
+
+must_not_render:
+  - "<禁止漂移内容>"
+
+render_priority: "blocking"
+target_length_cn: "约 180-260 字"
+prose_visibility: "explicit_scene"
+
+tension_delta:
+  from: "neutral"
+  to: "tense"
+  note: "<张力变化说明>"
+
+comedy_function:
+  type: "none"
+  note: ""
+
+mechanism_reveal:
+  type: "none"
+  mechanic_ids: []
+  note: ""
+
+entity_refs:
+  - "EC-C001"
+
+transient_entity_refs: []
+
+world_mechanic_refs:
+  - "<world mechanic id>"
+
+author_fingerprint_refs:
+  - "<author fingerprint rule id>"
+
+transition:
+  in: "<进入该 event 的自然钩子>"
+  out: "<离开该 event 的自然钩子>"
+  hook_to_next: "<接到下一 event 的具体钩子>"
+
+render_constraints:
+  - "<事件级渲染限制>"
+
+audit_questions:
+  - "<审计问题>"
+```
+
+## Audit Plan
+
+```yaml
+audit_plan:
+  event_level_audit_required: true
+  audit_output_schema: "RenderEventAudit"
+  allow_event_merge: false
+  allow_event_reorder: false
+  terminology_lock_required: true
+  ending_landing_check_required: true
+  future_source_leak_check_required: true
+  internal_only_leak_check_required: true
+  source_boundary_check_required: true
+```
+
+```
+
+---
+
+## 18. RenderEventAudit 建议结构
+
+```yaml
+event_id: "REL-E001"
+event_title: "<事件标题>"
+
+coverage:
+  event_present: true
+  must_render_covered:
+    - item: "<must_render item>"
+      covered: true
+      evidence_note: "<简短说明>"
+  missing_must_render:
+    - "<缺失项>"
+
+forbidden_drift:
+  violations:
+    - "<违反 must_not_render 的内容>"
+  pass: true
+
+transition_quality:
+  transition_in_natural: true
+  transition_out_natural: true
+  issue: null
+
+entity_alignment:
+  checked_entity_refs:
+    - "EC-C001"
+  violations:
+    - "<实体状态冲突>"
+  pass: true
+
+world_mechanics_alignment:
+  checked_world_mechanics:
+    - "<world mechanic id>"
+  violations:
+    - "<世界机制冲突>"
+  pass: true
+
+author_fingerprint_alignment:
+  checked_author_refs:
+    - "<author fingerprint rule id>"
+  violations:
+    - "<写法冲突>"
+  pass: true
+
+source_boundary:
+  future_source_leak: false
+  benchmark_reference_leak: false
+  internal_only_leak: false
+  forbidden_source_leak: false
+
+event_judgment:
+  pass: true
+  severity: "none | low | medium | high | critical"
+  notes:
+    - "<审计备注>"
+```
+
+---
+
+## 19. Validator 建议
+
+建议为 Render Event Log 增加 lightweight structural validator。
+它只检查结构，不生成小说正文，不调用外部 LLM，不运行完整写作管线。
+
+检查项：
+
+```text
+1. 顶层必须有 source_boundary。
+2. source_boundary 必须声明 source_mode 和 continuation_safe。
+3. 真实续写用 Event Log 不得使用 benchmark_reference 作为 source_label。
+4. 真实续写用 Event Log 不得引用目标章真实正文、真实 trace、后续章节或 benchmark reference。
+5. 顶层必须有 metadata。
+6. 每个 event 必须有 event_id。
+7. 每个 event_id 必须唯一。
+8. writing_order 必须连续递增。
+9. 每个 event 必须有 source_label / source_basis。
+10. continuation_safe: true 的 event 不得引用 forbidden_sources。
+11. 每个 event 必须有 event_purpose / entry_condition / core_event。
+12. 每个 event 必须有 must_render / must_not_render。
+13. 每个 event 必须有 entity_refs 或说明为什么不需要。
+14. 每个 event 必须有 transition 对象，或至少有 transition.out / hook_to_next。
+15. 每个 event 必须有 audit_questions。
+16. 不得同时输出大量重复旧字段和新字段。
+17. 不得出现最终小说正文。
+18. 不得把 Event Log 当 Entity Cards 使用。
+19. 不得把 Event Log 当 World Mechanics 使用。
+20. 不得把 Event Log 当 Author Fingerprint 使用。
+```
+
+---
+
+## 20. 向后兼容规则
+
+v0.4 推荐统一字段，但允许读取旧字段。
+
+### 20.1 字段映射
+
+```yaml
+clean_forward_safe -> continuation_safe
+active_entities -> entity_refs
+world_mechanics_used -> world_mechanic_refs
+author_fingerprint_targets -> author_fingerprint_refs
+audit_checks -> audit_questions
+transition_in -> transition.in
+transition_out -> transition.out
+transition_hook_to_next_event -> transition.hook_to_next
+```
+
+### 20.2 输出建议
+
+新生成文件建议只写 v0.4 字段：
+
+```yaml
+continuation_safe:
+entity_refs:
+world_mechanic_refs:
+author_fingerprint_refs:
+audit_questions:
+transition:
+  in:
+  out:
+  hook_to_next:
+```
+
+不建议同时输出旧字段和新字段，否则 assembly prompt 会变臃肿。
+
+---
+
+## 21. 常见失败模式
+
+### 21.1 checklist expansion
+
+错误：
+
+```text
+他们做了事件 A。然后他们做了事件 B。然后他们讨论了事件 C。
+```
+
+问题：正文暴露 Event Log 骨架。
+
+修正：每个 event 必须通过动作、对白、物件或场景变化发生。
+
+---
+
+### 21.2 event compression
+
+错误：
+
+```text
+他们试了几个办法，最终知道该怎么做。
+```
+
+问题：跳过关键 event。
+
+修正：关键 event 必须有可审计动作、对白、物件、失败、纠正、再次选择等锚点。
+
+---
+
+### 21.3 worldbuilding overload
+
+错误：
+
+```text
+本世界的机制如下……
+```
+
+问题：Event Log 被写成世界观百科。
+
+修正：世界机制应由 World Mechanics 提供；Event Log 只规定该机制在哪个事件中释放、通过什么动作或对白释放。
+
+---
+
+### 21.4 entity state overwrite
+
+错误：
+
+```text
+某角色忽然获得了 Entity Cards 中明确禁止的新能力。
+```
+
+问题：Event Log 越权改写 Entity Cards。
+
+修正：Event Log 可以规定角色参与某个 event，但不得覆盖实体卡中的能力边界。
+
+---
+
+### 21.5 internal-only leak
+
+错误：
+
+```text
+正文显性写出了只应该给 Renderer 看的内部机制、系统、进度或隐藏规则。
+```
+
+问题：内部约束泄漏进正文。
+
+修正：如果引用 internal-only entity，只能写成含混的内心压力、经验判断或动作执念。
+
+---
+
+### 21.6 future-source contamination
+
+错误：
+
+```text
+真实续写 Event Log 引用目标章真实正文、真实 trace、后续章节或 benchmark reference。
+```
+
+问题：真实续写变成偷看答案，测试和生产都失效。
+
+修正：真实续写只允许使用 pre-target truth files、人工计划、手工 outline、clean cards、world mechanics、author fingerprint，以及明确标记的模型假设。
+
+---
+
+## 22. PR 定位
+
+本 schema 应定位为：
+
+```text
+Render Event Log = 事件级渲染蓝图
+```
+
+它不替代 InkOS 既有 planner，也不替代 truth files。
+
+建议管线位置：
+
+```text
+InkOS truth files
+→ Active Entity Cards
+→ Worldbuilding / World Mechanics
+→ Author Fingerprint
+→ Render Event Log
+→ Structured Render Assembly
+→ Renderer LLM
+→ Event-level Auditor
+```
+
+---
+
+#

--- a/docs/structured-render-schemas/worldbuilding_world_mechanics_schema.md
+++ b/docs/structured-render-schemas/worldbuilding_world_mechanics_schema.md
@@ -1,0 +1,2136 @@
+# Worldbuilding / World Mechanics Schema v0.3 中文主版
+
+## 1. 用途
+
+`Worldbuilding / World Mechanics` 用于描述目标章节渲染时必须遵守的世界规则、机制边界、社会规则、经济规则、技术规则、魔法规则、战术规则和设定限制。
+
+它只回答一个问题：
+
+> Writer 在渲染目标章节时，世界如何运作？哪些事情可行、昂贵、稀缺、有风险、受权限限制，或者不能被新装备、新魔法、新机械、新情报直接解决？
+
+本文件不是 Entity Cards schema。
+实体当前状态、人物关系、装备归属、秘密边界属于 `Active Entity Cards`。
+
+本文件不是 Render Event Log schema。
+事件顺序、章节 beat、转场链、目标字数、event-level must render 属于 `Render Event Log`。
+
+本文件不是 Author Fingerprint schema。
+句长、段长、对白节奏、角色声音、作者味属于 `Author Fingerprint`。
+
+本文件不是某本书、某一章或某个项目的专用 instance。
+具体作品、具体角色、具体章节事件、具体测试答案应放入 instance 文件或 test output，不应写入 schema。
+
+---
+
+## 2. 通用性原则
+
+Schema 必须保持项目无关。
+
+本文件中不得包含：
+
+- 具体书名；
+- 具体角色名；
+- 具体章节剧情；
+- 具体项目路径；
+- 某次 benchmark 的答案；
+- 某个目标章真实正文内容；
+- 某个测试 instance 中的专有术语；
+- 真实续写时不该提前知道的信息。
+
+允许出现：
+
+- 占位符；
+- 泛化示例；
+- 字段定义；
+- 校验规则；
+- 类型枚举；
+- 通用模板；
+- 不绑定具体作品的说明。
+
+具体项目内容必须放入 instance 文件，而不是 schema 文件。
+
+推荐区分：
+
+```text
+worldbuilding_world_mechanics_schema.md
+  -> 通用 schema，只定义结构和规则
+
+worldbuilding_world_mechanics_<target_chapter>_from_boundary.md
+  -> 某目标章节的 production-clean / continuation-safe instance
+
+worldbuilding_world_mechanics_<target_chapter>_planned.md
+  -> 某目标章节的 planned instance
+
+worldbuilding_world_mechanics_<target_chapter>_benchmark_reference.md
+  -> benchmark / 回放测试 instance，不用于真实续写
+
+worldbuilding_world_mechanics_schema_test_report_<target_chapter>.md
+  -> schema fit 测试报告
+```
+
+---
+
+## 3. 核心边界
+
+Worldbuilding / World Mechanics 可以包含：
+
+- 世界类型；
+- 社会规则；
+- 金钱 / 赏金 / 交易规则；
+- 技术机制；
+- 武器机制；
+- 魔法机制；
+- 科技与魔法的交互边界；
+- 施法者、工程师、发明家、特殊职业等群体的生态规则；
+- 幻象、侦测、感知、识别、权限等机制；
+- 机械装置、特殊设备、权限系统；
+- 由世界规则制造出来的战术矛盾；
+- 由机制直接推出的渲染禁止项；
+- 哪些机制 clean 支持不足，需要 planned / manual / benchmark 来源补强。
+
+Worldbuilding / World Mechanics 不应包含：
+
+- 完整实体状态；
+- 角色库存清单，除非是解释世界机制所需；
+- 事件顺序；
+- 目标章节 beat sequence；
+- 目标字数；
+- 文风、句式、角色声音；
+- 最终小说正文；
+- 未标记的未来章节信息；
+- 未标记的 benchmark / 回放答案；
+- 未标记的目标章节真实正文信息。
+
+---
+
+## 4. Source Mode / 来源模式
+
+每个 pack 和每条 mechanic 都必须声明来源模式，避免真实续写被未来信息、benchmark reference 或目标章真实正文污染。
+
+合法 `source_mode`：
+
+```yaml
+source_mode: production_clean | planned | manual | hybrid_planned | model_hypothesis | benchmark_reference
+```
+
+也可保留旧字段：
+
+```yaml
+render_mode: clean | hybrid | benchmark_reference
+```
+
+推荐真实续写使用：
+
+```yaml
+source_mode: production_clean
+continuation_safe: true
+```
+
+或：
+
+```yaml
+source_mode: planned
+continuation_safe: true
+```
+
+---
+
+## 5. source_mode 定义
+
+### `production_clean`
+
+只使用目标章节之前已经可用的 truth/state/rules/outline 信息。
+
+适合真实续写。
+
+```yaml
+source_mode: production_clean
+clean_forward_safe: true
+continuation_safe: true
+```
+
+---
+
+### `planned`
+
+使用目标章节之前的信息，加上用户、作者或人工写作计划指定的目标章机制需求。
+
+适合真实续写。
+
+```yaml
+source_mode: planned
+clean_forward_safe: true
+continuation_safe: true
+```
+
+注意：`planned` 可以包含“作者打算让本章出现的机制”，但不能伪装成 pre-target canon。
+
+---
+
+### `manual`
+
+主要由人工指定机制结构。
+
+适合真实续写、人工控制测试或编辑流程。
+
+```yaml
+source_mode: manual
+continuation_safe: true
+```
+
+---
+
+### `hybrid_planned`
+
+clean 信息、人工计划、少量模型推断混合，但不使用目标章真实正文或后续章节。
+
+适合真实续写，但需要更强审计。
+
+```yaml
+source_mode: hybrid_planned
+continuation_safe: true
+```
+
+---
+
+### `model_hypothesis`
+
+模型推断的机制结构，尚未确认。
+
+适合探索，不应直接作为最终写作依据。
+
+```yaml
+source_mode: model_hypothesis
+continuation_safe: true
+```
+
+前提：模型推断没有使用目标章真实正文、后续章节、benchmark reference 或外部 LLM 已生成目标章正文。
+
+---
+
+### `benchmark_reference`
+
+仅用于测试 schema 表达能力、回放对照、评估上限或分析真实目标章。
+
+不得用于真实续写生产路径。
+
+```yaml
+source_mode: benchmark_reference
+clean_forward_safe: false
+continuation_safe: false
+```
+
+---
+
+## 6. continuation_safe / clean_forward_safe 规则
+
+真实续写可用的 World Mechanics pack 应写：
+
+```yaml
+continuation_safe: true
+```
+
+如果该 pack 完全来自目标章之前的 clean 来源，也应写：
+
+```yaml
+clean_forward_safe: true
+```
+
+出现以下情况必须写：
+
+```yaml
+continuation_safe: false
+clean_forward_safe: false
+```
+
+- 使用目标章节真实正文；
+- 使用目标章节真实 trace；
+- 使用后续章节；
+- 使用 benchmark reference；
+- 使用回放答案；
+- 使用外部 LLM 已经生成的目标章正文；
+- 使用任何会让真实续写“偷看答案”的材料。
+
+---
+
+## 7. support_status / 支持状态
+
+v0.3 新增 `support_status`，用于区分某条机制是否能由 clean 来源稳定支持。
+
+合法值：
+
+```yaml
+support_status: clean_supported | low_confidence | not_clean_supported | requires_planned_source
+```
+
+含义：
+
+- `clean_supported`：目标章之前的来源足以支持该机制。
+- `low_confidence`：有部分 clean 支持，但不足以展开细节。
+- `not_clean_supported`：clean 来源不支持，不应写入 production-clean instance。
+- `requires_planned_source`：需要作者计划、manual notes、Render Event Log 或其他 planned 来源才能进入真实续写。
+
+规则：
+
+- production-clean instance 中可以包含 `clean_supported` 和少量 `low_confidence`。
+- production-clean instance 不应把 `not_clean_supported` 当成可渲染规则。
+- `requires_planned_source` 只能作为 gap / open question 或 planned instance 内容，不能伪装成 canon。
+
+---
+
+## 8. mechanic_scope / 机制作用域
+
+v0.3 新增 `mechanic_scope`。
+
+合法值：
+
+```yaml
+mechanic_scope: global | chapter_relevant | unresolved_gap
+```
+
+含义：
+
+- `global`：全书或世界长期有效机制。
+- `chapter_relevant`：本目标章节需要特别注意的机制。
+- `unresolved_gap`：当前 clean 来源不足，需要后续 planned/manual/benchmark source 补强的机制缺口。
+
+示例：
+
+```yaml
+mechanic_scope: global
+```
+
+```yaml
+mechanic_scope: chapter_relevant
+```
+
+```yaml
+mechanic_scope: unresolved_gap
+```
+
+---
+
+## 9. source_label / provenance 字段
+
+每条 mechanic 必须标注来源可靠性。
+
+允许值：
+
+```yaml
+source_label: canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference
+```
+
+含义：
+
+- `canon_confirmed`：由目标章之前的 canon/truth files 直接支持。
+- `inferred`：从目标章之前的 canon/truth files 推断。
+- `human_planned`：来自用户、作者或人工写作计划。
+- `human_override`：人工覆盖或修正。
+- `model_hypothesis`：模型推断，尚未确认。
+- `benchmark_reference`：来自答案回放、目标章真实正文或对照测试；真实续写中不得使用。
+
+旧版中的 `benchmark_reference` 不推荐用于真实续写 schema。
+如果历史 instance 中存在 `benchmark_reference`，应迁移为：
+
+```yaml
+source_label: benchmark_reference
+continuation_safe: false
+```
+
+---
+
+## 10. 顶层对象：`WorldbuildingMechanicsPack`
+
+```yaml
+schema_version: "worldbuilding_world_mechanics.v0.3"
+pack_id: "worldbuilding_world_mechanics_<target_chapter>_<source_mode>"
+target_chapter: "<target_chapter>"
+
+source_mode: production_clean
+render_mode: clean
+clean_forward_safe: true
+continuation_safe: true
+
+source_boundary:
+  allowed_sources:
+    - "<pre-target truth/state/rules source>"
+    - "<story bible or book rules>"
+    - "<pre-target chapter summaries>"
+    - "<clean Active Entity Cards>"
+  excluded_sources:
+    - "<target chapter real manuscript>"
+    - "<target chapter real trace>"
+    - "<later chapter prose>"
+    - "<benchmark reference>"
+    - "<external LLM target-chapter prose>"
+    - "<uncertain generated artifacts>"
+  contamination_note: "Production-clean pack compiled only from pre-target sources."
+
+scope:
+  includes:
+    - world mechanics
+    - social rules
+    - economy and trade constraints
+    - technology constraints
+    - weapon constraints
+    - magic constraints
+    - special profession ecology
+    - detection / perception / permission mechanics
+    - tactical implications
+    - clean gaps and support status
+  excludes:
+    - full entity state
+    - event order
+    - author style
+    - final prose
+    - target-chapter transient entities not clean-supported
+
+global_world_type:
+  id: "WM-C001"
+  title: "<世界类型标题>"
+  category: world_type
+  support_status: clean_supported
+  mechanic_scope: global
+  rule_statement: "<本世界的基础类型和主要机制并存方式。>"
+  narrative_function: "<这条世界类型规则在渲染中的作用。>"
+  allowed_rendering:
+    - "<允许如何在正文中体现世界类型。>"
+  forbidden_rendering:
+    - "<禁止把世界写偏的方式。>"
+  required_render_signals:
+    - "<正文中可审计的世界类型信号。>"
+  escalation_limits:
+    - "<该规则不能被扩展到哪里。>"
+  target_chapter_relevance: "<为什么目标章节需要这条机制。>"
+  dependencies:
+    entity_cards:
+      - "<EC-ID>"
+    truth_files:
+      - "<truth file or section>"
+    raw_chapters:
+      - "<pre-target chapter range>"
+    event_log_candidates:
+      - "<optional planned event id>"
+  source_label: canon_confirmed
+  compiled_from: mixed
+  evidence_granularity: state_summary + chapter_summary + world_rules
+  source_coverage:
+    evidence_count: null
+    source_types:
+      - truth_state
+      - chapter_summary
+      - book_rules
+  source_basis:
+    - "<人类可审计来源摘要>"
+  excluded_sources:
+    - "<excluded source>"
+  clean_forward_safe: true
+  continuation_safe: true
+  contamination_note: "No target-chapter or future-source evidence used."
+  confidence: high
+  validation_flags:
+    must_check:
+      - "<审计问题>"
+
+mechanics:
+  - id: "WM-C002"
+    title: "<机制标题>"
+    category: "<category>"
+    support_status: clean_supported
+    mechanic_scope: chapter_relevant
+    rule_statement: "<机制规则>"
+    narrative_function: "<叙事功能>"
+    allowed_rendering:
+      - "<允许渲染>"
+    forbidden_rendering:
+      - "<禁止渲染>"
+    required_render_signals:
+      - "<可审计信号>"
+    escalation_limits:
+      - "<升级限制>"
+    target_chapter_relevance: "<目标章相关性>"
+    dependencies:
+      entity_cards: []
+      truth_files: []
+      raw_chapters: []
+      event_log_candidates: []
+    source_label: canon_confirmed
+    compiled_from: mixed
+    evidence_granularity: state_summary + chapter_summary
+    source_coverage:
+      evidence_count: null
+      source_types:
+        - truth_state
+        - chapter_summary
+    source_basis:
+      - "<来源摘要>"
+    excluded_sources:
+      - "<排除来源>"
+    clean_forward_safe: true
+    continuation_safe: true
+    contamination_note: "No target-chapter or future-source evidence used."
+    confidence: high
+    validation_flags:
+      must_check:
+        - "<审计问题>"
+
+open_questions:
+  - id: "WM-GAP-001"
+    title: "<clean 来源不足的机制>"
+    support_status: requires_planned_source
+    mechanic_scope: unresolved_gap
+    note: "<说明为什么 production-clean 不足以填充>"
+    allowed_next_sources:
+      - human_plan
+      - manual_note
+      - planned_render_event_log
+      - benchmark_reference_for_test_only
+
+audit:
+  required_questions:
+    - "使用了哪些来源？"
+    - "明确排除了哪些来源？"
+    - "每条 mechanic 是否 continuation_safe？"
+    - "是否有 target-chapter transient 被误写入 clean instance？"
+    - "是否越权承担 Entity Cards / Render Event Log / Author Fingerprint 职责？"
+    - "哪些机制是 clean_supported，哪些是 low_confidence 或 requires_planned_source？"
+```
+
+---
+
+## 11. 顶层字段说明
+
+### `schema_version`
+
+类型：string
+必填：是
+
+推荐值：
+
+```yaml
+schema_version: "worldbuilding_world_mechanics.v0.3"
+```
+
+---
+
+### `pack_id`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+pack_id: "worldbuilding_world_mechanics_<target_chapter>_production_clean"
+```
+
+用途：给当前 World Mechanics pack 一个稳定 ID。
+
+---
+
+### `target_chapter`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+target_chapter: "<target_chapter>"
+```
+
+---
+
+### `source_mode`
+
+类型：enum
+必填：推荐
+
+允许值：
+
+```yaml
+production_clean
+planned
+manual
+hybrid_planned
+model_hypothesis
+benchmark_reference
+```
+
+---
+
+### `render_mode`
+
+类型：enum
+必填：兼容旧版，推荐保留
+
+允许值：
+
+```yaml
+clean
+hybrid
+benchmark_reference
+```
+
+说明：
+
+- `source_mode` 更适合真实续写。
+- `render_mode` 保留用于兼容旧 schema 和旧 instance。
+
+---
+
+### `clean_forward_safe`
+
+类型：boolean
+必填：是
+
+规则：
+
+- 完全由目标章节之前的来源支持时为 `true`。
+- 使用目标章真实正文、真实 trace、后续章节、benchmark reference 时为 `false`。
+
+---
+
+### `continuation_safe`
+
+类型：boolean
+必填：是
+
+规则：
+
+- 可用于真实续写时为 `true`。
+- 只适合 benchmark / 回放 / 答案分析时为 `false`。
+
+---
+
+### `source_boundary`
+
+类型：object
+必填：是
+
+结构：
+
+```yaml
+source_boundary:
+  allowed_sources:
+    - string
+  excluded_sources:
+    - string
+  contamination_note: string
+```
+
+用途：显式声明来源边界。
+
+规则：
+
+- production-clean pack 必须排除目标章正文、目标章真实 trace、后续章节、benchmark reference、外部 LLM 目标章正文、不确定生成产物。
+- benchmark_reference pack 可以使用目标章真实信息，但必须明确 `continuation_safe: false`。
+- 不得把 benchmark_reference 伪装成 production_clean。
+
+---
+
+### `scope`
+
+类型：object
+必填：是
+
+结构：
+
+```yaml
+scope:
+  includes:
+    - string
+  excludes:
+    - string
+```
+
+用途：防止 Worldbuilding schema 吃掉其他 structured render 层。
+
+推荐 `excludes`：
+
+```yaml
+excludes:
+  - full entity state
+  - event order
+  - author style
+  - final prose
+  - target-chapter transient entities not clean-supported
+```
+
+---
+
+### `global_world_type`
+
+类型：`WorldMechanic` 简化对象
+必填：推荐
+
+用途：描述基础世界类型和大设定混合方式。
+
+示例：
+
+```yaml
+global_world_type:
+  id: "WM-C001"
+  title: "<世界类型标题>"
+  category: world_type
+  rule_statement: "<世界类型规则。>"
+```
+
+---
+
+## 12. 对象：`WorldMechanic`
+
+每条 `mechanics` 下的机制建议使用以下结构：
+
+```yaml
+id: string
+title: string
+category: world_type | social_rules | economy | weapons | technology | magic | profession_ecology | detection | perception | permission | inventor_mechanics | tactical_resolution | logistics | legal_order | geography | other
+
+support_status: clean_supported | low_confidence | not_clean_supported | requires_planned_source
+mechanic_scope: global | chapter_relevant | unresolved_gap
+
+rule_statement: string
+narrative_function: string
+
+allowed_rendering:
+  - string
+
+forbidden_rendering:
+  - string
+
+required_render_signals:
+  - string
+
+escalation_limits:
+  - string
+
+target_chapter_relevance: string
+
+dependencies:
+  entity_cards:
+    - string
+  truth_files:
+    - string
+  raw_chapters:
+    - string
+  event_log_candidates:
+    - string
+
+source_label: canon_confirmed | inferred | human_planned | human_override | model_hypothesis | benchmark_reference
+compiled_from: truth_state | raw_chapters | event_log | human_override | human_plan | benchmark_reference | mixed
+evidence_granularity: state_summary | chapter_summary | raw_line | manual_note | world_rules | trace_summary | mixed
+
+source_coverage:
+  evidence_count: number | null
+  source_types:
+    - truth_state
+    - chapter_summary
+    - raw_chapters
+    - book_rules
+    - story_bible
+    - human_plan
+    - manual_note
+    - benchmark_reference
+
+source_basis:
+  - string
+
+excluded_sources:
+  - string
+
+clean_forward_safe: boolean
+continuation_safe: boolean
+contamination_note: string
+
+confidence: high | medium | low
+
+validation_flags:
+  must_check:
+    - string
+```
+
+---
+
+## 13. `WorldMechanic` 字段规则
+
+### `id`
+
+类型：string
+必填：是
+
+规则：
+
+- 使用稳定 ID。
+- 推荐使用 `WM-C001`、`WM-P001`、`WM-GAP-001` 或 snake_case。
+- 不要把同一个 ID 用给不同机制。
+
+示例：
+
+```yaml
+id: "WM-C001"
+id: "world_type_hybrid_setting"
+id: "weapon_is_object_not_stat_block"
+```
+
+---
+
+### `title`
+
+类型：string
+必填：推荐
+
+人类可读短标题。
+
+示例：
+
+```yaml
+title: "武器是物件，不是属性菜单"
+```
+
+---
+
+### `category`
+
+类型：enum
+必填：是
+
+推荐值：
+
+```yaml
+world_type
+social_rules
+economy
+weapons
+technology
+magic
+profession_ecology
+detection
+perception
+permission
+inventor_mechanics
+tactical_resolution
+logistics
+legal_order
+geography
+other
+```
+
+说明：
+
+- `weapons` 用于枪械、冷兵器、载具武器、未来武器等泛武器机制。
+- `technology` 用于工程、机械、电子、蒸汽、赛博、生物技术等。
+- `magic` 用于法术、超自然、神术、灵能等。
+- `profession_ecology` 用于施法者、骑士、工程师、赏金猎人、军官等群体生态。
+- `detection` / `perception` 用于识别、侦测、幻象、感知、扫描等机制。
+- `permission` 用于资格、权限、绑定、血统、接口、许可证等机制。
+- `inventor_mechanics` 保留给发明家、工匠、特殊制造者相关机制。
+- `other` 只在没有更合适分类时使用。
+
+---
+
+### `support_status`
+
+类型：enum
+必填：推荐
+
+允许值：
+
+```yaml
+clean_supported
+low_confidence
+not_clean_supported
+requires_planned_source
+```
+
+规则：
+
+- clean instance 中主要使用 `clean_supported`。
+- clean 支持不足但值得提醒的机制写 `low_confidence`。
+- 不应把 `not_clean_supported` 写成可渲染机制。
+- 需要作者计划才能出现的机制写 `requires_planned_source`。
+
+---
+
+### `mechanic_scope`
+
+类型：enum
+必填：推荐
+
+允许值：
+
+```yaml
+global
+chapter_relevant
+unresolved_gap
+```
+
+规则：
+
+- 长期世界规则写 `global`。
+- 和目标章有关的机制写 `chapter_relevant`。
+- clean 缺口写 `unresolved_gap`。
+
+---
+
+### `rule_statement`
+
+类型：string
+必填：是
+
+说明这条世界机制本身是什么。
+
+好例子：
+
+```yaml
+rule_statement: "某类技术装置需要特定材料、权限或操作者技能，不能被任何角色随手使用。"
+```
+
+坏例子：
+
+```yaml
+rule_statement: "这一段要写得酷。"
+```
+
+---
+
+### `narrative_function`
+
+类型：string
+必填：是
+
+说明这条机制为什么对渲染有用。
+
+示例：
+
+```yaml
+narrative_function: "防止新设备成为万能解法，并为角色选择制造成本和权限压力。"
+```
+
+---
+
+### `allowed_rendering`
+
+类型：list[string]
+必填：是
+
+写 Writer 可以如何渲染这条机制。
+
+示例：
+
+```yaml
+allowed_rendering:
+  - "可以通过价格、材料、权限、损耗或使用者失误体现限制。"
+  - "可以让角色误以为该机制能解决问题，再被现实条件压回。"
+```
+
+---
+
+### `forbidden_rendering`
+
+类型：list[string]
+必填：是
+
+写 Writer 不能如何渲染这条机制。
+
+示例：
+
+```yaml
+forbidden_rendering:
+  - "不要让新设备没有成本地解决所有问题。"
+  - "不要让未具备权限的角色突然使用专属机制。"
+```
+
+---
+
+### `required_render_signals`
+
+类型：list[string]
+必填：推荐
+
+用于审计“这条机制是否真的进入正文”的小信号。
+
+示例：
+
+```yaml
+required_render_signals:
+  - "出现价格、权限、材料、风险或技能限制。"
+  - "机制限制通过动作、对话、失败或取舍表现，而非纯旁白说明。"
+```
+
+---
+
+### `escalation_limits`
+
+类型：list[string]
+必填：推荐
+
+防止机制被写过头。
+
+示例：
+
+```yaml
+escalation_limits:
+  - "该机制只能解释为什么方案受限，不能自动规定事件顺序。"
+  - "不得扩展成完整世界百科。"
+```
+
+---
+
+### `target_chapter_relevance`
+
+类型：string
+必填：是
+
+说明这条机制为什么和目标章节有关。
+
+示例：
+
+```yaml
+target_chapter_relevance: "目标章节涉及准备、交易、试用或战术选择，因此需要明确该机制的成本和限制。"
+```
+
+---
+
+### `dependencies`
+
+类型：object
+必填：推荐
+
+v0.3 推荐稳定结构：
+
+```yaml
+dependencies:
+  entity_cards:
+    - string
+  truth_files:
+    - string
+  raw_chapters:
+    - string
+  event_log_candidates:
+    - string
+```
+
+用途：将 world mechanic 和其他 structured render 层建立弱连接，但不替代那些层。
+
+规则：
+
+- `entity_cards` 只引用实体卡，不复制实体状态。
+- `truth_files` 只列来源文件或概念来源。
+- `raw_chapters` 只列 pre-target chapter 范围或样本来源。
+- `event_log_candidates` 只提示可能关联的 Event Log，不规定事件顺序。
+
+---
+
+### `source_label`
+
+类型：enum
+必填：是
+
+允许值：
+
+```yaml
+canon_confirmed
+inferred
+human_planned
+human_override
+model_hypothesis
+benchmark_reference
+```
+
+规则：
+
+- 真实续写中不得使用 `benchmark_reference`。
+- benchmark/reference 来源必须 `continuation_safe: false`。
+- 模型推断不得伪装成 canon。
+
+---
+
+### `compiled_from`
+
+类型：enum
+必填：是
+
+允许值：
+
+```yaml
+truth_state
+raw_chapters
+event_log
+human_override
+human_plan
+benchmark_reference
+mixed
+```
+
+规则：
+
+- production-clean 通常使用 `truth_state`、`raw_chapters`、`mixed`。
+- planned instance 可使用 `human_plan`。
+- benchmark 测试可使用 `benchmark_reference`，但不得用于真实续写。
+
+---
+
+### `evidence_granularity`
+
+类型：enum/string
+必填：是
+
+允许值：
+
+```yaml
+state_summary
+chapter_summary
+raw_line
+manual_note
+world_rules
+trace_summary
+mixed
+```
+
+也可用组合形式：
+
+```yaml
+evidence_granularity: state_summary + chapter_summary + world_rules
+```
+
+用途：说明证据粒度。
+
+---
+
+### `source_coverage`
+
+类型：object
+必填：推荐
+
+v0.3 新增。
+
+结构：
+
+```yaml
+source_coverage:
+  evidence_count: number | null
+  source_types:
+    - truth_state
+    - chapter_summary
+    - raw_chapters
+    - book_rules
+    - story_bible
+    - human_plan
+    - manual_note
+    - benchmark_reference
+```
+
+用途：
+
+- 辅助判断 confidence；
+- 说明该机制由多少种来源支撑；
+- 避免把弱推断当成强 canon。
+
+---
+
+### `source_basis`
+
+类型：list[string]
+必填：是
+
+人类可审计的来源摘要。
+
+示例：
+
+```yaml
+source_basis:
+  - "<story bible>: confirms technology and magic coexist."
+  - "<pre-target chapter summaries>: repeated weapon/resource limitations."
+  - "<clean Active Entity Cards>: confirms entity has skill gap."
+```
+
+规则：
+
+- 不要粘贴大量原文。
+- production-clean 机制不得引用目标章真实正文、后续章节或 benchmark reference。
+- benchmark 机制必须明确标记。
+
+---
+
+### `excluded_sources`
+
+类型：list[string]
+必填：推荐
+
+用途：记录这条机制明确没有使用哪些来源。
+
+production-clean 机制建议写：
+
+```yaml
+excluded_sources:
+  - "<target chapter real manuscript>"
+  - "<target chapter real trace>"
+  - "<later chapter prose>"
+  - "<benchmark reference>"
+  - "<external LLM target-chapter prose>"
+  - "<uncertain generated artifacts>"
+```
+
+---
+
+### `clean_forward_safe`
+
+类型：boolean
+必填：是
+
+规则：
+
+- 该机制可用于 clean forward test 时为 `true`。
+- 如果受到目标章真实正文、真实 trace、后续章节或 benchmark reference 影响，必须为 `false`。
+
+---
+
+### `continuation_safe`
+
+类型：boolean
+必填：是
+
+规则：
+
+- 该机制可用于真实续写时为 `true`。
+- 只适合 benchmark / 回放 / 答案分析时为 `false`。
+
+---
+
+### `contamination_note`
+
+类型：string
+必填：是
+
+示例：
+
+```yaml
+contamination_note: "No target-chapter or future-source evidence used."
+```
+
+```yaml
+contamination_note: "Benchmark reference only; not safe for production continuation."
+```
+
+---
+
+### `confidence`
+
+类型：enum
+必填：是
+
+允许值：
+
+```yaml
+high
+medium
+low
+```
+
+含义：
+
+- `high`：直接支持或高度确定。
+- `medium`：合理推断。
+- `low`：弱推断或 clean 支持不足，使用前应审计。
+
+建议：
+
+- `support_status: clean_supported` 可为 `high` 或 `medium`。
+- `support_status: low_confidence` 通常为 `low`。
+- `source_label: model_hypothesis` 通常不能高于 `medium`。
+- `source_label: benchmark_reference` 可以 high，但不 continuation-safe。
+
+---
+
+### `validation_flags`
+
+类型：object
+必填：推荐
+
+结构：
+
+```yaml
+validation_flags:
+  must_check:
+    - string
+```
+
+用途：给 Auditor 明确检查问题。
+
+示例：
+
+```yaml
+validation_flags:
+  must_check:
+    - "正文是否让该机制变成万能解法？"
+    - "正文是否把 low-confidence clean gap 当成已确认 canon？"
+```
+
+---
+
+## 14. 推荐机制分类
+
+### 14.1 `world_type`
+
+用于基础世界类型。
+
+例：
+
+- 多机制混合世界；
+- 科技与魔法并存；
+- 边境社会；
+- 帝国/都市/废土/太空殖民等基础世界结构。
+
+---
+
+### 14.2 `social_rules`
+
+用于偏见、阶层、种族、声望、身份、地方权威、职业地位、社会承认方式。
+
+例：
+
+- 社会偏见仍存在；
+- 声望可改变局部待遇；
+- 某些身份会影响交易、执法或公共空间互动。
+
+---
+
+### 14.3 `economy`
+
+用于金钱、赏金、信用、票据、稀缺性、价格、库存、资源取舍。
+
+例：
+
+- 有报酬不等于无限预算；
+- 高级装备或服务昂贵且稀缺；
+- 普通资源可获得，高端资源需要计划或代价。
+
+---
+
+### 14.4 `weapons`
+
+用于武器操作、维护、弹药、耐久、携带、精度、训练、使用者技能。
+
+例：
+
+- 武器是物件，不是属性菜单；
+- 新武器改善可靠性，但不自动提升使用者能力；
+- 近战/远程/重武器/轻武器各有取舍。
+
+---
+
+### 14.5 `technology`
+
+用于机械、工程、电子、蒸汽、赛博、生物技术、AI、载具、能源等。
+
+例：
+
+- 技术装置需要材料、维护、权限或操作者；
+- 技术可辅助观察/行动，但不能自动解决冲突；
+- 新技术暴露新限制。
+
+---
+
+### 14.6 `magic`
+
+用于法术、魔法物品、超自然力量、神术、灵能、诅咒等。
+
+例：
+
+- 魔法存在但不能按需成为解法；
+- 高级魔法昂贵、稀缺或受权限限制；
+- 低阶魔法也可能有战术价值，但不能变万能。
+
+---
+
+### 14.7 `profession_ecology`
+
+用于特定职业或群体在世界中的生态位置。
+
+例：
+
+- 施法者生态；
+- 工程师/发明家生态；
+- 佣兵/赏金猎人生态；
+- 贵族/军官/神职人员生态。
+
+---
+
+### 14.8 `detection`
+
+用于侦测、扫描、看穿、识别、追踪、验真等机制。
+
+例：
+
+- 看见和理解是两回事；
+- 识别目标不等于击中目标；
+- 侦测工具不能自动共享给所有人。
+
+---
+
+### 14.9 `perception`
+
+用于感官、视野、误判、幻象、信息差、认知限制。
+
+例：
+
+- 角色只能根据可见信息判断；
+- 感知优势必须受角度、距离、噪声或误导影响。
+
+---
+
+### 14.10 `permission`
+
+用于权限、绑定、资质、血统、接口、许可证、职业资格等。
+
+例：
+
+- 某工具只有特定角色或权限者可用；
+- 可识别不等于可操作；
+- 可拥有不等于可安全使用。
+
+---
+
+### 14.11 `inventor_mechanics`
+
+用于发明家、工匠、维修者、特殊制造者、装置维护者等机制。
+
+例：
+
+- 发明能力有载体和边界；
+- 维护能力不等于战斗万能；
+- 工具可解决小问题，同时暴露新问题。
+
+---
+
+### 14.12 `tactical_resolution`
+
+用于章节级机制矛盾和战术边界。
+
+例：
+
+- 准备不等于胜利；
+- 新工具改善一个问题，但留下另一个问题；
+- 目标章可以建立行动压力，但不得提前解决未来敌人。
+
+---
+
+### 14.13 `logistics`
+
+用于运输、补给、时间、距离、天气、可携带性、维护资源。
+
+---
+
+### 14.14 `legal_order`
+
+用于法律、执法、许可证、通缉、契约、债务、地方权力。
+
+---
+
+### 14.15 `geography`
+
+用于地形、距离、城镇结构、边境、道路、关卡、环境压力。
+
+---
+
+## 15. Clean Gap / Open Question 规则
+
+如果某机制对目标章可能重要，但 production-clean 来源不足，不要强行写成 confirmed mechanic。
+
+应该放入：
+
+```yaml
+open_questions:
+  - id: "WM-GAP-001"
+    title: "<机制缺口>"
+    support_status: requires_planned_source
+    mechanic_scope: unresolved_gap
+    note: "<clean 来源为什么不足>"
+    allowed_next_sources:
+      - human_plan
+      - manual_note
+      - planned_render_event_log
+      - benchmark_reference_for_test_only
+```
+
+规则：
+
+- clean gap 可以提醒 assembly，但不得直接驱动 Renderer 展开细节。
+- planned/manual 来源可以补强 clean gap。
+- benchmark_reference 只能用于测试，不得用于真实续写。
+- 如果后续补强，应生成 planned instance，不要回写 production-clean instance。
+
+---
+
+## 16. 最小验证规则
+
+生成的 worldbuilding pack 至少需要通过以下检查：
+
+1. 声明 `schema_version`。
+2. 声明 `target_chapter`。
+3. 声明 `source_mode`。
+4. 声明 `clean_forward_safe`。
+5. 声明 `continuation_safe`。
+6. 声明 `source_boundary`。
+7. 声明 `scope`。
+8. 每条 mechanic 都有：
+   - `id`
+   - `title`
+   - `category`
+   - `support_status`
+   - `mechanic_scope`
+   - `rule_statement`
+   - `narrative_function`
+   - `allowed_rendering`
+   - `forbidden_rendering`
+   - `required_render_signals`
+   - `escalation_limits`
+   - `target_chapter_relevance`
+   - `dependencies`
+   - `source_label`
+   - `compiled_from`
+   - `evidence_granularity`
+   - `source_coverage`
+   - `source_basis`
+   - `excluded_sources`
+   - `clean_forward_safe`
+   - `continuation_safe`
+   - `contamination_note`
+   - `confidence`
+   - `validation_flags`
+9. continuation-safe pack 不得使用 `benchmark_reference` 作为可渲染机制来源。
+10. production-clean pack 不得引用目标章真实正文、真实 trace、后续章节或 benchmark reference。
+11. mechanic 不得包含事件顺序。
+12. mechanic 不得包含文风指令。
+13. mechanic 不得替代 Entity Cards。
+14. mechanic 不得替代 Render Event Log。
+15. mechanic 不得替代 Author Fingerprint。
+16. mechanic 不得要求 Writer 暴露未来信息，除非 `source_mode: benchmark_reference` 且 `continuation_safe: false`。
+
+---
+
+## 17. Auditor Checklist
+
+用于审计生成正文或 structured render packet 是否遵守 Worldbuilding / World Mechanics。
+
+```yaml
+worldbuilding_audit:
+  source_boundary:
+    checked: true
+    issue: null
+
+  continuation_safety:
+    checked: true
+    issue: null
+
+  benchmark_contamination:
+    checked: true
+    issue: null
+
+  future_source_leak:
+    checked: true
+    issue: null
+
+  mechanic_coverage:
+    checked: true
+    missing_mechanics:
+      - string
+
+  clean_gap_handling:
+    checked: true
+    unresolved_gaps:
+      - string
+    incorrectly_promoted_gaps:
+      - string
+
+  overreach:
+    checked: true
+    issues:
+      - string
+
+  forbidden_rendering_violations:
+    checked: true
+    violations:
+      - mechanic_id: string
+        issue: string
+
+  event_log_leakage:
+    checked: true
+    issue: null
+
+  entity_card_leakage:
+    checked: true
+    issue: null
+
+  author_fingerprint_leakage:
+    checked: true
+    issue: null
+
+  final_judgment:
+    pass: true
+    notes:
+      - string
+```
+
+审计重点：
+
+- 机制是否被写成事件顺序？
+- 世界规则是否被写成百科？
+- 新装备/新技术/新魔法/新情报是否变成万能解法？
+- benchmark / future source 是否被伪装成 clean？
+- low-confidence gap 是否被当成 confirmed canon？
+- 是否把实体状态塞进了 world mechanics？
+- 是否把 prose style 塞进了 world mechanics？
+- 是否把 Event Log 的事件顺序塞进了 world mechanics？
+
+---
+
+## 18. TypeScript 参考接口
+
+字段名保留英文，便于后续程序使用；注释和文档以中文为主。
+
+```ts
+export type SourceMode =
+  | "production_clean"
+  | "planned"
+  | "manual"
+  | "hybrid_planned"
+  | "model_hypothesis"
+  | "benchmark_reference";
+
+export type RenderMode =
+  | "clean"
+  | "hybrid"
+  | "benchmark_reference";
+
+export type WorldMechanicCategory =
+  | "world_type"
+  | "social_rules"
+  | "economy"
+  | "weapons"
+  | "technology"
+  | "magic"
+  | "profession_ecology"
+  | "detection"
+  | "perception"
+  | "permission"
+  | "inventor_mechanics"
+  | "tactical_resolution"
+  | "logistics"
+  | "legal_order"
+  | "geography"
+  | "other";
+
+export type SupportStatus =
+  | "clean_supported"
+  | "low_confidence"
+  | "not_clean_supported"
+  | "requires_planned_source";
+
+export type MechanicScope =
+  | "global"
+  | "chapter_relevant"
+  | "unresolved_gap";
+
+export type SourceLabel =
+  | "canon_confirmed"
+  | "inferred"
+  | "human_planned"
+  | "human_override"
+  | "model_hypothesis"
+  | "benchmark_reference";
+
+export type CompiledFrom =
+  | "truth_state"
+  | "raw_chapters"
+  | "event_log"
+  | "human_override"
+  | "human_plan"
+  | "benchmark_reference"
+  | "mixed";
+
+export type EvidenceGranularity =
+  | "state_summary"
+  | "chapter_summary"
+  | "raw_line"
+  | "manual_note"
+  | "world_rules"
+  | "trace_summary"
+  | "mixed"
+  | string;
+
+export type Confidence = "high" | "medium" | "low";
+
+export interface SourceBoundary {
+  allowed_sources: string[];
+  excluded_sources: string[];
+  contamination_note: string;
+}
+
+export interface ScopeBoundary {
+  includes: string[];
+  excludes: string[];
+}
+
+export interface MechanicDependencies {
+  entity_cards?: string[];
+  truth_files?: string[];
+  raw_chapters?: string[];
+  event_log_candidates?: string[];
+}
+
+export interface SourceCoverage {
+  evidence_count: number | null;
+  source_types: Array<
+    | "truth_state"
+    | "chapter_summary"
+    | "raw_chapters"
+    | "book_rules"
+    | "story_bible"
+    | "human_plan"
+    | "manual_note"
+    | "benchmark_reference"
+    | string
+  >;
+}
+
+export interface ValidationFlags {
+  must_check: string[];
+}
+
+export interface WorldMechanic {
+  id: string;
+  title: string;
+  category: WorldMechanicCategory;
+
+  support_status: SupportStatus;
+  mechanic_scope: MechanicScope;
+
+  rule_statement: string;
+  narrative_function: string;
+
+  allowed_rendering: string[];
+  forbidden_rendering: string[];
+  required_render_signals: string[];
+  escalation_limits: string[];
+
+  target_chapter_relevance: string;
+
+  dependencies: MechanicDependencies;
+
+  source_label: SourceLabel;
+  compiled_from: CompiledFrom;
+  evidence_granularity: EvidenceGranularity;
+
+  source_coverage: SourceCoverage;
+  source_basis: string[];
+  excluded_sources: string[];
+
+  clean_forward_safe: boolean;
+  continuation_safe: boolean;
+  contamination_note: string;
+
+  confidence: Confidence;
+
+  validation_flags: ValidationFlags;
+}
+
+export interface OpenQuestion {
+  id: string;
+  title: string;
+  support_status: "requires_planned_source" | "not_clean_supported" | "low_confidence";
+  mechanic_scope: "unresolved_gap";
+  note: string;
+  allowed_next_sources: string[];
+}
+
+export interface WorldbuildingMechanicsPack {
+  schema_version: "worldbuilding_world_mechanics.v0.3";
+  pack_id: string;
+  target_chapter: string;
+
+  source_mode: SourceMode;
+  render_mode?: RenderMode;
+
+  clean_forward_safe: boolean;
+  continuation_safe: boolean;
+
+  source_boundary: SourceBoundary;
+  scope: ScopeBoundary;
+
+  global_world_type?: Partial<WorldMechanic>;
+  mechanics: WorldMechanic[];
+
+  open_questions?: OpenQuestion[];
+
+  audit?: {
+    required_questions: string[];
+  };
+}
+```
+
+---
+
+## 19. Production-clean instance 最小模板
+
+```yaml
+schema_version: "worldbuilding_world_mechanics.v0.3"
+pack_id: "worldbuilding_world_mechanics_<target_chapter>_production_clean"
+target_chapter: "<target_chapter>"
+
+source_mode: production_clean
+render_mode: clean
+clean_forward_safe: true
+continuation_safe: true
+
+source_boundary:
+  allowed_sources:
+    - "<pre-target truth/state file>"
+    - "<story bible>"
+    - "<book rules>"
+    - "<pre-target chapter summaries>"
+    - "<clean Active Entity Cards>"
+  excluded_sources:
+    - "<target chapter real manuscript>"
+    - "<target chapter real trace>"
+    - "<later chapter prose>"
+    - "<benchmark reference>"
+    - "<external LLM target-chapter prose>"
+    - "<uncertain generated artifacts>"
+  contamination_note: "Production-clean pack compiled only from pre-target sources."
+
+scope:
+  includes:
+    - world mechanics
+    - social rules
+    - economy and trade constraints
+    - technology constraints
+    - weapon constraints
+    - magic constraints
+    - profession ecology support status
+    - tactical implications
+  excludes:
+    - full entity state
+    - event order
+    - author style
+    - final prose
+    - target-chapter transient entities not clean-supported
+
+global_world_type:
+  id: "WM-C001"
+  title: "<世界类型标题>"
+  category: world_type
+  support_status: clean_supported
+  mechanic_scope: global
+  rule_statement: "<pre-target 来源确认的基础世界类型。>"
+  narrative_function: "<防止世界类型漂移。>"
+  allowed_rendering:
+    - "<允许如何体现世界类型。>"
+  forbidden_rendering:
+    - "<禁止如何写偏。>"
+  required_render_signals:
+    - "<可审计信号。>"
+  escalation_limits:
+    - "<不得升级到哪里。>"
+  target_chapter_relevance: "<目标章为什么需要这条机制。>"
+  dependencies:
+    entity_cards: []
+    truth_files: []
+    raw_chapters: []
+    event_log_candidates: []
+  source_label: canon_confirmed
+  compiled_from: mixed
+  evidence_granularity: state_summary + chapter_summary + world_rules
+  source_coverage:
+    evidence_count: null
+    source_types:
+      - truth_state
+      - chapter_summary
+      - book_rules
+  source_basis:
+    - "<来源摘要>"
+  excluded_sources:
+    - "<target chapter real manuscript>"
+    - "<later chapter prose>"
+    - "<benchmark reference>"
+  clean_forward_safe: true
+  continuation_safe: true
+  contamination_note: "No target-chapter or future-source evidence used."
+  confidence: high
+  validation_flags:
+    must_check:
+      - "<审计问题>"
+
+mechanics:
+  - id: "WM-C002"
+    title: "<机制标题>"
+    category: "<category>"
+    support_status: clean_supported
+    mechanic_scope: chapter_relevant
+    rule_statement: "<机制规则。>"
+    narrative_function: "<叙事功能。>"
+    allowed_rendering:
+      - "<允许渲染。>"
+    forbidden_rendering:
+      - "<禁止渲染。>"
+    required_render_signals:
+      - "<可审计信号。>"
+    escalation_limits:
+      - "<升级限制。>"
+    target_chapter_relevance: "<目标章相关性。>"
+    dependencies:
+      entity_cards:
+        - "<EC-ID>"
+      truth_files:
+        - "<truth source>"
+      raw_chapters:
+        - "<pre-target chapter range>"
+      event_log_candidates:
+        - "<optional planned event id>"
+    source_label: canon_confirmed
+    compiled_from: mixed
+    evidence_granularity: state_summary + chapter_summary
+    source_coverage:
+      evidence_count: null
+      source_types:
+        - truth_state
+        - chapter_summary
+    source_basis:
+      - "<来源摘要。>"
+    excluded_sources:
+      - "<target chapter real manuscript>"
+      - "<later chapter prose>"
+      - "<benchmark reference>"
+    clean_forward_safe: true
+    continuation_safe: true
+    contamination_note: "No target-chapter or future-source evidence used."
+    confidence: high
+    validation_flags:
+      must_check:
+        - "<审计问题>"
+
+open_questions:
+  - id: "WM-GAP-001"
+    title: "<clean 支持不足的机制>"
+    support_status: requires_planned_source
+    mechanic_scope: unresolved_gap
+    note: "<说明为什么 clean 来源不足。>"
+    allowed_next_sources:
+      - human_plan
+      - manual_note
+      - planned_render_event_log
+      - benchmark_reference_for_test_only
+
+audit:
+  required_questions:
+    - "是否使用了 target/future/benchmark source？"
+    - "是否把 clean gap 当成 confirmed mechanic？"
+    - "是否越权承担 Entity Cards / Render Event Log / Author Fingerprint 职责？"
+```
+
+---
+
+## 20. Planned instance 指南
+
+如果某机制来自作者计划，而不是 pre-target canon，应使用 planned instance：
+
+```yaml
+source_mode: planned
+clean_forward_safe: true
+continuation_safe: true
+source_label: human_planned
+support_status: requires_planned_source
+```
+
+使用场景：
+
+- 作者明确计划目标章出现某种商品、场景、装置、规则；
+- Render Event Log 需要某机制支撑，但 clean 来源不足；
+- 人工 worldbuilding note 给出了目标章允许使用的机制。
+
+规则：
+
+- planned 信息可以用于真实续写。
+- planned 信息不能伪装成 `canon_confirmed`。
+- planned 信息不得使用目标章真实正文或后续章节。
+- planned 信息应在 `source_basis` 中指向 human plan / manual note。
+
+---
+
+## 21. Benchmark reference 指南
+
+如果某机制来自真实目标章、目标章 trace、后续章节、benchmark reference 或回放答案，应使用：
+
+```yaml
+source_mode: benchmark_reference
+clean_forward_safe: false
+continuation_safe: false
+source_label: benchmark_reference
+compiled_from: benchmark_reference
+```
+
+规则：
+
+- 只能用于 schema fit test、回放、分析、upper-bound 对照。
+- 不得用于真实续写。
+- 不得回写 production-clean instance。
+- 不得伪装成 pre-target canon。
+
+---
+
+## 22. 常见失败模式
+
+### 22.1 世界规则百科化
+
+错误：
+
+```text
+本世界的完整设定如下……
+```
+
+问题：World Mechanics 被写成百科说明，而不是渲染约束。
+
+修正：mechanic 应写“允许如何渲染 / 禁止如何渲染 / 可审计信号”。
+
+---
+
+### 22.2 越权写事件顺序
+
+错误：
+
+```yaml
+rule_statement: "角色先去地点 A，再遇到人物 B，然后发生事件 C。"
+```
+
+问题：这是 Render Event Log，不是 World Mechanics。
+
+修正：World Mechanics 只能说明机制如何运作，不规定事件顺序。
+
+---
+
+### 22.3 复制实体状态
+
+错误：
+
+```yaml
+rule_statement: "角色 A 当前穿着什么、拿着什么、和谁关系如何……"
+```
+
+问题：这是 Active Entity Cards。
+
+修正：World Mechanics 只引用实体卡 ID，不复制完整实体状态。
+
+---
+
+### 22.4 写作者风格
+
+错误：
+
+```yaml
+rule_statement: "这段要用短句、吐槽、对白密集。"
+```
+
+问题：这是 Author Fingerprint。
+
+修正：World Mechanics 只规定世界机制，不规定句法和文风。
+
+---
+
+### 22.5 把新机制写成万能解法
+
+错误：
+
+```text
+新工具一出现就解决所有任务问题。
+```
+
+问题：违反机制边界。
+
+修正：每条新机制都应有成本、权限、风险、稀缺、技能或使用条件。
+
+---
+
+### 22.6 clean gap 被当成 canon
+
+错误：
+
+```yaml
+support_status: low_confidence
+rule_statement: "该机制被当成确定世界规则详细展开。"
+```
+
+问题：低置信 gap 被过度确定化。
+
+修正：low-confidence 机制只能提示风险，不能未经 planned/manual 补强就写成详细规则。
+
+---
+
+### 22.7 benchmark 污染真实续写
+
+错误：
+
+```yaml
+source_mode: production_clean
+source_basis:
+  - "<target chapter real manuscript>"
+```
+
+问题：真实续写偷看答案。
+
+修正：使用真实目标章或 benchmark reference 时必须 `source_mode: benchmark_reference`，并 `continuation_safe: false`。
+
+---
+
+## 23. PR 定位
+
+本 schema 应定位为：
+
+```text
+Worldbuilding / World Mechanics = 世界机制与机制边界包
+```
+
+它不替代 InkOS 既有 truth files，也不替代 planner。
+
+建议管线位置：
+
+```text
+InkOS truth files
+→ Active Entity Cards
+→ Worldbuilding / World Mechanics
+→ Author Fingerprint
+→ Render Event Log
+→ Structured Render Assembly
+→ Renderer LLM
+→ Event-level Auditor
+```
+
+---
+
+## 24. v0.3 修改摘要
+
+相对 v0.2，本版做了以下修改：
+
+- 移除具体作品、具体角色、具体章节、具体项目实例。
+- 增加 `source_mode`，支持 `production_clean | planned | manual | hybrid_planned | model_hypothesis | benchmark_reference`。
+- 增加 `continuation_safe`，与真实续写安全边界对齐。
+- 增加 `support_status`：
+  - `clean_supported`
+  - `low_confidence`
+  - `not_clean_supported`
+  - `requires_planned_source`
+- 增加 `mechanic_scope`：
+  - `global`
+  - `chapter_relevant`
+  - `unresolved_gap`
+- 增加 `source_coverage`，用于记录 evidence_count 和 source_types。
+- 稳定 `dependencies` 子字段：
+  - `entity_cards`
+  - `truth_files`
+  - `raw_chapters`
+  - `event_log_candidates`
+- 将历史 `benchmark_reference` 概念迁移为 `benchmark_reference`。
+- 明确 benchmark/reference 只能用于测试/回放，不得用于真实续写。
+- 强化 clean gap / open question 处理规则。
+- 强化 World Mechanics 不接管 Entity Cards / Render Event Log / Author Fingerprint 的边界。
+- 保留中文主说明和英文字段名，便于人读和程序处理。


### PR DESCRIPTION
## 摘要

本 PR 新增一组实验性的 structured render schema 文档，建议放在：

`docs/structured-render-schemas/`

这些文档只定义结构化渲染前的中间输入格式，不修改 InkOS runtime、planner、renderer 或主写作流程。

本 PR 涉及四个 schema：

- `active_entity_cards_schema.md`
- `worldbuilding_world_mechanics_schema.md`
- `author_fingerprint_schema.md`
- `render_event_log_schema.md`

四层职责分别是：

1. **Active Entity Cards**  
   描述目标章节开始前的活跃实体、实体状态边界、关系、隐藏/内部约束和禁止漂移。

2. **Worldbuilding / World Mechanics**  
   描述世界规则、社会规则、经济规则、技术/魔法/战术机制、支持状态和来源边界。

3. **Author Fingerprint**  
   描述作者风格、节奏约束、角色声音、Renderer 执行规则和文风漂移防护。

4. **Render Event Log**  
   描述目标章节的事件顺序、event-level must-render / must-not-render、转场、张力变化、机制释放和审计问题。

## 背景：来自一次本地结构化渲染实验

这个 PR 的来源是一组本地 InkOS 续写实验。

实验目标是判断：在 InkOS 现有 truth/state/style 信息之外，是否需要一个更明确、可审计、可验证的结构化中间层，帮助 Renderer 稳定续写目标章节。

本地实验分为三组：

### A 组：InkOS 裸写目标章节

A 组直接使用 InkOS 现有上下文和写作链路续写目标章节，作为 baseline。

它用于观察：不额外提供结构化 guideline 时，InkOS 在事件承接、实体状态、世界机制、角色声音和章节落点上容易出现哪些漂移。

### B 组：benchmark/reference guideline 上限测试

B 组允许 Codex 读取真实目标章节，然后生成 benchmark/reference guideline，再测试 InkOS 渲染效果。

这一组不是为了真实续写使用，而是为了测试上限：如果目标章节的事件、机制、实体边界和风格要求被充分结构化，InkOS 的 Renderer 能否更稳定地渲染出接近目标的章节。

### C 组：禁止读取目标章的推演 guideline

C 组禁止 Codex 读取目标章节，只允许读取目标章之前的 1–10 章材料和现有 truth/state/style 信息，再生成推演 guideline。

这一组更接近真实续写场景，用于测试：没有答案时，是否能从前文和 InkOS 状态文件中推演出可用的结构化创作指导。

## 从实验中得到的结论

A/B/C 实验显示，单一 guideline 文件很容易混合多种职责：

- 实体状态；
- 世界机制；
- 作者风格；
- 事件顺序；
- 渲染禁令；
- 来源边界；
- benchmark/reference 信息。

这些信息混在一起后，既不容易审计，也不容易判断哪些内容适合真实续写、哪些只适合 benchmark/reference。

因此，本 PR 把 guideline 拆成四个职责明确的 schema：

- Active Entity Cards：负责“现在有什么，以及它们的状态边界”；
- Worldbuilding / World Mechanics：负责“世界和机制如何运作”；
- Author Fingerprint：负责“应该怎么写”；
- Render Event Log：负责“这一章按什么事件顺序发生”。

## 设计原则

### 1. LLM-native，但 validator-gated

本设计允许 LLM 生成 structured render 输入草稿，但不把裸 LLM 输出直接视为可信结果。

生成和放行分离：

- LLM 可以生成候选 structured files；
- 本地 validator 应检查 schema compliance、source boundary、continuation safety、internal-only leakage 和跨层职责边界；
- Renderer 应只接收通过校验的 packet，而不是裸 LLM draft。

换句话说，本设计不是要假设所有 InkOS 用户都有 Codex 级别的本地 CLI LLM。它更接近：

- 普通 LLM API 可以辅助生成草稿；
- schema 约束字段结构；
- validator 决定是否放行；
- 高风险内容需要标注来源和置信度。

### 2. 真实续写和 benchmark/reference 必须分开

schema 中明确区分：

- `production_clean`
- `planned`
- `manual`
- `hybrid_planned`
- `model_hypothesis`
- `benchmark_reference`

真实续写可用文件应显式标记 `continuation_safe: true`。

只用于测试、回放、答案参考或上限评估的材料必须标记为：

- `source_mode: benchmark_reference`
- `continuation_safe: false`

这样可以避免把“看过答案的 guideline”误当成真实续写输入。

### 3. 四层职责不互相替代

schema 明确限制跨层越权：

- 实体状态属于 Active Entity Cards。
- 世界规则属于 Worldbuilding / World Mechanics。
- 事件顺序属于 Render Event Log。
- 文风和角色声音属于 Author Fingerprint。

这可以避免一个文件同时承担状态、世界观、剧情大纲和文风提示，导致 Renderer 输入臃肿且不可审计。

### 4. internal-only 信息不得泄漏进正文

schema 支持 internal-only / prose-invisible 约束，用于防止隐藏机制、prompt 语言、schema 字段或内部约束进入最终小说正文。

这对带有隐藏机制、作者控制信息、系统性约束或 benchmark/reference 信息的 structured render 尤其重要。

## 本地验证情况

我在本地 InkOS 项目工作区中做过 schema fit 测试，用于确认这些 schema 能生成有用的 structured render 中间文件。

这些测试保持在 InkOS 主流程之外：

- 未修改 InkOS 主流程；
- 未生成小说正文；
- 未调用外部 LLM；
- 未运行完整写作管线；
- 未把项目专用 test outputs 提交到本 PR。

本 PR 只包含通用 schema 文档，不包含具体作品、具体角色、具体章节、benchmark/reference 输出或本地测试数据。

## 本 PR 不包含什么

本 PR 不包含：

- structured render compiler；
- renderer assembly layer；
- 完整 validator 实现；
- 新 CLI 命令；
- runtime 集成；
- 生成正文；
- 模型专用 prompt adapter；
- 项目专用测试输出。

这些应作为后续 PR 或实验继续推进。

## 后续工作建议

可能的后续方向：

1. 为每个 schema 增加 lightweight structural validator。
2. 对可从 truth/state/style 文件确定性编译的字段增加 deterministic extraction。
3. 增加可选的 LLM-assisted draft generation，但必须经过 validator gate。
4. 后续再加入 Structured Render Assembly layer，把四层输入合并成 renderer-ready packet。
5. 使用通用 fixture 做测试，避免项目专用文本进入核心仓库。

## 希望重点 review 的问题

1. 这四层划分是否符合 InkOS 现有架构？
2. `source_mode` / `continuation_safe` 命名是否符合 InkOS 术语习惯？
3. schema 文档是否应该放在 `docs/structured-render-schemas/`，还是更适合其他目录？
4. validator 是否应该放在后续 PR，而不是本 PR？
5. 是否有字段过于具体或过于宽泛，不适合进入 InkOS core docs？
6. 是否应该把 `benchmark_reference` 改成 InkOS 内部更习惯的术语？


