### PR TITLE
feat: 支持 newapi/higress 网关类服务的模型探测和配置

### DIFF
--- a/packages/core/src/utils/effective-llm-config.ts
+++ b/packages/core/src/utils/effective-llm-config.ts
@@ -465,7 +465,8 @@ function modelBelongsToService(service: string, model: string): boolean {
 }
 
 function serviceAllowsUnlistedModels(service: string): boolean {
-  return service === "ollama";
+  // Gateway providers (empty model lists) allow any user-specified model
+  return service === "ollama" || service === "newapi" || service === "higress";
 }
 
 function serviceEntryKey(entry: ServiceConfigEntry): string {

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -32,6 +32,7 @@ import {
   listModelsForService,
   isApiKeyOptionalForEndpoint,
   getAllEndpoints,
+  getEndpoint,
   probeModelsFromUpstream,
   fetchWithProxy,
   chatCompletion,
@@ -521,17 +522,20 @@ async function readEnvConfigStatus(root: string): Promise<EnvConfigStatus> {
 async function resolveConfiguredServiceBaseUrl(root: string, serviceId: string, inlineBaseUrl?: string): Promise<string | undefined> {
   if (inlineBaseUrl?.trim()) return inlineBaseUrl.trim();
 
-  if (!isCustomServiceId(serviceId)) {
-    return resolveServicePreset(serviceId)?.baseUrl;
+  // 预设已有 baseUrl 的非网关服务直接使用预设
+  const presetBaseUrl = resolveServicePreset(serviceId)?.baseUrl;
+  if (presetBaseUrl && !isCustomServiceId(serviceId) && serviceId !== "newapi" && serviceId !== "higress") {
+    return presetBaseUrl;
   }
 
+  // custom/newapi/higress 等网关服务需要查配置文件
   try {
     const config = await loadRawConfig(root);
     const services = normalizeServiceConfig((config.llm as Record<string, unknown> | undefined)?.services);
     const matched = services.find((entry) => serviceConfigKey(entry) === serviceId);
-    return matched?.baseUrl;
+    return matched?.baseUrl || (presetBaseUrl || undefined);
   } catch {
-    return undefined;
+    return presetBaseUrl;
   }
 }
 
@@ -1624,11 +1628,12 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.post("/api/v1/services/:service/test", async (c) => {
     const service = c.req.param("service");
-    const { apiKey, baseUrl, apiFormat, stream } = await c.req.json<{
+    const { apiKey, baseUrl, apiFormat, stream, preferredModel } = await c.req.json<{
       apiKey: string;
       baseUrl?: string;
       apiFormat?: "chat" | "responses";
       stream?: boolean;
+      preferredModel?: string;
     }>();
 
     const resolvedBaseUrl = await resolveConfiguredServiceBaseUrl(root, service, baseUrl);
@@ -1657,6 +1662,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
       baseUrl: resolvedBaseUrl,
       preferredApiFormat: apiFormat,
       preferredStream: stream,
+      preferredModel,
       proxyUrl: typeof llm.proxyUrl === "string" ? llm.proxyUrl : undefined,
     });
 
@@ -1723,6 +1729,8 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.get("/api/v1/services/models", async (c) => {
     const secrets = await loadSecrets(root);
+
+    // Bank endpoints with preset models
     const endpoints = getAllEndpoints()
       .filter((ep) => ep.id !== "custom" && Boolean(secrets.services[ep.id]?.apiKey));
 
@@ -1740,7 +1748,31 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
         })),
     }));
 
-    return c.json({ groups });
+    // Gateway services (newapi, higress): probe live models when baseUrl is configured
+    const gatewayServices = ["newapi", "higress"];
+    const gatewayGroups = await Promise.all(
+      gatewayServices
+        .filter((svc) => Boolean(secrets.services[svc]?.apiKey))
+        .map(async (svc) => {
+          const baseUrl = await resolveConfiguredServiceBaseUrl(root, svc);
+          if (!baseUrl) return null;
+          const ep = getEndpoint(svc);
+          const probed = await probeModelsFromUpstream(baseUrl, secrets.services[svc].apiKey, 10_000);
+          const textModels = filterTextChatModels(probed);
+          return {
+            service: svc,
+            label: ep?.label ?? svc,
+            models: textModels.map((m) => ({
+              id: m.id,
+              name: m.name,
+              ...(m.contextWindow > 0 ? { contextWindow: m.contextWindow } : {}),
+            })),
+          };
+        }),
+    );
+
+    const result = [...groups, ...gatewayGroups.filter((g): g is NonNullable<typeof g> => g !== null)];
+    return c.json({ groups: result });
   });
 
   app.get("/api/v1/services/models/custom", async (c) => {
@@ -1798,10 +1830,12 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     }
 
     // B13: 走 listModelsForService 走 live probe + bank 交叉，返回带元数据的 models
+    // 网关类服务（custom/newapi/higress）baseUrl 为空，需要传 resolvedBaseUrl 才能探测
+    const needsLiveBaseUrl = isCustomServiceId(service) || service === "newapi" || service === "higress";
     const enriched = await listModelsForService(
       isCustomServiceId(service) ? "custom" : service,
       apiKey,
-      isCustomServiceId(service) ? resolvedBaseUrl ?? undefined : undefined,
+      needsLiveBaseUrl ? (resolvedBaseUrl ?? undefined) : undefined,
     );
     const models = filterTextChatModels(enriched).map((m) => ({
       id: m.id,

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -43,6 +43,8 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
 
   const svc = services.find((s) => s.service === serviceId);
   const isCustom = serviceId === "custom" || serviceId.startsWith("custom:");
+  // newapi/higress 等网关类服务也需要填写 Base URL
+  const needsBaseUrl = isCustom || serviceId === "newapi" || serviceId === "higress";
   const persistedCustomName = serviceId.startsWith("custom:") ? decodeURIComponent(serviceId.slice("custom:".length)) : "";
 
   // -- Local form state --
@@ -54,6 +56,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [apiFormat, setApiFormat] = useState<"chat" | "responses">("chat");
   const [stream, setStream] = useState(true);
   const [detectedModel, setDetectedModel] = useState<string>("");
+  const [model, setModel] = useState("");
   const [detectedConfig, setDetectedConfig] = useState<DetectedConfig | null>(null);
   const [verifiedProbe, setVerifiedProbe] = useState<VerifiedProbe | null>(null);
 
@@ -62,18 +65,30 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
 
   useEffect(() => {
     let cancelled = false;
-    void fetchJson<{ services: Array<Record<string, unknown>> }>("/services/config")
+    void fetchJson<Record<string, unknown>>("/services/config")
       .then((data) => {
         if (cancelled) return;
-        const matched = matchServiceConfigEntryForDetail(data.services ?? [], serviceId);
+        const services = (data.services as Array<Record<string, unknown>>) ?? [];
+        const matched = matchServiceConfigEntryForDetail(services, serviceId);
         if (!matched) return;
         if (isCustom) {
           setCustomName(String(matched.name ?? persistedCustomName));
+        }
+        if (needsBaseUrl) {
           setBaseUrl(String(matched.baseUrl ?? ""));
         }
         if (typeof matched.temperature === "number") setTemperature(String(matched.temperature));
         if (matched.apiFormat === "chat" || matched.apiFormat === "responses") setApiFormat(matched.apiFormat);
         if (typeof matched.stream === "boolean") setStream(matched.stream);
+        if (typeof matched.defaultModel === "string") setModel(matched.defaultModel);
+        // Also check top-level defaultModel when service matches
+        if (!matched.defaultModel && typeof data.defaultModel === "string" && data.service === serviceId) {
+          setModel(data.defaultModel as string);
+        }
+        // For non-custom services, check top-level model if service matches
+        if (!isCustom && typeof data.model === "string" && data.service === serviceId) {
+          setModel(data.model as string);
+        }
       })
       .catch(() => {});
     return () => { cancelled = true; };
@@ -119,6 +134,21 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
     svc?.connected,
   ]);
 
+  // Load models on mount for connected services
+  useEffect(() => {
+    if (!svc?.connected) return;
+    let cancelled = false;
+    void fetchJson<{ models: ModelInfo[] }>(`/services/${encodeURIComponent(serviceId)}/models`)
+      .then((data) => {
+        if (cancelled) return;
+        if (data.models?.length > 0) {
+          setStoreModels(effectiveServiceId, data.models);
+        }
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [effectiveServiceId, serviceId, setStoreModels, svc?.connected]);
+
   if (loading) return <DetailSkeleton />;
 
   // -- Derived state --
@@ -133,7 +163,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
       setStatus({ state: "error", message: "请先输入 API Key" });
       return;
     }
-    if (isCustom && !baseUrl.trim()) {
+    if (needsBaseUrl && !baseUrl.trim()) {
       setStatus({ state: "error", message: "请先填写 Base URL" });
       return;
     }
@@ -144,16 +174,17 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         apiKey: trimmedKey,
         apiFormat,
         stream,
-        ...(isCustom ? { baseUrl: baseUrl.trim() } : {}),
+        ...(needsBaseUrl ? { baseUrl: baseUrl.trim() } : {}),
+        ...(model.trim() ? { preferredModel: model.trim() } : {}),
       });
       if (result.ok) {
         const models = result.models ?? [];
         const verifiedApiFormat = result.detected?.apiFormat ?? apiFormat;
         const verifiedStream = typeof result.detected?.stream === "boolean" ? result.detected.stream : stream;
-        const verifiedBaseUrl = isCustom ? (result.detected?.baseUrl ?? baseUrl.trim()) : "";
+        const verifiedBaseUrl = needsBaseUrl ? (result.detected?.baseUrl ?? baseUrl.trim()) : "";
         if (result.detected?.apiFormat) setApiFormat(result.detected.apiFormat);
         if (typeof result.detected?.stream === "boolean") setStream(result.detected.stream);
-        if (isCustom && result.detected?.baseUrl) setBaseUrl(result.detected.baseUrl);
+        if (needsBaseUrl && result.detected?.baseUrl) setBaseUrl(result.detected.baseUrl);
         setDetectedModel(result.selectedModel ?? "");
         setDetectedConfig(result.detected ?? null);
         setVerifiedProbe({
@@ -194,7 +225,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const handleSave = async () => {
     const trimmedKey = apiKey.trim();
     setApiKey(trimmedKey);
-    if (isCustom && !baseUrl.trim()) {
+    if (needsBaseUrl && !baseUrl.trim()) {
       setStatus({ state: "error", message: "请先填写 Base URL" });
       return;
     }
@@ -204,6 +235,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         effectiveServiceId,
         serviceId,
         isCustom,
+        needsBaseUrl,
         resolvedCustomName,
         apiKey: trimmedKey,
         baseUrl,
@@ -216,7 +248,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
       if (result.status.state === "connected") {
         if (result.detectedConfig?.apiFormat) setApiFormat(result.detectedConfig.apiFormat);
         if (typeof result.detectedConfig?.stream === "boolean") setStream(result.detectedConfig.stream);
-        if (isCustom && result.detectedConfig?.baseUrl) setBaseUrl(result.detectedConfig.baseUrl);
+        if (needsBaseUrl && result.detectedConfig?.baseUrl) setBaseUrl(result.detectedConfig.baseUrl);
         setDetectedModel(result.detectedModel);
         setDetectedConfig(result.detectedConfig);
         setStoreModels(effectiveServiceId, result.status.models);
@@ -255,13 +287,15 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
       <ServiceQuickLinks serviceId={serviceId} />
 
       <div className="space-y-5">
-        {/* Custom fields */}
-        {isCustom && (
+        {/* Base URL for gateway services (custom, newapi, higress) */}
+        {needsBaseUrl && (
         <div className="grid grid-cols-2 gap-4">
+            {isCustom && (
             <Field label="服务名称">
               <input type="text" value={customName} onChange={(e) => setCustomName(e.target.value)}
                 placeholder="例如：本地 Ollama" className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm" />
             </Field>
+            )}
             <Field label="Base URL">
               <input type="text" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)}
                 placeholder="https://api.example.com/v1" className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm font-mono" />
@@ -283,6 +317,18 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
             </button>
           </div>
         </Field>
+
+        {/* Model input for gateway services */}
+        {needsBaseUrl && (
+          <Field label="模型名称">
+            <input
+              type="text" value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="例如：gpt-4o、qwen-plus"
+              className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm font-mono"
+            />
+          </Field>
+        )}
 
         {/* Actions + feedback */}
         <div className="flex items-center gap-2">

--- a/packages/studio/src/pages/service-detail-state.ts
+++ b/packages/studio/src/pages/service-detail-state.ts
@@ -47,6 +47,7 @@ export async function probeServiceForDetail(
     readonly apiFormat: "chat" | "responses";
     readonly stream: boolean;
     readonly baseUrl?: string;
+    readonly preferredModel?: string;
   },
   deps?: { readonly fetchJsonImpl?: JsonFetcher },
 ): Promise<ServiceProbeResponse> {
@@ -107,6 +108,7 @@ export async function saveServiceConfig(args: {
   readonly effectiveServiceId: string;
   readonly serviceId: string;
   readonly isCustom: boolean;
+  readonly needsBaseUrl?: boolean;
   readonly resolvedCustomName: string;
   readonly apiKey: string;
   readonly baseUrl: string;
@@ -125,6 +127,7 @@ export async function saveServiceConfig(args: {
   const trimmedKey = args.apiKey.trim();
   const trimmedBaseUrl = args.baseUrl.trim();
 
+  const needsBaseUrl = args.needsBaseUrl ?? args.isCustom;
   if (!trimmedKey && !args.isCustom) {
     return {
       status: { state: "error", message: "请先输入 API Key" },
@@ -132,7 +135,7 @@ export async function saveServiceConfig(args: {
       detectedConfig: null,
     };
   }
-  if (args.isCustom && !trimmedBaseUrl) {
+  if (needsBaseUrl && !trimmedBaseUrl) {
     return {
       status: { state: "error", message: "请先填写 Base URL" },
       detectedModel: "",
@@ -164,7 +167,8 @@ export async function saveServiceConfig(args: {
         apiKey: trimmedKey,
         apiFormat: args.apiFormat,
         stream: args.stream,
-        ...(args.isCustom ? { baseUrl: trimmedBaseUrl } : {}),
+        ...(needsBaseUrl ? { baseUrl: trimmedBaseUrl } : {}),
+        ...(args.detectedModel ? { preferredModel: args.detectedModel } : {}),
       }, { fetchJsonImpl });
     } catch (error) {
       return {
@@ -187,7 +191,7 @@ export async function saveServiceConfig(args: {
   const detectedConfig = probe.detected ?? null;
   const savedApiFormat = detectedConfig?.apiFormat ?? args.apiFormat;
   const savedStream = typeof detectedConfig?.stream === "boolean" ? detectedConfig.stream : args.stream;
-  const savedBaseUrl = args.isCustom ? (detectedConfig?.baseUrl ?? trimmedBaseUrl) : undefined;
+  const savedBaseUrl = needsBaseUrl ? (detectedConfig?.baseUrl ?? trimmedBaseUrl) : undefined;
 
   await fetchJsonImpl(`/services/${encodeURIComponent(args.effectiveServiceId)}/secret`, {
     method: "PUT",
@@ -207,8 +211,8 @@ export async function saveServiceConfig(args: {
           temperature: parseFloat(args.temperature),
           apiFormat: savedApiFormat,
           stream: savedStream,
-          ...(args.isCustom ? {
-            name: args.resolvedCustomName,
+          ...(needsBaseUrl ? {
+            ...(args.isCustom ? { name: args.resolvedCustomName } : {}),
             baseUrl: savedBaseUrl,
           } : {}),
         },


### PR DESCRIPTION
- newapi/higress 网关服务的预设模型列表为空，添加 modelBelongsToService 白名单
- ServiceDetailPage 为网关类服务增加 Base URL 和模型名称输入框
- 保存配置时正确传递网关服务的 baseUrl，解决"未知服务商"错误
- /services/models 接口增加网关类服务的 live probe，使首页模型选择器可用
- 页面加载时自动获取已连接服务的模型列表

## Summary
<!-- 1-3 bullet points: what changed and why -->

-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation (optional)
<!-- Why this change is needed. Link issues if applicable. Closes #xxx -->

## Changes
<!-- File-level change list: what each file does -->

| File | Change |
|------|--------|
| | |

## Usage (optional)
<!-- Code snippets, CLI examples, or config samples showing how to use the new feature -->

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (all existing + new tests)
- [ ] Manual verification: <!-- describe manual test steps -->

## Breaking changes (optional)
<!-- List any breaking changes to public API, CLI flags, config format, etc. -->
