### PR TITLE
fix(providers): support both /v1/models and /models paths for custom endpoints

### DIFF
--- a/packages/core/src/llm/providers/verify.ts
+++ b/packages/core/src/llm/providers/verify.ts
@@ -35,11 +35,22 @@ async function probe(
     return { ok: false, models: 0, error: "无 baseUrl 可探测（custom / newapi / higress 需要用户填）" };
   }
   try {
-    const url = probeBaseUrl.replace(/\/$/, "") + "/models";
-    const res = await fetchWithProxy(url, {
+    // 尝试标准 OpenAI 路径 /v1/models，如果 404 则回退到 /models
+    let url = probeBaseUrl.replace(/\/$/, "") + "/v1/models";
+    let res = await fetchWithProxy(url, {
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(10_000),
     }, proxyUrl);
+    
+    // 如果 /v1/models 404，尝试旧版路径 /models
+    if (!res.ok && res.status === 404) {
+      url = probeBaseUrl.replace(/\/$/, "") + "/models";
+      res = await fetchWithProxy(url, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(10_000),
+      }, proxyUrl);
+    }
+    
     if (!res.ok) {
       return { ok: false, models: 0, error: `HTTP ${res.status} ${res.statusText}` };
     }


### PR DESCRIPTION
## 问题描述

自定义 OpenAI 兼容端点测试连接时，/models 路径返回 404，因为一些服务使用 /v1/models（如 CLIProxyAPI），而另一些使用 /models。

## 解决方案

probe() 函数现在优先尝试 /v1/models，如果返回 404，则回退到 /models。

## 测试验证

- 测试了 CLIProxyAPI (http://localhost:8317) - 使用 /v1/models ✅
- 测试了标准 OpenAI 兼容服务 - 使用 /v1/models ✅
- 向后兼容使用 /models 的服务 ✅