### PR TITLE
feat: Log agent chat raw messages as files on disk

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -247,6 +247,21 @@ The hook system uses Zod schema validation — `lastAdvancedChapter` must be an 
 
 User-configured `INKOS_LLM_MAX_TOKENS` now acts as a global cap on all API calls. Reserved keys in `llm.extra` (max_tokens, temperature, etc.) are automatically stripped to prevent accidental overrides.
 
+### Agent Chat Log
+
+Configure `chatLogDirs` in `inkos.json` to enable per-agent chat request/response file logging:
+
+```json
+{
+  "chatLogDirs": {
+    "writer": "C:\\my-novel\\.logs\\writer",
+    "planner": "C:\\my-novel\\.logs\\planner"
+  }
+}
+```
+
+Each chat call produces a log file named `chat-log-{agentName}-{ISO timestamp}-{random}.log`. The log includes a request header (model/provider/temperature/maxTokens/messageCount), every prompt message with role and content, plus the response content and token usage. InkOS automatically creates the target directory recursively if it does not exist. Useful for debugging prompt effectiveness, auditing LLM behavior, or analyzing token consumption.
+
 ---
 
 ## How It Works

--- a/README.ja.md
+++ b/README.ja.md
@@ -233,6 +233,21 @@ inkos compose chapter my-book
 
 ユーザー設定の `INKOS_LLM_MAX_TOKENS` がすべてのAPI呼び出しのグローバルキャップとして機能。`llm.extra` の予約キー（max_tokens、temperatureなど）は自動的に除去され、意図しないオーバーライドを防止。
 
+### エージェントチャットログ
+
+`inkos.json` に `chatLogDirs` を設定すると、異なるエージェントのchatリクエスト/レスポンスをファイルに記録できます：
+
+```json
+{
+  "chatLogDirs": {
+    "writer": "C:\\my-novel\\.logs\\writer",
+    "planner": "C:\\my-novel\\.logs\\planner"
+  }
+}
+```
+
+各chat呼び出しごとに `chat-log-{agentName}-{ISO timestamp}-{random}.log` という名前のログファイルが生成されます。ログにはリクエストヘッダー（model/provider/temperature/maxTokens/messageCount）、各prompt messageのroleとcontent、レスポンス内容とtoken使用量が含まれます。対象のフォルダが存在しない場合、InkOSは自動的に再帰的に作成します。プロンプトの効果検証、LLM動作の監査、token消費量の分析に便利です。
+
 ---
 
 ## 仕組み

--- a/README.md
+++ b/README.md
@@ -295,6 +295,21 @@ inkos compose chapter 吞天魔帝
 
 模型输出上限由 provider bank 的模型卡管理；`llm.extra` / `INKOS_LLM_EXTRA_*` 中的保留键（max_tokens、temperature、model、messages、stream 等）会被自动过滤，防止意外覆盖核心请求参数。
 
+### 调试日志（Agent Chat Log）
+
+`inkos.json` 中配置 `chatLogDirs` 可为不同 agent 开启 chat 请求/响应的文件日志：
+
+```json
+{
+  "chatLogDirs": {
+    "writer": "C:\\my-novel\\.logs\\writer",
+    "planner": "C:\\my-novel\\.logs\\planner"
+  }
+}
+```
+
+生成的日志文件命名格式为 `chat-log-{agentName}-{ISO timestamp}-{random}.log`，内容包括请求头（model/provider/temperature/maxTokens/messageCount）、每条 prompt 的角色和内容、以及响应内容与 token 用量统计。如果配置的文件夹不存在，InkOS 会自动递归创建。可用于调试 prompt 效果、审计 LLM 行为或分析 token 消耗。
+
 ---
 
 ## 工作原理

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -155,6 +155,7 @@ export function buildPipelineConfig(
     externalContext: extra?.externalContext,
     logger,
     onStreamProgress,
+    chatLogDirs: config.chatLogDirs,
   };
 }
 

--- a/packages/core/src/__tests__/base-agent-chat-log.test.ts
+++ b/packages/core/src/__tests__/base-agent-chat-log.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Writable } from "node:stream";
+import { BaseAgent, type AgentContext } from "../agents/base.js";
+import * as provider from "../llm/provider.js";
+
+class RecordingWritable extends Writable {
+  public chunks: string[] = [];
+
+  _write(chunk: any, _encoding: string, callback: () => void) {
+    this.chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    callback();
+  }
+
+  getWritten(): string {
+    return this.chunks.join("");
+  }
+}
+
+const AGENT_CONTEXT_BASE: AgentContext = {
+  client: {
+    provider: "openai" as const,
+    apiFormat: "chat" as const,
+    stream: false,
+    defaults: {
+      temperature: 0.7,
+      maxTokens: 4096,
+      thinkingBudget: 0,
+      extra: {},
+    },
+    service: "openai",
+    _piModel: { baseUrl: "https://api.openai.com/v1", id: "test-model" },
+  } as any,
+  model: "test-model",
+  projectRoot: "/tmp/test",
+};
+
+class TestAgent extends BaseAgent {
+  get name() {
+    return "test-agent";
+  }
+
+  private _writable: Writable | undefined;
+
+  setWritable(writable: Writable | undefined) {
+    this._writable = writable;
+  }
+
+  protected _createChatLogWriteStream(): Writable | undefined {
+    const logDir = this.ctx.chatLogDir;
+    if (!logDir) return undefined;
+    return this._writable;
+  }
+
+  async callChat(messages: ReadonlyArray<{ role: string; content: string }>) {
+    return this.chat(messages as never);
+  }
+}
+
+describe("BaseAgent chat log", () => {
+  let agent: TestAgent;
+
+  beforeEach(() => {
+    vi.spyOn(provider, "chatCompletion").mockResolvedValue({
+      content: "mock response",
+      usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes header line with model and provider info", async () => {
+    const recording = new RecordingWritable();
+    agent = new TestAgent({
+      ...AGENT_CONTEXT_BASE,
+      chatLogDir: "/fake/dir",
+    });
+    agent.setWritable(recording);
+
+    await agent.callChat([{ role: "user", content: "hello" }]);
+
+    const lines = recording.getWritten().split("\n");
+    expect(lines[0]).toMatch(/^\[test-agent\] >>> BEGIN >>>/);
+    expect(lines[0]).toContain("model=test-model");
+    expect(lines[0]).toContain("provider=openai");
+    expect(lines[0]).toContain("messageCount=1");
+  });
+
+  it("writes prompt messages to chat log", async () => {
+    const recording = new RecordingWritable();
+    agent = new TestAgent({
+      ...AGENT_CONTEXT_BASE,
+      chatLogDir: "/fake/dir",
+    });
+    agent.setWritable(recording);
+
+    await agent.callChat([
+      { role: "system", content: "system prompt" },
+      { role: "user", content: "user message" },
+    ]);
+
+    const written = recording.getWritten();
+    expect(written).toContain("PROMPT [system] (13 chars):");
+    expect(written).toContain("system prompt");
+    expect(written).toContain("PROMPT [user] (12 chars):");
+    expect(written).toContain("user message");
+  });
+
+  it("writes response with content and token usage", async () => {
+    const recording = new RecordingWritable();
+    agent = new TestAgent({
+      ...AGENT_CONTEXT_BASE,
+      chatLogDir: "/fake/dir",
+    });
+    agent.setWritable(recording);
+
+    await agent.callChat([{ role: "user", content: "hello" }]);
+
+    const written = recording.getWritten();
+    expect(written).toContain("<<< RESPONSE <<<");
+    expect(written).toContain("mock response");
+    expect(written).toContain("prompt=100");
+    expect(written).toContain("completion=50");
+    expect(written).toContain("total=150");
+    expect(written).toContain("=== END ===");
+  });
+
+  it("ends stream after successful chat", async () => {
+    const recording = new RecordingWritable();
+    const endSpy = vi.spyOn(recording, "end");
+    agent = new TestAgent({
+      ...AGENT_CONTEXT_BASE,
+      chatLogDir: "/fake/dir",
+    });
+    agent.setWritable(recording);
+
+    await agent.callChat([{ role: "user", content: "hello" }]);
+
+    expect(endSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends stream when chat throws", async () => {
+    vi.spyOn(provider, "chatCompletion").mockRejectedValue(new Error("API error"));
+
+    const recording = new RecordingWritable();
+    const endSpy = vi.spyOn(recording, "end");
+    agent = new TestAgent({
+      ...AGENT_CONTEXT_BASE,
+      chatLogDir: "/fake/dir",
+    });
+    agent.setWritable(recording);
+
+    await expect(
+      agent.callChat([{ role: "user", content: "hello" }]),
+    ).rejects.toThrow("API error");
+
+    expect(endSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not write to stream when chatLogDir is not set", async () => {
+    const recording = new RecordingWritable();
+    const writeSpy = vi.spyOn(recording, "write");
+    agent = new TestAgent({
+      ...AGENT_CONTEXT_BASE,
+      // chatLogDir intentionally not set
+    });
+    agent.setWritable(recording);
+
+    const response = await agent.callChat([{ role: "user", content: "hello" }]);
+
+    expect(response.content).toBe("mock response");
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,3 +1,6 @@
+import { createWriteStream, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { Writable } from "node:stream";
 import type { LLMClient, LLMMessage, LLMResponse, OnStreamProgress } from "../llm/provider.js";
 import { chatCompletion } from "../llm/provider.js";
 import { searchWeb, fetchUrl } from "../utils/web-search.js";
@@ -10,6 +13,7 @@ export interface AgentContext {
   readonly bookId?: string;
   readonly logger?: Logger;
   readonly onStreamProgress?: OnStreamProgress;
+  readonly chatLogDir?: string;
 }
 
 export abstract class BaseAgent {
@@ -23,14 +27,58 @@ export abstract class BaseAgent {
     return this.ctx.logger;
   }
 
+  protected _createChatLogWriteStream(): Writable | undefined {
+    const logDir = this.ctx.chatLogDir;
+    if (!logDir) return undefined;
+
+    if (!existsSync(logDir)) {
+      mkdirSync(logDir, { recursive: true });
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const random = Math.random().toString(36).slice(2, 8);
+    const filename = `chat-log-${this.name}-${timestamp}-${random}.log`;
+    return createWriteStream(join(logDir, filename), { encoding: "utf-8" });
+  }
+
   protected async chat(
     messages: ReadonlyArray<LLMMessage>,
     options?: { readonly temperature?: number; readonly maxTokens?: number },
   ): Promise<LLMResponse> {
-    return chatCompletion(this.ctx.client, this.ctx.model, messages, {
-      ...options,
-      onStreamProgress: this.ctx.onStreamProgress,
-    });
+    const chatLogWriteStream = this._createChatLogWriteStream();
+
+    try {
+      const client = this.ctx.client;
+      const model = this.ctx.model;
+      const temperature = options?.temperature ?? client.defaults.temperature;
+      const maxTokens = options?.maxTokens ?? client.defaults.maxTokens;
+      const headerLine = `[${this.name}] >>> BEGIN >>> model=${model} provider=${client.provider} service=${client.service} baseUrl=${client._piModel?.baseUrl ?? "(unknown)"} temperature=${temperature} maxTokens=${maxTokens} messageCount=${messages.length}`;
+
+      if (chatLogWriteStream) {
+        chatLogWriteStream.write(`${headerLine}\n`);
+        for (let i = 0; i < messages.length; i++) {
+          const msg = messages[i];
+          const hdr = `PROMPT [${msg.role}] (${msg.content.length} chars):`;
+          chatLogWriteStream.write(`${hdr}\n${msg.content}\n`);
+          if (i < messages.length - 1) chatLogWriteStream.write("---\n");
+        }
+      }
+
+      const result = await chatCompletion(client, model, messages, {
+        ...options,
+        onStreamProgress: this.ctx.onStreamProgress,
+      });
+
+      const respLine = `[${this.name}] <<< RESPONSE <<< ${result.content.length} chars | tokens: prompt=${result.usage.promptTokens} completion=${result.usage.completionTokens} total=${result.usage.totalTokens}`;
+
+      if (chatLogWriteStream) {
+        chatLogWriteStream.write(`${respLine}\n${result.content}\n=== END ===\n\n`);
+      }
+
+      return result;
+    } finally {
+      chatLogWriteStream?.end();
+    }
   }
 
   /**

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -141,6 +141,7 @@ export const ProjectConfigSchema = z.object({
       retryTemperatureStep: 0.1,
     },
   }),
+  chatLogDirs: z.record(z.string(), z.string()).optional(),
 });
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -231,6 +231,7 @@ export interface PipelineConfig {
   readonly inputGovernanceMode?: InputGovernanceMode;
   readonly logger?: Logger;
   readonly onStreamProgress?: OnStreamProgress;
+  readonly chatLogDirs?: Record<string, string>;
 }
 
 export interface TokenUsageSummary {
@@ -510,6 +511,10 @@ export class PipelineRunner {
         ].join("\n");
   }
 
+  private getChatLogDir(agentName: string): string | undefined {
+    return this.config.chatLogDirs?.[agentName];
+  }
+
   private agentCtx(bookId?: string): AgentContext {
     return {
       client: this.config.client,
@@ -518,6 +523,7 @@ export class PipelineRunner {
       bookId,
       logger: this.config.logger,
       onStreamProgress: this.config.onStreamProgress,
+      chatLogDir: this.getChatLogDir("base"),
     };
   }
 
@@ -578,6 +584,7 @@ export class PipelineRunner {
       bookId,
       logger: this.config.logger?.child(agent),
       onStreamProgress: this.config.onStreamProgress,
+      chatLogDir: this.getChatLogDir(agent),
     };
   }
 


### PR DESCRIPTION
## Summary
- Added feature to log agent chat raw messages as files on disk for debugging/auditing
- Implemented in BaseAgent with file output for all chat completions
- Added tests for the chat logging functionality

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation (optional)
Enables users to inspect raw LLM messages to better understand how context inputs and control docs (e.g., author_intent.md, current_focus.md, style_guide.md) influence the input prompts to AI models.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/utils.ts` | 1 line added |
| `packages/core/src/__tests__/base-agent-chat-log.test.ts` | New test file (175 lines) |
| `packages/core/src/agents/base.ts` | Core logging implementation (+56 lines) |
| `packages/core/src/models/project.ts` | Added `chatLogDir` field to project config |
| `packages/core/src/pipeline/runner.ts` | Config passthrough (+7 lines) |

## Usage (optional)
Configure `chatLogDir` in project config to enable chat logging:
```json
  "chatLogDirs": {
    "writer": "C:\\my-novel\\.logs\\writer",
    "planner": "C:\\my-novel\\.logs\\planner"
  }
```
## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all existing + new tests)
- [x] Manual verification: 
1. Set chatLogDirs prop in inkos.json for writer agent and planner agent
2. Run plan chapter or draft command
3. Verify new log files are created under configured path

## Breaking changes (optional)
N/A
