### PR TITLE
feat: add codex auth support

### DIFF
--- a/packages/cli/src/__tests__/tui-setup-i18n.test.ts
+++ b/packages/cli/src/__tests__/tui-setup-i18n.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { buildAutoInitMessages, buildInteractiveSetupCopy, resolveSetupProvider, resolveSetupService } from "../tui/setup.js";
+import {
+  buildAutoInitMessages,
+  buildInteractiveSetupCopy,
+  buildSetupEnvContent,
+  hasUsableLlmEnv,
+  resolveSetupBaseUrl,
+  resolveSetupModel,
+  resolveSetupProvider,
+  resolveSetupService,
+} from "../tui/setup.js";
 
 describe("tui setup i18n", () => {
   it("builds Chinese setup copy by default", () => {
@@ -27,5 +36,25 @@ describe("tui setup i18n", () => {
     expect(resolveSetupProvider("kkaiapi", "https://api.kkaiapi.com/v1")).toBe("openai");
     expect(resolveSetupService("kkaiapi", "")).toBe("kkaiapi");
     expect(resolveSetupService("openai", "https://api.kkaiapi.com/v1")).toBe("kkaiapi");
+  });
+
+  it("configures Codex OAuth as a keyless service", () => {
+    expect(resolveSetupProvider("codexOAuth", "")).toBe("openai");
+    expect(resolveSetupService("codexOAuth", "")).toBe("codexOAuth");
+    expect(resolveSetupBaseUrl("codexOAuth", "")).toBe("https://chatgpt.com/backend-api/codex");
+    expect(resolveSetupModel("codexOAuth", "")).toBe("gpt-5.5");
+
+    const env = buildSetupEnvContent({
+      provider: "codexOAuth",
+      baseUrl: "",
+      apiKey: "sk-ignored",
+      model: "",
+    });
+    expect(env).toContain("INKOS_LLM_SERVICE=codexOAuth");
+    expect(env).toContain("INKOS_LLM_BASE_URL=https://chatgpt.com/backend-api/codex");
+    expect(env).toContain("INKOS_LLM_MODEL=gpt-5.5");
+    expect(env).toContain("INKOS_LLM_API_FORMAT=responses");
+    expect(env).not.toContain("INKOS_LLM_API_KEY");
+    expect(hasUsableLlmEnv(env)).toBe(true);
   });
 });

--- a/packages/cli/src/tui/setup.ts
+++ b/packages/cli/src/tui/setup.ts
@@ -3,6 +3,8 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import readline from "node:readline/promises";
+import { parse as parseEnv } from "dotenv";
+import { CODEX_OAUTH_BASE_URL, CODEX_OAUTH_SERVICE_ID, getCodexOAuthStatus } from "@actalk/inkos-core";
 import {
   c, bold, dim, italic,
   cyan, green, yellow, gray, red,
@@ -12,18 +14,25 @@ import { resolveTuiLocale, type TuiLocale } from "./i18n.js";
 import { GLOBAL_ENV_PATH, loadConfig } from "../utils.js";
 import { ensureProjectGitignore } from "../project-bootstrap.js";
 
-const PROVIDERS = ["openai", "anthropic", "kkaiapi", "custom"] as const;
+const PROVIDERS = ["openai", "anthropic", "kkaiapi", "codexOAuth", "custom"] as const;
 const KKAIAPI_BASE_URL = "https://api.kkaiapi.com/v1";
+const CODEX_OAUTH_DEFAULT_MODEL = "gpt-5.5";
 type SetupProvider = typeof PROVIDERS[number];
 type RuntimeProvider = "openai" | "anthropic" | "custom";
 
+function normalizeSetupProvider(provider: string): SetupProvider {
+  const normalized = provider.trim().toLowerCase();
+  return PROVIDERS.find((candidate) => candidate.toLowerCase() === normalized) ?? "openai";
+}
+
 export function resolveSetupProvider(provider: string, baseUrl: string): RuntimeProvider {
-  const normalizedProvider = PROVIDERS.includes(provider.trim() as SetupProvider)
-    ? provider.trim() as SetupProvider
-    : "openai";
+  const normalizedProvider = normalizeSetupProvider(provider);
   const normalizedUrl = baseUrl.trim().toLowerCase();
   if (normalizedUrl.includes("api.kimi.com/coding")) {
     return "anthropic";
+  }
+  if (normalizedProvider === CODEX_OAUTH_SERVICE_ID) {
+    return "openai";
   }
   if (normalizedProvider === "anthropic" || normalizedProvider === "custom") {
     return normalizedProvider;
@@ -34,10 +43,67 @@ export function resolveSetupProvider(provider: string, baseUrl: string): Runtime
 export function resolveSetupService(provider: string, baseUrl: string): string | undefined {
   const normalizedProvider = provider.trim().toLowerCase();
   const normalizedUrl = baseUrl.trim().toLowerCase();
+  if (normalizedProvider === CODEX_OAUTH_SERVICE_ID.toLowerCase() || normalizedUrl.includes("chatgpt.com/backend-api/codex")) {
+    return CODEX_OAUTH_SERVICE_ID;
+  }
   if (normalizedProvider === "kkaiapi" || normalizedUrl.includes("api.kkaiapi.com")) {
     return "kkaiapi";
   }
   return undefined;
+}
+
+export function resolveSetupBaseUrl(provider: string, baseUrl: string): string {
+  const normalizedProvider = normalizeSetupProvider(provider);
+  if (normalizedProvider === CODEX_OAUTH_SERVICE_ID) {
+    return CODEX_OAUTH_BASE_URL;
+  }
+  if (normalizedProvider === "kkaiapi") {
+    return baseUrl.trim() || KKAIAPI_BASE_URL;
+  }
+  return baseUrl.trim();
+}
+
+export function resolveSetupModel(provider: string, model: string): string {
+  if (normalizeSetupProvider(provider) === CODEX_OAUTH_SERVICE_ID) {
+    return model.trim() || CODEX_OAUTH_DEFAULT_MODEL;
+  }
+  return model.trim();
+}
+
+export function buildSetupEnvContent(options: {
+  readonly provider: string;
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly model: string;
+}): string {
+  const effectiveBaseUrl = resolveSetupBaseUrl(options.provider, options.baseUrl);
+  const finalProvider = resolveSetupProvider(options.provider, effectiveBaseUrl);
+  const finalService = resolveSetupService(options.provider, effectiveBaseUrl);
+  const isCodexOAuth = finalService === CODEX_OAUTH_SERVICE_ID;
+  const envLines = [
+    `INKOS_LLM_PROVIDER=${finalProvider}`,
+    ...(finalService ? [`INKOS_LLM_SERVICE=${finalService}`] : []),
+    `INKOS_LLM_BASE_URL=${effectiveBaseUrl}`,
+    ...(isCodexOAuth ? [] : [`INKOS_LLM_API_KEY=${options.apiKey.trim()}`]),
+    `INKOS_LLM_MODEL=${resolveSetupModel(options.provider, options.model)}`,
+    ...(isCodexOAuth ? [
+      "INKOS_LLM_API_FORMAT=responses",
+      "INKOS_LLM_STREAM=true",
+    ] : []),
+  ];
+  return envLines.join("\n");
+}
+
+export function hasUsableLlmEnv(content: string): boolean {
+  const env = parseEnv(content);
+  const apiKey = env.INKOS_LLM_API_KEY?.trim() ?? "";
+  if (apiKey.length > 0 && !apiKey.includes("your-api-key")) {
+    return true;
+  }
+
+  const service = env.INKOS_LLM_SERVICE?.trim().toLowerCase();
+  const model = env.INKOS_LLM_MODEL?.trim() ?? "";
+  return service === CODEX_OAUTH_SERVICE_ID.toLowerCase() && model.length > 0;
 }
 
 interface SetupResult {
@@ -87,9 +153,9 @@ export function buildInteractiveSetupCopy(locale: TuiLocale): InteractiveSetupCo
         scope: "Save scope",
       },
       hints: {
-        provider: "openai / anthropic / kkaiapi / custom (OpenAI-compatible proxy)",
+        provider: "openai / anthropic / kkaiapi / codexOAuth / custom (OpenAI-compatible proxy)",
         baseUrl: "Your API endpoint",
-        apiKey: "Paste the API key for the selected provider.",
+        apiKey: "Paste an API key, or use the local Codex ChatGPT OAuth login for codexOAuth.",
         model: "e.g. gpt-4o, claude-sonnet-4-20250514, deepseek-chat",
         scope: "global = all projects, project = this directory only",
       },
@@ -117,9 +183,9 @@ export function buildInteractiveSetupCopy(locale: TuiLocale): InteractiveSetupCo
       scope: "保存范围",
     },
     hints: {
-      provider: "openai / anthropic / kkaiapi / custom（兼容 OpenAI 的代理）",
+      provider: "openai / anthropic / kkaiapi / codexOAuth / custom（兼容 OpenAI 的代理）",
       baseUrl: "你的 API 入口地址",
-      apiKey: "粘贴所选服务商的 API Key",
+      apiKey: "粘贴 API Key；codexOAuth 使用本机 Codex ChatGPT OAuth 登录",
       model: "例如 gpt-5.4、claude-sonnet-4-20250514、deepseek-chat",
       scope: "global = 所有项目，project = 仅当前目录",
     },
@@ -189,35 +255,45 @@ export async function interactiveLlmSetup(
     console.log(`  ${c("1", cyan)}  ${c(copy.steps.provider, gray)}`);
     console.log(c(`     ${copy.hints.provider}`, dim));
     const providerInput = await rl.question(`     ${c("❯", cyan)} `);
-    const provider = PROVIDERS.includes(providerInput.trim() as SetupProvider)
-      ? providerInput.trim() as SetupProvider
-      : copy.defaults.provider as SetupProvider;
-    const providerDefaultBaseUrl = provider === "kkaiapi" ? KKAIAPI_BASE_URL : copy.defaults.baseUrl;
+    const provider = providerInput.trim() ? normalizeSetupProvider(providerInput) : copy.defaults.provider as SetupProvider;
+    const isCodexOAuth = provider === CODEX_OAUTH_SERVICE_ID;
+    const providerDefaultBaseUrl = isCodexOAuth ? CODEX_OAUTH_BASE_URL : provider === "kkaiapi" ? KKAIAPI_BASE_URL : copy.defaults.baseUrl;
     console.log(`     ${c("✓", brightGreen)} ${provider}`);
     console.log();
 
     // Base URL
     console.log(`  ${c("2", cyan)}  ${c(copy.steps.baseUrl, gray)}`);
+    if (isCodexOAuth) {
+      console.log(c(`     ${CODEX_OAUTH_BASE_URL}`, dim));
+    }
     console.log(c(`     ${copy.hints.baseUrl}`, dim));
-    const baseUrl = await rl.question(`     ${c("❯", cyan)} `);
-    console.log(`     ${c("✓", brightGreen)} ${baseUrl.trim() || providerDefaultBaseUrl}`);
+    const baseUrl = isCodexOAuth ? "" : await rl.question(`     ${c("❯", cyan)} `);
+    console.log(`     ${c("✓", brightGreen)} ${resolveSetupBaseUrl(provider, baseUrl) || providerDefaultBaseUrl}`);
     console.log();
 
     // API Key
     console.log(`  ${c("3", cyan)}  ${c(copy.steps.apiKey, gray)}`);
     console.log(c(`     ${copy.hints.apiKey}`, dim));
-    const apiKey = await rl.question(`     ${c("❯", cyan)} `);
-    const maskedKey = apiKey.trim().length > 8
-      ? apiKey.trim().slice(0, 4) + "···" + apiKey.trim().slice(-4)
-      : "···";
-    console.log(`     ${c("✓", brightGreen)} ${maskedKey}`);
+    const apiKey = isCodexOAuth ? "" : await rl.question(`     ${c("❯", cyan)} `);
+    if (isCodexOAuth) {
+      const status = await getCodexOAuthStatus();
+      const statusLabel = status.connected
+        ? status.accountId ? `Codex OAuth ${status.accountId}` : "Codex OAuth"
+        : status.message ?? "Run `codex login` and choose ChatGPT.";
+      console.log(`     ${c(status.connected ? "✓" : "!", status.connected ? brightGreen : yellow)} ${statusLabel}`);
+    } else {
+      const maskedKey = apiKey.trim().length > 8
+        ? apiKey.trim().slice(0, 4) + "···" + apiKey.trim().slice(-4)
+        : "···";
+      console.log(`     ${c("✓", brightGreen)} ${maskedKey}`);
+    }
     console.log();
 
     // Model
     console.log(`  ${c("4", cyan)}  ${c(copy.steps.model, gray)}`);
     console.log(c(`     ${copy.hints.model}`, dim));
-    const model = await rl.question(`     ${c("❯", cyan)} `);
-    console.log(`     ${c("✓", brightGreen)} ${model.trim()}`);
+    const model = await rl.question(`     ${c("❯", cyan)} ${isCodexOAuth ? c(`[${CODEX_OAUTH_DEFAULT_MODEL}]`, dim) + " " : ""}`);
+    console.log(`     ${c("✓", brightGreen)} ${resolveSetupModel(provider, model)}`);
     console.log();
 
     // Scope
@@ -225,17 +301,7 @@ export async function interactiveLlmSetup(
     console.log(c(`     ${copy.hints.scope}`, dim));
     const scope = await rl.question(`     ${c("❯", cyan)} ${c(copy.defaults.scope, dim)} `);
     const useGlobal = scope.trim().toLowerCase() !== "project";
-    const effectiveBaseUrl = baseUrl.trim() || (provider === "kkaiapi" ? providerDefaultBaseUrl : "");
-    const finalProvider = resolveSetupProvider(provider, effectiveBaseUrl);
-    const finalService = resolveSetupService(provider, effectiveBaseUrl);
-
-    const envContent = [
-      `INKOS_LLM_PROVIDER=${finalProvider}`,
-      ...(finalService ? [`INKOS_LLM_SERVICE=${finalService}`] : []),
-      `INKOS_LLM_BASE_URL=${effectiveBaseUrl}`,
-      `INKOS_LLM_API_KEY=${apiKey.trim()}`,
-      `INKOS_LLM_MODEL=${model.trim()}`,
-    ].join("\n");
+    const envContent = buildSetupEnvContent({ provider, baseUrl, apiKey, model });
 
     if (useGlobal) {
       const globalDir = join(GLOBAL_ENV_PATH, "..");
@@ -322,8 +388,7 @@ async function hasGlobalConfig(): Promise<boolean> {
 async function checkEnvForKey(envPath: string): Promise<boolean> {
   try {
     const content = await readFile(envPath, "utf-8");
-    const match = content.match(/INKOS_LLM_API_KEY=(.+)/);
-    return !!match && match[1]!.trim().length > 0 && !match[1]!.includes("your-api-key");
+    return hasUsableLlmEnv(content);
   } catch {
     return false;
   }
@@ -371,14 +436,11 @@ export async function detectProjectLanguage(projectRoot: string): Promise<string
 async function parseEnvModel(envPath: string): Promise<ModelInfo | undefined> {
   try {
     const content = await readFile(envPath, "utf-8");
-    const get = (key: string) => {
-      const m = content.match(new RegExp(`^${key}=(.+)$`, "m"));
-      return m?.[1]?.trim() ?? "";
-    };
-    const key = get("INKOS_LLM_API_KEY");
-    if (!key || key.includes("your-api-key")) return undefined;
+    const env = parseEnv(content);
+    if (!hasUsableLlmEnv(content)) return undefined;
+    const get = (key: string) => env[key]?.trim() ?? "";
     return {
-      provider: get("INKOS_LLM_PROVIDER") || "openai",
+      provider: get("INKOS_LLM_SERVICE") || get("INKOS_LLM_PROVIDER") || "openai",
       model: get("INKOS_LLM_MODEL") || "unknown",
       baseUrl: get("INKOS_LLM_BASE_URL") || "",
     };

--- a/packages/core/src/__tests__/agent-session.test.ts
+++ b/packages/core/src/__tests__/agent-session.test.ts
@@ -12,9 +12,15 @@ const EMPTY_USAGE = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
+function jwtWithExp(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `${header}.${payload}.`;
+}
+
 const { agentInstances, streamCalls, heldStreamCompletions, heldStreamWaiters } = vi.hoisted(() => ({
   agentInstances: [] as any[],
-  streamCalls: [] as Array<{ model: any; context: any }>,
+  streamCalls: [] as Array<{ model: any; context: any; options?: { apiKey?: string; headers?: Record<string, string> } }>,
   heldStreamCompletions: [] as Array<() => void>,
   heldStreamWaiters: [] as Array<() => void>,
 }));
@@ -67,8 +73,15 @@ vi.mock("@mariozechner/pi-ai", async () => {
     };
   }
 
-  const streamSimple = vi.fn((model: any, context: any) => {
-    streamCalls.push({ model: clone(model), context: clone(context) });
+  const streamSimple = vi.fn((model: any, context: any, options?: { apiKey?: string; headers?: Record<string, string> }) => {
+    streamCalls.push({
+      model: clone(model),
+      context: clone(context),
+      options: {
+        ...(options?.apiKey ? { apiKey: options.apiKey } : {}),
+        ...(options?.headers ? { headers: clone(options.headers) as Record<string, string> } : {}),
+      },
+    });
     const stream = actual.createAssistantMessageEventStream();
     const last = context.messages.at(-1);
     const prompt = lastVisibleUserText(context.messages);
@@ -172,12 +185,58 @@ describe("runAgentSession cache — bookId switch", () => {
 
   afterEach(async () => {
     evictAgentCache("s1");
+    evictAgentCache("s-codex-oauth");
     evictAgentCache("s-cache-seq");
     evictAgentCache("s-error");
     evictAgentCache("s-project-root-cache");
     evictAgentCache("s-interleave-seq");
     await rm(projectRoot, { recursive: true, force: true });
     if (otherProjectRoot) await rm(otherProjectRoot, { recursive: true, force: true });
+  });
+
+  it("passes Codex OAuth runtime credentials to pi-agent sessions", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "inkos-agent-codex-home-"));
+    const previousCodexHome = process.env.CODEX_HOME;
+    const accessToken = jwtWithExp(2_000_000_000);
+    try {
+      process.env.CODEX_HOME = codexHome;
+      await writeFile(join(codexHome, "auth.json"), JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: accessToken,
+          account_id: "acct_codex",
+          id_token: jwtWithExp(2_000_000_000),
+          refresh_token: "refresh",
+        },
+      }));
+      const model = {
+        provider: "openai-codex",
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 272_000,
+        maxTokens: 272_000,
+      } as any;
+      const pipeline = {} as any;
+
+      await runAgentSession(
+        { sessionId: "s-codex-oauth", bookId: null, language: "zh", pipeline, projectRoot, model },
+        "hi",
+      );
+
+      expect(streamCalls.at(-1)?.options?.apiKey).toBe(accessToken);
+      expect(streamCalls.at(-1)?.model.headers).toMatchObject({
+        "ChatGPT-Account-ID": "acct_codex",
+      });
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it("rebuilds Agent when bookId changes for same sessionId", async () => {

--- a/packages/core/src/__tests__/codex-oauth.test.ts
+++ b/packages/core/src/__tests__/codex-oauth.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildCodexOAuthHeaders,
+  getCodexOAuthStatus,
+  listCodexOAuthModels,
+} from "../llm/codex-oauth.js";
+
+function jwtWithExp(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `${header}.${payload}.`;
+}
+
+describe("Codex OAuth runtime auth", () => {
+  it("reads ChatGPT OAuth status from CODEX_HOME auth.json", async () => {
+    const root = await mkdtemp(join(tmpdir(), "inkos-codex-home-"));
+    try {
+      await mkdir(root, { recursive: true });
+      await writeFile(join(root, "auth.json"), JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: jwtWithExp(2_000_000_000),
+          account_id: "acct_123",
+          id_token: jwtWithExp(2_000_000_000),
+          refresh_token: "refresh",
+        },
+        last_refresh: "2026-05-26T03:23:48Z",
+      }));
+
+      const status = await getCodexOAuthStatus({ codexHome: root, now: new Date("2026-05-27T00:00:00Z") });
+
+      expect(status).toMatchObject({
+        connected: true,
+        authMode: "chatgpt",
+        accountId: "acct_123",
+        authPath: join(root, "auth.json"),
+      });
+      expect(status.expiresAt).toBe("2033-05-18T03:33:20.000Z");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("builds bearer and ChatGPT account headers without exposing tokens in status", async () => {
+    const root = await mkdtemp(join(tmpdir(), "inkos-codex-home-"));
+    try {
+      await mkdir(root, { recursive: true });
+      await writeFile(join(root, "auth.json"), JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: jwtWithExp(2_000_000_000),
+          account_id: "acct_456",
+          id_token: jwtWithExp(2_000_000_000),
+          refresh_token: "refresh",
+        },
+      }));
+
+      await expect(buildCodexOAuthHeaders({ codexHome: root })).resolves.toEqual({
+        Authorization: expect.stringMatching(/^Bearer /),
+        "ChatGPT-Account-ID": "acct_456",
+      });
+
+      await expect(getCodexOAuthStatus({ codexHome: root })).resolves.not.toHaveProperty("accessToken");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lists models from the Codex backend and maps slug metadata", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      expect(url).toBe("https://chatgpt.com/backend-api/codex/models?client_version=0.134.0");
+      expect(init?.headers).toMatchObject({
+        Authorization: expect.stringMatching(/^Bearer /),
+        "ChatGPT-Account-ID": "acct_789",
+      });
+      return new Response(JSON.stringify({
+        models: [
+          { slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 272000, max_context_window: 272000, supported_in_api: true, visibility: "list" },
+          { slug: "hidden-model", display_name: "Hidden", supported_in_api: false, visibility: "hidden" },
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const root = await mkdtemp(join(tmpdir(), "inkos-codex-home-"));
+    try {
+      await mkdir(root, { recursive: true });
+      await writeFile(join(root, "auth.json"), JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: jwtWithExp(2_000_000_000),
+          account_id: "acct_789",
+          id_token: jwtWithExp(2_000_000_000),
+          refresh_token: "refresh",
+        },
+      }));
+
+      await expect(listCodexOAuthModels({ codexHome: root, fetchImpl, codexVersion: "0.134.0" })).resolves.toEqual([
+        { id: "gpt-5.5", name: "GPT-5.5", contextWindow: 272000, maxOutput: 272000 },
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/__tests__/provider.test.ts
+++ b/packages/core/src/__tests__/provider.test.ts
@@ -233,6 +233,48 @@ describe("chatCompletion via pi-ai", () => {
     expect(opts.maxTokens).toBe(256);
   });
 
+  it("omits temperature for Codex Responses transport", async () => {
+    mockStreamSimple.mockReturnValue(makeTextStream("ok"));
+
+    const client = makeClient(0.5, {
+      service: "codexOAuth",
+      _piModel: {
+        ...MOCK_PI_MODEL,
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      },
+    });
+    await chatCompletion(client, "gpt-5.5", [{ role: "user", content: "hi" }], {
+      temperature: 0.8,
+      maxTokens: 256,
+    });
+
+    const opts = mockStreamSimple.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty("temperature");
+    expect(opts.maxTokens).toBe(256);
+  });
+
+  it("adds default instructions for Codex Responses transport when no system prompt is present", async () => {
+    mockStreamSimple.mockReturnValue(makeTextStream("ok"));
+
+    const client = makeClient(0.5, {
+      service: "codexOAuth",
+      _piModel: {
+        ...MOCK_PI_MODEL,
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      },
+    });
+    await chatCompletion(client, "gpt-5.5", [{ role: "user", content: "hi" }], {
+      maxTokens: 16,
+    });
+
+    const context = mockStreamSimple.mock.calls[0]?.[1] as { systemPrompt?: string };
+    expect(context.systemPrompt).toBe("You are a helpful assistant.");
+  });
+
   it("drops non-ByteString headers before calling pi-ai", async () => {
     mockStreamSimple.mockReturnValue(makeTextStream("ok"));
 
@@ -949,5 +991,22 @@ describe("createLLMClient with providers lookup", () => {
     expect(client._piModel?.provider).toBe("google");
     expect(client._piModel?.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
     expect(client._piModel?.compat).toBeUndefined();
+  });
+
+  it("Codex OAuth uses the native openai-codex responses transport", async () => {
+    const { createLLMClient } = await import("../llm/provider.js");
+    const { LLMConfigSchema } = await import("../models/project.js");
+    const client = createLLMClient(LLMConfigSchema.parse({
+      provider: "openai",
+      service: "codexOAuth",
+      model: "gpt-5.5",
+      apiKey: "",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      apiFormat: "responses",
+      stream: true,
+    }));
+    expect(client._piModel?.api).toBe("openai-codex-responses");
+    expect(client._piModel?.provider).toBe("openai-codex");
+    expect(client._piModel?.baseUrl).toBe("https://chatgpt.com/backend-api/codex");
   });
 });

--- a/packages/core/src/__tests__/providers-group.test.ts
+++ b/packages/core/src/__tests__/providers-group.test.ts
@@ -20,7 +20,7 @@ describe("InkosEndpoint.group", () => {
     expect(byGroup("aggregator")).toEqual([
       "kkaiapi", "newapi", "openrouter", "siliconcloud",
     ].sort());
-    expect(byGroup("local")).toEqual(["githubCopilot", "ollama"].sort());
+    expect(byGroup("local")).toEqual(["codexOAuth", "githubCopilot", "ollama"].sort());
     expect(byGroup("codingPlan")).toEqual([
       "astronCodingPlan", "bailianCodingPlan", "glmCodingPlan", "kimiCodingPlan", "kimicode",
       "minimaxCodingPlan", "opencodeCodingPlan", "volcengineCodingPlan",

--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -7,7 +7,7 @@ describe("providers structural integrity", () => {
     for (const p of getAllEndpoints()) {
       expect(p.id).toBeTruthy();
       expect(p.label).toBeTruthy();
-      expect(p.api).toMatch(/^(openai-completions|openai-responses|anthropic-messages|google-generative-ai)$/);
+      expect(p.api).toMatch(/^(openai-completions|openai-responses|openai-codex-responses|anthropic-messages|google-generative-ai)$/);
       // gateway/anchor provider 允许 baseUrl 为空（由用户填）
       if (gatewayProviders.has(p.id)) {
         expect(typeof p.baseUrl).toBe("string");
@@ -110,7 +110,7 @@ describe("providers structural integrity", () => {
 
   it("B4：海外/本地/自定义/聚合/GH 全部收录（8 个）", () => {
     const ids = getAllEndpoints().map((p) => p.id);
-    for (const id of ["ollama", "openrouter", "custom", "mistral", "xai", "newapi", "githubCopilot", "kkaiapi"]) {
+    for (const id of ["ollama", "openrouter", "custom", "mistral", "xai", "newapi", "githubCopilot", "kkaiapi", "codexOAuth"]) {
       expect(ids).toContain(id);
     }
   });
@@ -120,9 +120,9 @@ describe("providers structural integrity", () => {
     expect(getEndpoint("newapi")?.baseUrl).toBe("");
   });
 
-  it("B4：总 provider 数 = 30（不含 CodingPlan 分组，R5 删 qwen / higress 且精简聚合入口后）", () => {
+  it("B4：总 provider 数 = 31（不含 CodingPlan 分组，R5 删 qwen / higress 且精简聚合入口后）", () => {
     const nonCoding = getAllEndpoints().filter((p) => p.group !== "codingPlan");
-    expect(nonCoding.length).toBe(30);
+    expect(nonCoding.length).toBe(31);
   });
 
   it("B6：CodingPlan 8 个 provider 全部收录", () => {
@@ -136,8 +136,8 @@ describe("providers structural integrity", () => {
     }
   });
 
-  it("B6：总 provider 数 = 38 (30 base + 8 CodingPlan)", () => {
-    expect(getAllEndpoints().length).toBe(38);
+  it("B6：总 provider 数 = 39 (31 base + 8 CodingPlan)", () => {
+    expect(getAllEndpoints().length).toBe(39);
   });
 
   it("B6：CodingPlan provider 都走 anthropic-messages", () => {

--- a/packages/core/src/__tests__/service-resolver.test.ts
+++ b/packages/core/src/__tests__/service-resolver.test.ts
@@ -156,6 +156,20 @@ describe("resolveServiceModel", () => {
     expect(result.model.baseUrl).toBe("http://localhost:11434/v1");
   });
 
+  it("resolves Codex OAuth models without a project API key", async () => {
+    const result = await resolveServiceModel(
+      "codexOAuth",
+      "gpt-5.5",
+      root,
+    );
+
+    expect(result.apiKey).toBe("");
+    expect(result.model.id).toBe("gpt-5.5");
+    expect(result.model.api).toBe("openai-codex-responses");
+    expect(result.model.provider).toBe("openai-codex");
+    expect(result.model.baseUrl).toBe("https://chatgpt.com/backend-api/codex");
+  });
+
   it("resolves local custom OpenAI-compatible services without an API key", async () => {
     const result = await resolveServiceModel(
       "custom:LocalProxy",

--- a/packages/core/src/agent/agent-session.ts
+++ b/packages/core/src/agent/agent-session.ts
@@ -28,6 +28,7 @@ import {
 } from "../interaction/session-transcript-restore.js";
 import type { TranscriptEvent, TranscriptRole } from "../interaction/session-transcript-schema.js";
 import { assertSafeBookId } from "../utils/book-id.js";
+import { CODEX_OAUTH_BASE_URL, buildCodexOAuthHeaders } from "../llm/codex-oauth.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -142,7 +143,38 @@ function agentModelIdentity(model: Model<Api>): string {
     model.provider,
     model.baseUrl ?? "",
     model.id,
+    JSON.stringify(model.headers ?? {}),
   ].join("::");
+}
+
+function isCodexOAuthModel(model: Model<Api>): boolean {
+  return (model.baseUrl ?? "").replace(/\/+$/u, "") === CODEX_OAUTH_BASE_URL;
+}
+
+async function applyAgentRuntimeAuth(
+  model: Model<Api>,
+  configuredApiKey: string | undefined,
+): Promise<{ model: Model<Api>; apiKey: string | undefined }> {
+  if (!isCodexOAuthModel(model)) {
+    return { model, apiKey: configuredApiKey };
+  }
+
+  const headers = await buildCodexOAuthHeaders();
+  const authorization = headers.Authorization ?? "";
+  const apiKey = authorization.replace(/^Bearer\s+/i, "");
+  const runtimeHeaders = { ...headers };
+  delete runtimeHeaders.Authorization;
+
+  return {
+    apiKey,
+    model: {
+      ...model,
+      headers: {
+        ...(model.headers ?? {}),
+        ...runtimeHeaders,
+      },
+    },
+  };
 }
 
 function sessionQueueKey(projectRoot: string, sessionId: string): string {
@@ -520,7 +552,10 @@ async function runAgentSessionUnlocked(
   // skipped) and we don't want that to (a) throw in path.join or (b) trigger
   // a spurious cache eviction because `null !== undefined`.
   const bookId: string | null = config.bookId ? assertSafeBookId(config.bookId) : null;
-  const model = resolveModel(config.model);
+  const baseModel = resolveModel(config.model);
+  const runtimeAuth = await applyAgentRuntimeAuth(baseModel, config.apiKey);
+  const model = runtimeAuth.model;
+  const effectiveApiKey = runtimeAuth.apiKey;
   const requestedModelIdentity = agentModelIdentity(model);
   const allowSystemFileRead = config.allowSystemFileRead ?? envFlagEnabled(process.env.INKOS_AGENT_ALLOW_SYSTEM_READ, false);
   const cacheKey = agentCacheKey(projectRoot, sessionId);
@@ -539,7 +574,7 @@ async function runAgentSessionUnlocked(
     const projectRootChanged = cached.projectRoot !== projectRoot;
     const bookChanged = cached.bookId !== bookId;
     const languageChanged = cached.language !== language;
-    const apiKeyChanged = cached.apiKey !== config.apiKey;
+    const apiKeyChanged = cached.apiKey !== effectiveApiKey;
     const readPermissionChanged = cached.allowSystemFileRead !== allowSystemFileRead;
     const transcriptChanged = cached.lastCommittedSeq !== currentCommittedSeq;
 
@@ -578,7 +613,7 @@ async function runAgentSessionUnlocked(
       convertToLlm: (messages) => convertAgentMessagesForModel(messages, model),
       streamFn: streamSimple,
       getApiKey: (provider: string) => {
-        if (config.apiKey) return config.apiKey;
+        if (effectiveApiKey) return effectiveApiKey;
         return getEnvApiKey(provider);
       },
     });
@@ -590,7 +625,7 @@ async function runAgentSessionUnlocked(
       bookId,
       language,
       modelIdentity: requestedModelIdentity,
-      apiKey: config.apiKey,
+      apiKey: effectiveApiKey,
       allowSystemFileRead,
       lastCommittedSeq: currentCommittedSeq ?? await latestCommittedSeq(projectRoot, sessionId),
       lastActive: Date.now(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -273,6 +273,16 @@ export {
 export { resolveServiceModel, type ResolvedModel } from "./llm/service-resolver.js";
 export { loadSecrets, saveSecrets, getServiceApiKey, type SecretsFile } from "./llm/secrets.js";
 export {
+  CODEX_OAUTH_BASE_URL,
+  CODEX_OAUTH_SERVICE_ID,
+  buildCodexOAuthHeaders,
+  getCodexOAuthStatus,
+  isCodexOAuthService,
+  listCodexOAuthModels,
+  type CodexOAuthModelInfo,
+  type CodexOAuthStatus,
+} from "./llm/codex-oauth.js";
+export {
   COVER_PROVIDER_PRESETS,
   coverSecretKey,
   resolveCoverProviderPreset,

--- a/packages/core/src/llm/codex-oauth.ts
+++ b/packages/core/src/llm/codex-oauth.ts
@@ -1,0 +1,229 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const CODEX_OAUTH_SERVICE_ID = "codexOAuth";
+export const CODEX_OAUTH_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const DEFAULT_CODEX_VERSION = "0.134.0";
+
+interface CodexAuthJson {
+  readonly auth_mode?: unknown;
+  readonly tokens?: {
+    readonly access_token?: unknown;
+    readonly account_id?: unknown;
+    readonly id_token?: unknown;
+    readonly refresh_token?: unknown;
+  };
+  readonly last_refresh?: unknown;
+}
+
+export interface CodexOAuthStatus {
+  readonly connected: boolean;
+  readonly authMode?: string;
+  readonly accountId?: string;
+  readonly authPath: string;
+  readonly expiresAt?: string;
+  readonly lastRefresh?: string;
+  readonly message?: string;
+}
+
+export interface CodexOAuthModelInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly contextWindow: number;
+  readonly maxOutput?: number;
+}
+
+interface CodexOAuthCredentials {
+  readonly accessToken: string;
+  readonly accountId: string;
+  readonly authPath: string;
+  readonly expiresAt?: string;
+}
+
+export function isCodexOAuthService(service: string | undefined): boolean {
+  return service === CODEX_OAUTH_SERVICE_ID;
+}
+
+function resolveCodexHome(codexHome?: string): string {
+  return codexHome || process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+function resolveAuthPath(codexHome?: string): string {
+  return join(resolveCodexHome(codexHome), "auth.json");
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function jwtExpiresAt(token: string): string | undefined {
+  const exp = decodeJwtPayload(token)?.exp;
+  if (typeof exp !== "number" || !Number.isFinite(exp)) return undefined;
+  return new Date(exp * 1000).toISOString();
+}
+
+function isExpired(expiresAt: string | undefined, now: Date): boolean {
+  return Boolean(expiresAt && Date.parse(expiresAt) <= now.getTime());
+}
+
+async function readCodexAuth(codexHome?: string): Promise<{ authPath: string; auth: CodexAuthJson }> {
+  const authPath = resolveAuthPath(codexHome);
+  const raw = await readFile(authPath, "utf-8");
+  return { authPath, auth: JSON.parse(raw) as CodexAuthJson };
+}
+
+async function readCredentials(
+  options?: { readonly codexHome?: string; readonly now?: Date },
+): Promise<CodexOAuthCredentials> {
+  const { authPath, auth } = await readCodexAuth(options?.codexHome);
+  const accessToken = typeof auth.tokens?.access_token === "string" ? auth.tokens.access_token : "";
+  const accountId = typeof auth.tokens?.account_id === "string" ? auth.tokens.account_id : "";
+  const authMode = typeof auth.auth_mode === "string" ? auth.auth_mode : "";
+  const expiresAt = accessToken ? jwtExpiresAt(accessToken) : undefined;
+
+  if (authMode !== "chatgpt") {
+    throw new Error("Codex is not logged in with ChatGPT OAuth. Run `codex login` and choose ChatGPT.");
+  }
+  if (!accessToken || !accountId) {
+    throw new Error("Codex ChatGPT OAuth tokens are incomplete. Run `codex login` again.");
+  }
+  if (isExpired(expiresAt, options?.now ?? new Date())) {
+    throw new Error("Codex ChatGPT OAuth access token is expired. Run `codex login status` or `codex login` to refresh it.");
+  }
+
+  return { accessToken, accountId, authPath, ...(expiresAt ? { expiresAt } : {}) };
+}
+
+export async function getCodexOAuthStatus(
+  options?: { readonly codexHome?: string; readonly now?: Date },
+): Promise<CodexOAuthStatus> {
+  const authPath = resolveAuthPath(options?.codexHome);
+  try {
+    const { auth } = await readCodexAuth(options?.codexHome);
+    const authMode = typeof auth.auth_mode === "string" ? auth.auth_mode : undefined;
+    const accessToken = typeof auth.tokens?.access_token === "string" ? auth.tokens.access_token : "";
+    const accountId = typeof auth.tokens?.account_id === "string" ? auth.tokens.account_id : undefined;
+    const expiresAt = accessToken ? jwtExpiresAt(accessToken) : undefined;
+    const lastRefresh = typeof auth.last_refresh === "string" ? auth.last_refresh : undefined;
+
+    if (authMode !== "chatgpt") {
+      return {
+        connected: false,
+        ...(authMode ? { authMode } : {}),
+        authPath,
+        message: "Codex is logged in with a non-ChatGPT auth mode.",
+      };
+    }
+    if (!accessToken || !accountId) {
+      return { connected: false, authMode, authPath, message: "Codex ChatGPT OAuth tokens are incomplete." };
+    }
+    if (isExpired(expiresAt, options?.now ?? new Date())) {
+      return {
+        connected: false,
+        authMode,
+        accountId,
+        authPath,
+        ...(expiresAt ? { expiresAt } : {}),
+        ...(lastRefresh ? { lastRefresh } : {}),
+        message: "Codex ChatGPT OAuth access token is expired.",
+      };
+    }
+    return {
+      connected: true,
+      authMode,
+      accountId,
+      authPath,
+      ...(expiresAt ? { expiresAt } : {}),
+      ...(lastRefresh ? { lastRefresh } : {}),
+    };
+  } catch (error) {
+    return {
+      connected: false,
+      authPath,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function buildCodexOAuthHeaders(
+  options?: { readonly codexHome?: string; readonly now?: Date },
+): Promise<Record<string, string>> {
+  const credentials = await readCredentials(options);
+  return {
+    Authorization: `Bearer ${credentials.accessToken}`,
+    "ChatGPT-Account-ID": credentials.accountId,
+  };
+}
+
+async function resolveCodexVersion(): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("codex", ["--version"], { timeout: 2_000 });
+    const match = stdout.match(/\d+\.\d+\.\d+/);
+    return match?.[0] ?? DEFAULT_CODEX_VERSION;
+  } catch {
+    return DEFAULT_CODEX_VERSION;
+  }
+}
+
+function modelString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function modelNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export async function listCodexOAuthModels(
+  options?: {
+    readonly codexHome?: string;
+    readonly codexVersion?: string;
+    readonly fetchImpl?: typeof fetch;
+  },
+): Promise<ReadonlyArray<CodexOAuthModelInfo>> {
+  const headers = await buildCodexOAuthHeaders({ codexHome: options?.codexHome });
+  const codexVersion = options?.codexVersion ?? await resolveCodexVersion();
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const res = await fetchImpl(`${CODEX_OAUTH_BASE_URL}/models?client_version=${encodeURIComponent(codexVersion)}`, {
+    headers,
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Codex OAuth model list failed: HTTP ${res.status} ${body.slice(0, 200)}`.trim());
+  }
+  const json = await res.json() as { models?: Array<Record<string, unknown>> };
+  const models = Array.isArray(json.models) ? json.models : [];
+  return models
+    .filter((model) => model.supported_in_api !== false)
+    .filter((model) => model.visibility !== "hidden")
+    .map((model) => {
+      const id = modelString(model.slug) ?? modelString(model.id) ?? modelString(model.model);
+      if (!id) return null;
+      const contextWindow = modelNumber(model.context_window)
+        ?? modelNumber(model.max_context_window)
+        ?? modelNumber(model.contextWindow)
+        ?? 0;
+      const maxOutput = modelNumber(model.max_output)
+        ?? modelNumber(model.max_output_tokens)
+        ?? modelNumber(model.max_context_window)
+        ?? modelNumber(model.context_window);
+      return {
+        id,
+        name: modelString(model.display_name) ?? modelString(model.name) ?? id,
+        contextWindow,
+        ...(maxOutput ? { maxOutput } : {}),
+      };
+    })
+    .filter((model): model is CodexOAuthModelInfo => model !== null);
+}

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -19,6 +19,7 @@ import { getEndpoint } from "./providers/index.js";
 import { lookupModel } from "./providers/lookup.js";
 import { fetchWithProxy } from "../utils/proxy-fetch.js";
 import { isApiKeyOptionalForEndpoint } from "../utils/llm-endpoint-auth.js";
+import { buildCodexOAuthHeaders, isCodexOAuthService } from "./codex-oauth.js";
 
 
 // === Streaming Monitor Types ===
@@ -206,6 +207,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
   else if (inkosProvider?.id === "zhipu") piProvider = "zai";
   else if (inkosProvider?.id === "openrouter") piProvider = "openrouter";
   else if (inkosProvider?.id === "githubCopilot") piProvider = "githubCopilot";
+  else if (isCodexOAuthService(inkosProvider?.id ?? serviceName)) piProvider = "openai-codex";
   else if (inkosProvider?.id === "ollama") piProvider = "ollama";
   else if (inkosProvider?.api === "anthropic-messages") piProvider = "anthropic";
   else piProvider = provider;
@@ -505,6 +507,28 @@ function shouldUseNativeCustomTransport(client: LLMClient): boolean {
   return client.service === "ollama"
     && client.provider === "openai"
     && shouldUseNativeLocalOpenAICompatibleTransport(client);
+}
+
+async function withCodexOAuthRuntimeAuth(client: LLMClient): Promise<LLMClient> {
+  if (!isCodexOAuthService(client.service)) return client;
+  const headers = await buildCodexOAuthHeaders();
+  const authorization = headers.Authorization ?? "";
+  const token = authorization.replace(/^Bearer\s+/i, "");
+  const runtimeHeaders = { ...headers };
+  delete runtimeHeaders.Authorization;
+  return {
+    ...client,
+    _apiKey: token,
+    _piModel: client._piModel
+      ? {
+          ...client._piModel,
+          headers: {
+            ...(client._piModel.headers ?? {}),
+            ...runtimeHeaders,
+          },
+        }
+      : client._piModel,
+  };
 }
 
 function shouldUseNativeLocalOpenAICompatibleTransport(client: LLMClient): boolean {
@@ -1028,10 +1052,11 @@ export async function chatCompletion(
   try {
     return await withTransientLLMRetry(
       async () => {
-        if (shouldUseNativeCustomTransport(client)) {
-          return chatCompletionViaCustomOpenAICompatible(client, model, messages, resolved, onStreamProgress, onTextDelta);
+        const runtimeClient = await withCodexOAuthRuntimeAuth(client);
+        if (shouldUseNativeCustomTransport(runtimeClient)) {
+          return chatCompletionViaCustomOpenAICompatible(runtimeClient, model, messages, resolved, onStreamProgress, onTextDelta);
         }
-        return chatCompletionViaPiAi(client, model, messages, resolved, onStreamProgress, onTextDelta);
+        return chatCompletionViaPiAi(runtimeClient, model, messages, resolved, onStreamProgress, onTextDelta);
       },
       // Retrying after UI text deltas have been emitted can duplicate visible text.
       { enabled: !onTextDelta },
@@ -1070,7 +1095,8 @@ export async function chatWithTools(
       ),
       maxTokens: options?.maxTokens ?? client.defaults.maxTokens,
     };
-    return await chatWithToolsViaPiAi(client, model, messages, tools, resolved);
+    const runtimeClient = await withCodexOAuthRuntimeAuth(client);
+    return await chatWithToolsViaPiAi(runtimeClient, model, messages, tools, resolved);
   } catch (error) {
     throw wrapLLMError(error, errorCtx);
   }
@@ -1113,6 +1139,13 @@ function toPiContext(messages: ReadonlyArray<LLMMessage>): PiContext {
       };
     });
   return { systemPrompt, messages: piMessages };
+}
+
+function ensureCodexInstructions(piModel: PiModel<PiApi>, context: PiContext): PiContext {
+  if (piModel.api !== "openai-codex-responses" || context.systemPrompt?.trim()) {
+    return context;
+  }
+  return { ...context, systemPrompt: "You are a helpful assistant." };
 }
 
 /** Convert inkos AgentMessage[] to pi-ai Context (with tool calls/results). */
@@ -1184,13 +1217,11 @@ async function chatCompletionViaPiAi(
   onTextDelta?: (text: string) => void,
 ): Promise<LLMResponse> {
   const piModel = resolvePiModel(client, model);
-  const context = toPiContext(messages);
-  const streamOpts = {
+  const context = ensureCodexInstructions(piModel, toPiContext(messages));
+  const streamOpts = buildPiStreamOptions(piModel, client, {
     temperature: resolved.temperature,
     maxTokens: resolved.maxTokens,
-    apiKey: client._apiKey,
-    headers: mergeUserAgent(piModel.headers),
-  };
+  });
 
   if (!client.stream) {
     const response = await piCompleteSimple(piModel, context, streamOpts);
@@ -1279,14 +1310,12 @@ async function chatWithToolsViaPiAi(
   resolved: { readonly temperature: number; readonly maxTokens: number },
 ): Promise<ChatWithToolsResult> {
   const piModel = resolvePiModel(client, model);
-  const context = agentMessagesToPiContext(messages);
+  const context = ensureCodexInstructions(piModel, agentMessagesToPiContext(messages));
   context.tools = toPiTools(tools);
-  const streamOpts = {
+  const streamOpts = buildPiStreamOptions(piModel, client, {
     temperature: resolved.temperature,
     maxTokens: resolved.maxTokens,
-    apiKey: client._apiKey,
-    headers: mergeUserAgent(piModel.headers),
-  };
+  });
 
   if (!client.stream) {
     const response = await piComplete(piModel, context, streamOpts);
@@ -1328,4 +1357,23 @@ async function chatWithToolsViaPiAi(
   }
 
   return { content, toolCalls };
+}
+
+function buildPiStreamOptions(
+  piModel: PiModel<PiApi>,
+  client: LLMClient,
+  resolved: { readonly temperature: number; readonly maxTokens: number },
+): {
+  readonly temperature?: number;
+  readonly maxTokens: number;
+  readonly apiKey?: string;
+  readonly headers: Record<string, string>;
+} {
+  const supportsTemperature = piModel.api !== "openai-codex-responses";
+  return {
+    ...(supportsTemperature ? { temperature: resolved.temperature } : {}),
+    maxTokens: resolved.maxTokens,
+    apiKey: client._apiKey,
+    headers: mergeUserAgent(piModel.headers),
+  };
 }

--- a/packages/core/src/llm/providers/endpoints/codexOAuth.ts
+++ b/packages/core/src/llm/providers/endpoints/codexOAuth.ts
@@ -1,0 +1,25 @@
+/**
+ * Codex OAuth
+ *
+ * Uses the local Codex CLI ChatGPT OAuth login from CODEX_HOME/auth.json.
+ * Runtime credentials stay outside project secrets.
+ */
+import { CODEX_OAUTH_BASE_URL } from "../../codex-oauth.js";
+import type { InkosEndpoint } from "../types.js";
+
+export const CODEX_OAUTH: InkosEndpoint = {
+  id: "codexOAuth",
+  label: "Codex OAuth",
+  group: "local",
+  authKind: "codexOAuth",
+  api: "openai-codex-responses",
+  baseUrl: CODEX_OAUTH_BASE_URL,
+  checkModel: "gpt-5.5",
+  temperatureRange: [0, 2],
+  defaultTemperature: 1,
+  writingTemperature: 1,
+  transportDefaults: { apiFormat: "responses", stream: true },
+  models: [
+    { id: "gpt-5.5", maxOutput: 272000, contextWindowTokens: 272000, enabled: true },
+  ],
+};

--- a/packages/core/src/llm/providers/index.ts
+++ b/packages/core/src/llm/providers/index.ts
@@ -31,6 +31,7 @@ import { MISTRAL } from "./endpoints/mistral.js";
 import { XAI } from "./endpoints/xai.js";
 import { NEWAPI } from "./endpoints/newapi.js";
 import { GITHUB_COPILOT } from "./endpoints/githubCopilot.js";
+import { CODEX_OAUTH } from "./endpoints/codexOAuth.js";
 import { KKAIAPI } from "./endpoints/kkaiapi.js";
 // B6 CodingPlan
 import { KIMI_CODING_PLAN } from "./endpoints/kimiCodingPlan.js";
@@ -53,7 +54,7 @@ const ALL_PROVIDERS: readonly InkosEndpoint[] = [
   MOONSHOT, ZHIPU, SILICONCLOUD, BAILIAN, VOLCENGINE, HUNYUAN, BAICHUAN, STEPFUN, WENXIN,
   SPARK, SENSENOVA, TENCENTCLOUD, XIAOMI_MIMO, LONGCAT, INTERNLM,
   ZEROONE, AI360,
-  OLLAMA, OPENROUTER, CUSTOM, MISTRAL, XAI, NEWAPI, GITHUB_COPILOT, KKAIAPI,
+  OLLAMA, OPENROUTER, CUSTOM, MISTRAL, XAI, NEWAPI, GITHUB_COPILOT, CODEX_OAUTH, KKAIAPI,
   // B6 CodingPlan（8 个）
   KIMI_CODING_PLAN, KIMI_CODE, MINIMAX_CODING_PLAN, BAILIAN_CODING_PLAN, GLM_CODING_PLAN, VOLCENGINE_CODING_PLAN, OPENCODE_CODING_PLAN, ASTRON_CODING_PLAN,
 ];

--- a/packages/core/src/llm/providers/types.ts
+++ b/packages/core/src/llm/providers/types.ts
@@ -9,6 +9,7 @@
 export type ApiProtocol =
   | "openai-completions"
   | "openai-responses"
+  | "openai-codex-responses"
   | "anthropic-messages"
   | "google-generative-ai";
 
@@ -69,6 +70,7 @@ export interface InkosEndpoint {
   readonly label: string;
   /** UI 分组。custom 不参与分组，其他 endpoint 必填。 */
   readonly group?: EndpointGroup;
+  readonly authKind?: "apiKey" | "codexOAuth";
 
   readonly api: ApiProtocol;
   readonly baseUrl: string;

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -1,6 +1,7 @@
 import { getEndpoint } from "./providers/index.js";
 import { probeModelsFromUpstream } from "./providers/probe.js";
 import { isApiKeyOptionalForEndpoint } from "../utils/llm-endpoint-auth.js";
+import { isCodexOAuthService, listCodexOAuthModels } from "./codex-oauth.js";
 
 export interface ServicePreset {
   readonly providerFamily: "openai" | "anthropic";
@@ -86,6 +87,7 @@ export function resolveServiceProviderFamily(service: string): "openai" | "anthr
 }
 
 export function resolveServicePiProvider(service: string): string | undefined {
+  if (isCodexOAuthService(service)) return "openai-codex";
   if (service === "google") return "google";
   const preset = resolveServicePreset(service);
   if (!preset) return undefined;
@@ -164,6 +166,15 @@ export async function listModelsForService(
   const provider = getEndpoint(service);
   const preset = SERVICE_PRESETS[service];
   if (!provider && !preset) return [];
+
+  if (isCodexOAuthService(service)) {
+    try {
+      const models = await listCodexOAuthModels();
+      if (models.length > 0) return models;
+    } catch {
+      // fall back to the bundled Codex OAuth model card below
+    }
+  }
 
   const byId = new Map<string, ModelInfo>();
 

--- a/packages/core/src/llm/service-resolver.ts
+++ b/packages/core/src/llm/service-resolver.ts
@@ -5,6 +5,7 @@ import { getServiceApiKey } from "./secrets.js";
 import { getEndpoint } from "./providers/index.js";
 import type { InkosEndpoint } from "./providers/types.js";
 import { isApiKeyOptionalForEndpoint } from "../utils/llm-endpoint-auth.js";
+import { isCodexOAuthService } from "./codex-oauth.js";
 
 export interface ResolvedModel {
   model: Model<Api>;
@@ -61,7 +62,7 @@ export async function resolveServiceModel(
   // Resolve API key after baseUrl/provider are known so local/self-hosted endpoints
   // such as Ollama can be used without forcing a fake secret.
   const apiKey = await getServiceApiKey(projectRoot, service);
-  if (!apiKey && !isApiKeyOptionalForEndpoint({ provider: preset?.providerFamily, baseUrl: effectiveBaseUrl })) {
+  if (!apiKey && !isCodexOAuthService(baseService) && !isApiKeyOptionalForEndpoint({ provider: preset?.providerFamily, baseUrl: effectiveBaseUrl })) {
     throw new Error(
       `API key not found for service "${service}". Add it in .inkos/secrets.json or set the environment variable.`,
     );

--- a/packages/core/src/utils/effective-llm-config.ts
+++ b/packages/core/src/utils/effective-llm-config.ts
@@ -5,6 +5,7 @@ import { loadSecrets } from "../llm/secrets.js";
 import { getEndpoint } from "../llm/providers/index.js";
 import { guessServiceFromBaseUrl, resolveServicePreset, resolveServiceProviderFamily } from "../llm/service-presets.js";
 import { isApiKeyOptionalForEndpoint } from "./llm-endpoint-auth.js";
+import { isCodexOAuthService } from "../llm/codex-oauth.js";
 import { cliOverlayEnv, legacyEnv, studioIgnoredEnv, type LLMEnvLayers, type LLMEnvMap } from "./llm-env.js";
 
 export type LLMConsumer = "studio" | "cli" | "daemon" | "deploy";
@@ -99,7 +100,8 @@ export async function resolveEffectiveLLMConfig(
   const provider = typeof llm.provider === "string" ? llm.provider : undefined;
   const baseUrl = typeof llm.baseUrl === "string" ? llm.baseUrl : undefined;
   const apiKey = typeof llm.apiKey === "string" ? llm.apiKey : "";
-  if (!apiKey && input.requireApiKey !== false && !isApiKeyOptionalForEndpoint({ provider, baseUrl })) {
+  const service = typeof llm.service === "string" ? llm.service : undefined;
+  if (!apiKey && input.requireApiKey !== false && !isCodexOAuthService(service) && !isApiKeyOptionalForEndpoint({ provider, baseUrl })) {
     throw new Error(
       configMode === "studio-project"
         ? "Studio LLM API key not set. Open Studio services and save an API key for the selected service."
@@ -465,7 +467,7 @@ function modelBelongsToService(service: string, model: string): boolean {
 }
 
 function serviceAllowsUnlistedModels(service: string): boolean {
-  return service === "ollama";
+  return service === "ollama" || isCodexOAuthService(service);
 }
 
 function serviceEntryKey(entry: ServiceConfigEntry): string {

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -35,6 +35,9 @@ const resolveServiceModelMock = vi.fn();
 const loadSecretsMock = vi.fn();
 const saveSecretsMock = vi.fn();
 const getServiceApiKeyMock = vi.fn();
+const getCodexOAuthStatusMock = vi.fn();
+const listCodexOAuthModelsMock = vi.fn();
+const isCodexOAuthServiceMock = vi.fn((service?: string) => service === "codexOAuth");
 type ServicePresetMock = {
   providerFamily: "openai" | "anthropic";
   baseUrl: string;
@@ -48,6 +51,7 @@ const SERVICE_PRESETS_MOCK: Record<string, ServicePresetMock> = {
   bailian: { providerFamily: "anthropic", baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic", modelsBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", knownModels: [] as string[] },
   google: { providerFamily: "openai", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", modelsBaseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", knownModels: [] as string[] },
   kkaiapi: { providerFamily: "openai", baseUrl: "https://api.kkaiapi.com/v1", modelsBaseUrl: "https://api.kkaiapi.com/v1", knownModels: [] as string[] },
+  codexOAuth: { providerFamily: "openai", baseUrl: "https://chatgpt.com/backend-api/codex", modelsBaseUrl: "https://chatgpt.com/backend-api/codex", knownModels: ["gpt-5.5"] },
   ollama: { providerFamily: "openai", baseUrl: "http://localhost:11434/v1", modelsBaseUrl: "http://localhost:11434/v1", knownModels: [] as string[] },
   custom: { providerFamily: "openai", baseUrl: "", knownModels: [] as string[] },
 };
@@ -87,7 +91,7 @@ const endpointIdsByGroup = {
     "volcengine", "wenxin", "xiaomimimo", "zeroone", "zhipu",
   ],
   aggregator: ["kkaiapi", "openrouter", "newapi", "siliconcloud"],
-  local: ["githubCopilot", "ollama"],
+  local: ["codexOAuth", "githubCopilot", "ollama"],
   codingPlan: [
     "astronCodingPlan", "bailianCodingPlan", "glmCodingPlan", "kimiCodingPlan", "kimicode",
     "minimaxCodingPlan", "opencodeCodingPlan", "volcengineCodingPlan",
@@ -101,6 +105,7 @@ const endpointMocks = [
     ...(id === "google" ? { checkModel: "gemini-2.5-flash" } : {}),
     ...(id === "minimax" ? { checkModel: "MiniMax-M2.7" } : {}),
     ...(id === "ollama" ? { checkModel: "llama3.2:3b" } : {}),
+    ...(id === "codexOAuth" ? { authKind: "codexOAuth", checkModel: "gpt-5.5" } : {}),
     ...(id === "volcengine" ? { checkModel: "doubao-lite-32k" } : {}),
     models: [
       { id: `${id}-model`, maxOutput: 4096, contextWindowTokens: 32768, enabled: true },
@@ -240,6 +245,10 @@ vi.mock("@actalk/inkos-core", async (importOriginal) => {
     loadSecrets: loadSecretsMock,
     saveSecrets: saveSecretsMock,
     getServiceApiKey: getServiceApiKeyMock,
+    CODEX_OAUTH_SERVICE_ID: "codexOAuth",
+    getCodexOAuthStatus: getCodexOAuthStatusMock,
+    listCodexOAuthModels: listCodexOAuthModelsMock,
+    isCodexOAuthService: isCodexOAuthServiceMock,
     listModelsForService: listModelsForServiceMock,
     getAllEndpoints: getAllEndpointsMock,
     probeModelsFromUpstream: probeModelsFromUpstreamMock,
@@ -407,6 +416,9 @@ describe("createStudioServer daemon lifecycle", () => {
     loadSecretsMock.mockReset();
     saveSecretsMock.mockReset();
     getServiceApiKeyMock.mockReset();
+    getCodexOAuthStatusMock.mockReset();
+    listCodexOAuthModelsMock.mockReset();
+    isCodexOAuthServiceMock.mockClear();
     resolveServicePresetMock.mockClear();
     resolveServiceProviderFamilyMock.mockClear();
     resolveServiceModelsBaseUrlMock.mockClear();
@@ -444,6 +456,14 @@ describe("createStudioServer daemon lifecycle", () => {
     loadSecretsMock.mockResolvedValue({ services: {} });
     saveSecretsMock.mockResolvedValue(undefined);
     getServiceApiKeyMock.mockResolvedValue(undefined);
+    getCodexOAuthStatusMock.mockResolvedValue({
+      connected: false,
+      authPath: "/tmp/codex/auth.json",
+      message: "Codex OAuth auth.json not found",
+    });
+    listCodexOAuthModelsMock.mockResolvedValue([
+      { id: "gpt-5.5", name: "GPT-5.5", contextWindow: 272000, maxOutput: 272000 },
+    ]);
   });
 
   afterEach(async () => {
@@ -796,18 +816,89 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { services: Array<{ service: string; group?: string; connected: boolean }> };
     const bank = body.services.filter((s) => !s.service.startsWith("custom"));
-    expect(bank.length).toBe(37);
+    expect(bank.length).toBe(38);
     expect(bank.every((s) => typeof s.group === "string")).toBe(true);
     expect(bank.filter((s) => s.group === "overseas")).toHaveLength(5);
     expect(bank.filter((s) => s.group === "china")).toHaveLength(18);
     expect(bank.filter((s) => s.group === "aggregator")).toHaveLength(4);
-    expect(bank.filter((s) => s.group === "local")).toHaveLength(2);
+    expect(bank.filter((s) => s.group === "local")).toHaveLength(3);
     expect(bank.filter((s) => s.group === "codingPlan")).toHaveLength(8);
     expect(bank.filter((s) => s.group === "aggregator").map((s) => s.service)[0]).toBe("kkaiapi");
     expect(body.services.find((s) => s.service === "moonshot")?.connected).toBe(true);
     expect(body.services.find((s) => s.service === "custom:内网GPT")).toMatchObject({
       connected: true,
     });
+  });
+
+  it("reports Codex OAuth connection from local runtime auth", async () => {
+    getCodexOAuthStatusMock.mockResolvedValue({
+      connected: true,
+      authMode: "chatgpt-oauth",
+      accountId: "acct_123",
+      expiresAt: "2027-01-15T08:00:00.000Z",
+      lastRefresh: "2026-05-27T00:00:00.000Z",
+      authPath: "/Users/test/.codex/auth.json",
+    });
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+
+    const res = await app.request("http://localhost/api/v1/services");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { services: Array<Record<string, unknown>> };
+    expect(body.services.find((s) => s.service === "codexOAuth")).toMatchObject({
+      authKind: "codexOAuth",
+      connected: true,
+      accountId: "acct_123",
+      authPath: "/Users/test/.codex/auth.json",
+    });
+  });
+
+  it("uses Codex OAuth runtime auth for status, tests, and models", async () => {
+    getCodexOAuthStatusMock.mockResolvedValue({
+      connected: true,
+      authMode: "chatgpt-oauth",
+      accountId: "acct_123",
+      expiresAt: "2027-01-15T08:00:00.000Z",
+      authPath: "/Users/test/.codex/auth.json",
+    });
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+
+    const secret = await app.request("http://localhost/api/v1/services/codexOAuth/secret");
+    expect(secret.status).toBe(200);
+    await expect(secret.json()).resolves.toMatchObject({
+      apiKey: "",
+      authKind: "codexOAuth",
+      connected: true,
+      accountId: "acct_123",
+    });
+
+    const test = await app.request("http://localhost/api/v1/services/codexOAuth/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiKey: "", apiFormat: "responses", stream: true }),
+    });
+    expect(test.status).toBe(200);
+    await expect(test.json()).resolves.toMatchObject({
+      ok: true,
+      selectedModel: "gpt-5.5",
+      detected: {
+        apiFormat: "responses",
+        stream: true,
+        modelsSource: "api",
+      },
+    });
+
+    const models = await app.request("http://localhost/api/v1/services/codexOAuth/models?refresh=1");
+    expect(models.status).toBe(200);
+    await expect(models.json()).resolves.toEqual({
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", maxOutput: 272000, contextWindow: 272000 },
+      ],
+    });
+    expect(listCodexOAuthModelsMock).toHaveBeenCalled();
   });
 
   it("returns connected bank model groups from the local bank", async () => {
@@ -2410,6 +2501,101 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(pipelineConfigs.at(-1)).toEqual(expect.objectContaining({
       writingReviewRetries: 3,
     }));
+  });
+
+  it("passes selected Codex OAuth model into Studio write-next without requiring an API key", async () => {
+    loadProjectConfigMock.mockImplementationOnce(async (_root: string, options?: { requireApiKey?: boolean }) => {
+      expect(options).toMatchObject({ consumer: "studio", requireApiKey: false });
+      return {
+        ...cloneProjectConfig(),
+        llm: {
+          provider: "openai",
+          service: "custom",
+          configSource: "studio",
+          baseUrl: "",
+          model: "",
+          stream: true,
+        },
+      };
+    });
+    resolveServiceModelMock.mockResolvedValueOnce({
+      apiKey: "",
+      model: { id: "gpt-5.5" },
+    });
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+
+    const response = await app.request("http://localhost/api/v1/books/demo-book/write-next", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ service: "codexOAuth", model: "gpt-5.5" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveServiceModelMock).toHaveBeenCalledWith(
+      "codexOAuth",
+      "gpt-5.5",
+      root,
+      "https://chatgpt.com/backend-api/codex",
+      undefined,
+    );
+    expect(createLLMClientMock).toHaveBeenCalledWith(expect.objectContaining({
+      service: "codexOAuth",
+      model: "gpt-5.5",
+      apiKey: "",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    }));
+    expect(pipelineConfigs.at(-1)).toEqual(expect.objectContaining({
+      model: "gpt-5.5",
+    }));
+  });
+
+  it("uses Codex OAuth for write-next when Studio config key validation fails and runtime auth is connected", async () => {
+    loadProjectConfigMock
+      .mockRejectedValueOnce(
+        new Error("Studio LLM API key not set. Open Studio services and save an API key for the selected service."),
+      )
+      .mockResolvedValueOnce({
+        ...cloneProjectConfig(),
+        llm: {
+          provider: "openai",
+          service: "custom",
+          configSource: "studio",
+          baseUrl: "",
+          model: "",
+          stream: true,
+        },
+      });
+    getCodexOAuthStatusMock.mockResolvedValueOnce({
+      connected: true,
+      authMode: "chatgpt-oauth",
+      accountId: "acct-1",
+      authPath: "/tmp/codex/auth.json",
+    });
+    resolveServiceModelMock.mockResolvedValueOnce({
+      apiKey: "",
+      model: { id: "gpt-5.5" },
+    });
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+
+    const response = await app.request("http://localhost/api/v1/books/demo-book/write-next", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveServiceModelMock).toHaveBeenCalledWith(
+      "codexOAuth",
+      "gpt-5.5",
+      root,
+      "https://chatgpt.com/backend-api/codex",
+      undefined,
+    );
+    expect(writeNextChapterMock).toHaveBeenCalledWith("demo-book", undefined);
   });
 
   it("handles explicit chat chapter edits outside the InkOS writing agent", async () => {

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -37,6 +37,10 @@ import {
   chatCompletion,
   buildExportArtifact,
   GLOBAL_ENV_PATH,
+  CODEX_OAUTH_SERVICE_ID,
+  getCodexOAuthStatus,
+  listCodexOAuthModels,
+  isCodexOAuthService,
   COVER_PROVIDER_PRESETS,
   Scheduler,
   coverSecretKey,
@@ -514,6 +518,18 @@ interface ServiceConfigEntry {
   stream?: boolean;
 }
 
+interface StudioServiceListItem {
+  service: string;
+  label: string;
+  group?: string;
+  authKind?: "apiKey" | "codexOAuth";
+  connected: boolean;
+  accountId?: string;
+  expiresAt?: string;
+  authPath?: string;
+  message?: string;
+}
+
 type LLMConfigSource = "env" | "studio";
 
 interface EnvConfigSummary {
@@ -922,6 +938,38 @@ function fallbackTextModelsForEndpoint(
   return preset?.knownModels?.map((id) => ({ id, name: id })) ?? [];
 }
 
+function endpointModelInfos(endpoint: ReturnType<typeof getAllEndpoints>[number]): Array<{
+  id: string;
+  name: string;
+  maxOutput?: number;
+  contextWindow?: number;
+}> {
+  return endpoint.models
+    .filter((model) => model.enabled !== false)
+    .filter((model) => isTextChatModelId(model.id))
+    .map((model) => ({
+      id: model.id,
+      name: model.id,
+      ...(typeof model.maxOutput === "number" ? { maxOutput: model.maxOutput } : {}),
+      ...(model.contextWindowTokens > 0 ? { contextWindow: model.contextWindowTokens } : {}),
+    }));
+}
+
+async function codexOAuthModelInfos(): Promise<Array<{
+  id: string;
+  name: string;
+  maxOutput?: number;
+  contextWindow?: number;
+}>> {
+  const models = await listCodexOAuthModels();
+  return filterTextChatModels(models).map((model) => ({
+    id: model.id,
+    name: model.name ?? model.id,
+    ...(model.maxOutput !== undefined ? { maxOutput: model.maxOutput } : {}),
+    ...(model.contextWindow > 0 ? { contextWindow: model.contextWindow } : {}),
+  }));
+}
+
 function shouldTrustStaticModelsWhenLiveListUnavailable(endpoint: ReturnType<typeof getAllEndpoints>[number] | undefined): boolean {
   return endpoint?.group === "aggregator";
 }
@@ -1001,6 +1049,28 @@ async function fetchModelsFromServiceBaseUrl(
   apiKey: string,
   proxyUrl?: string,
 ): Promise<{ models: Array<{ id: string; name: string }>; error?: string; authFailed?: boolean }> {
+  if (isCodexOAuthService(serviceId)) {
+    const status = await getCodexOAuthStatus();
+    if (!status.connected) {
+      return {
+        models: [],
+        error: status.message ?? "Codex OAuth 未登录。请先运行 codex login。",
+        authFailed: true,
+      };
+    }
+    try {
+      return {
+        models: await codexOAuthModelInfos(),
+      };
+    } catch (error) {
+      return {
+        models: [],
+        error: error instanceof Error ? error.message : String(error),
+        authFailed: true,
+      };
+    }
+  }
+
   const endpoint = isCustomServiceId(serviceId)
     ? undefined
     : getAllEndpoints().find((ep) => ep.id === serviceId);
@@ -1275,9 +1345,40 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     overrides?: Partial<Pick<PipelineConfig, "externalContext" | "client" | "model">> & {
       readonly currentConfig?: ProjectConfig;
       readonly sessionIdForSSE?: string;
+      readonly selectedService?: string;
+      readonly selectedModel?: string;
     },
   ): Promise<PipelineConfig> {
-    const currentConfig = overrides?.currentConfig ?? await loadCurrentProjectConfig();
+    const selectedService = overrides?.selectedService?.trim();
+    const selectedModel = overrides?.selectedModel?.trim();
+    const hasSelectedModel = Boolean(selectedService && selectedModel);
+    let fallbackService: string | undefined;
+    let fallbackModel: string | undefined;
+    let currentConfig: ProjectConfig;
+
+    if (overrides?.currentConfig) {
+      currentConfig = overrides.currentConfig;
+    } else {
+      try {
+        currentConfig = await loadCurrentProjectConfig(hasSelectedModel ? { requireApiKey: false } : undefined);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("LLM API key not set") && !message.includes("INKOS_LLM_API_KEY not set")) {
+          throw error;
+        }
+        const codexStatus = await getCodexOAuthStatus();
+        if (!codexStatus.connected) throw error;
+        currentConfig = await loadCurrentProjectConfig({ requireApiKey: false });
+        fallbackService = CODEX_OAUTH_SERVICE_ID;
+        fallbackModel = getCodexOAuthDefaultModel();
+      }
+    }
+
+    const selectedLlm = selectedService && selectedModel
+      ? await resolvePipelineLlmSelection(currentConfig, selectedService, selectedModel)
+      : fallbackService && fallbackModel && !overrides?.client && !overrides?.model
+        ? await resolvePipelineLlmSelection(currentConfig, fallbackService, fallbackModel)
+        : undefined;
     const scopedSseSink: LogSink = overrides?.sessionIdForSSE
       ? {
           write(entry) {
@@ -1292,10 +1393,10 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
       : sseSink;
     const logger = createLogger({ tag: "studio", sinks: [scopedSseSink, consoleSink] });
     return {
-      client: overrides?.client ?? createLLMClient(currentConfig.llm),
-      model: overrides?.model ?? currentConfig.llm.model,
+      client: overrides?.client ?? selectedLlm?.client ?? createLLMClient(currentConfig.llm),
+      model: overrides?.model ?? selectedLlm?.model ?? currentConfig.llm.model,
       projectRoot: root,
-      defaultLLMConfig: currentConfig.llm,
+      defaultLLMConfig: selectedLlm?.defaultLLMConfig ?? currentConfig.llm,
       foundationReviewRetries: currentConfig.foundation?.reviewRetries ?? 2,
       writingReviewRetries: currentConfig.writing?.reviewRetries ?? 1,
       modelOverrides: currentConfig.modelOverrides,
@@ -1312,6 +1413,52 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
       },
       externalContext: overrides?.externalContext,
     };
+  }
+
+  function getCodexOAuthDefaultModel(): string {
+    const endpoint = getAllEndpoints().find((ep) => isCodexOAuthService(ep.id));
+    return endpoint?.checkModel
+      ?? endpoint?.models.find((model) => model.enabled !== false)?.id
+      ?? "gpt-5.5";
+  }
+
+  async function resolvePipelineLlmSelection(
+    currentConfig: ProjectConfig,
+    service: string,
+    model: string,
+  ): Promise<Pick<PipelineConfig, "client" | "model"> & { readonly defaultLLMConfig: ProjectConfig["llm"] }> {
+    try {
+      const configuredEntry = await resolveConfiguredServiceEntry(root, service);
+      const resolvedBaseUrl = await resolveConfiguredServiceBaseUrl(root, service);
+      const resolved = await resolveServiceModel(
+        service,
+        model,
+        root,
+        resolvedBaseUrl,
+        configuredEntry?.apiFormat,
+      );
+      const llmConfig = {
+        ...currentConfig.llm,
+        service: configuredEntry?.service ?? service,
+        model,
+        apiKey: resolved.apiKey ?? "",
+        baseUrl: resolvedBaseUrl ?? configuredEntry?.baseUrl ?? "",
+        ...(configuredEntry?.apiFormat ? { apiFormat: configuredEntry.apiFormat } : {}),
+        ...(configuredEntry?.stream !== undefined ? { stream: configuredEntry.stream } : {}),
+        ...(configuredEntry?.temperature !== undefined ? { temperature: configuredEntry.temperature } : {}),
+      } as ProjectConfig["llm"];
+      return {
+        client: createLLMClient(llmConfig),
+        model,
+        defaultLLMConfig: llmConfig,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/API key/i.test(message)) {
+        throw new ApiError(400, "LLM_CONFIG_ERROR", `请先为 ${service} 配置 API Key，或切换到 Codex OAuth。`);
+      }
+      throw error;
+    }
   }
 
   // --- Books ---
@@ -1589,12 +1736,17 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.post("/api/v1/books/:id/write-next", async (c) => {
     const id = c.req.param("id");
-    const body = await c.req.json<{ wordCount?: number }>().catch(() => ({ wordCount: undefined }));
+    const body = await c.req
+      .json<{ wordCount?: number; service?: string; model?: string }>()
+      .catch(() => ({ wordCount: undefined, service: undefined, model: undefined }));
 
     broadcast("write:start", { bookId: id });
 
     // Fire and forget — progress/completion/errors pushed via SSE
-    const pipeline = new PipelineRunner(await buildPipelineConfig());
+    const pipeline = new PipelineRunner(await buildPipelineConfig({
+      selectedService: body.service,
+      selectedModel: body.model,
+    }));
     pipeline.writeNextChapter(id, body.wordCount).then(
       (result) => {
         broadcast("write:complete", { bookId: id, chapterNumber: result.chapterNumber, status: result.status, title: result.title, wordCount: result.wordCount });
@@ -1609,11 +1761,16 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.post("/api/v1/books/:id/draft", async (c) => {
     const id = c.req.param("id");
-    const body = await c.req.json<{ wordCount?: number; context?: string }>().catch(() => ({ wordCount: undefined, context: undefined }));
+    const body = await c.req
+      .json<{ wordCount?: number; context?: string; service?: string; model?: string }>()
+      .catch(() => ({ wordCount: undefined, context: undefined, service: undefined, model: undefined }));
 
     broadcast("draft:start", { bookId: id });
 
-    const pipeline = new PipelineRunner(await buildPipelineConfig());
+    const pipeline = new PipelineRunner(await buildPipelineConfig({
+      selectedService: body.service,
+      selectedModel: body.model,
+    }));
     pipeline.writeDraft(id, body.context, body.wordCount).then(
       (result) => {
         broadcast("draft:complete", { bookId: id, chapterNumber: result.chapterNumber, title: result.title, wordCount: result.wordCount });
@@ -1697,13 +1854,25 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
   app.get("/api/v1/services", async (c) => {
     const secrets = await loadSecrets(root);
     const endpoints = getAllEndpoints().filter((ep) => ep.id !== "custom");
+    const codexOAuthStatus = endpoints.some((ep) => isCodexOAuthService(ep.id))
+      ? await getCodexOAuthStatus()
+      : null;
 
     // Fast: only check connection status from secrets, no external API calls.
-    const services = endpoints.map((ep) => ({
+    const services: StudioServiceListItem[] = endpoints.map((ep) => ({
       service: ep.id,
       label: ep.label,
       group: ep.group,
-      connected: Boolean(secrets.services[ep.id]?.apiKey),
+      ...(ep.authKind ? { authKind: ep.authKind } : {}),
+      connected: isCodexOAuthService(ep.id)
+        ? Boolean(codexOAuthStatus?.connected)
+        : Boolean(secrets.services[ep.id]?.apiKey),
+      ...(isCodexOAuthService(ep.id) && codexOAuthStatus ? {
+        accountId: codexOAuthStatus.accountId,
+        expiresAt: codexOAuthStatus.expiresAt,
+        authPath: codexOAuthStatus.authPath,
+        message: codexOAuthStatus.message,
+      } : {}),
     })).sort(compareServiceListItems);
 
     // Add custom services from inkos.json
@@ -1878,10 +2047,11 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     }
 
     const baseService = isCustomServiceId(service) ? "custom" : service;
-    const apiKeyOptional = isApiKeyOptionalForEndpoint({
-      provider: resolveServiceProviderFamily(baseService) ?? "openai",
-      baseUrl: resolvedBaseUrl,
-    });
+    const apiKeyOptional = isCodexOAuthService(baseService)
+      || isApiKeyOptionalForEndpoint({
+        provider: resolveServiceProviderFamily(baseService) ?? "openai",
+        baseUrl: resolvedBaseUrl,
+      });
     if (!apiKey?.trim() && !apiKeyOptional) {
       return c.json({
         ok: false,
@@ -1936,6 +2106,21 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.put("/api/v1/services/:service/secret", async (c) => {
     const service = c.req.param("service");
+    if (isCodexOAuthService(service)) {
+      const status = await getCodexOAuthStatus();
+      return c.json({
+        ok: status.connected,
+        authKind: "codexOAuth",
+        connected: status.connected,
+        authMode: status.authMode,
+        accountId: status.accountId,
+        expiresAt: status.expiresAt,
+        lastRefresh: status.lastRefresh,
+        authPath: status.authPath,
+        message: status.message,
+      });
+    }
+
     const { apiKey } = await c.req.json<{ apiKey: string }>();
     const secrets = await loadSecrets(root);
     const trimmedKey = apiKey?.trim() ?? "";
@@ -1956,6 +2141,21 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.get("/api/v1/services/:service/secret", async (c) => {
     const service = c.req.param("service");
+    if (isCodexOAuthService(service)) {
+      const status = await getCodexOAuthStatus();
+      return c.json({
+        apiKey: "",
+        authKind: "codexOAuth",
+        connected: status.connected,
+        authMode: status.authMode,
+        accountId: status.accountId,
+        expiresAt: status.expiresAt,
+        lastRefresh: status.lastRefresh,
+        authPath: status.authPath,
+        message: status.message,
+      });
+    }
+
     const secrets = await loadSecrets(root);
     return c.json({
       apiKey: secrets.services[service]?.apiKey ?? "",
@@ -1964,22 +2164,18 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.get("/api/v1/services/models", async (c) => {
     const secrets = await loadSecrets(root);
+    const codexOAuthStatus = await getCodexOAuthStatus();
     const endpoints = getAllEndpoints()
-      .filter((ep) => ep.id !== "custom" && Boolean(secrets.services[ep.id]?.apiKey));
+      .filter((ep) => ep.id !== "custom")
+      .filter((ep) => isCodexOAuthService(ep.id) ? codexOAuthStatus.connected : Boolean(secrets.services[ep.id]?.apiKey));
 
-    const groups = endpoints.map((ep) => ({
+    const groups = await Promise.all(endpoints.map(async (ep) => ({
       service: ep.id,
       label: ep.label,
-      models: ep.models
-        .filter((m) => m.enabled !== false)
-        .filter((m) => isTextChatModelId(m.id))
-        .map((m) => ({
-          id: m.id,
-          name: m.id,
-          ...(typeof m.maxOutput === "number" ? { maxOutput: m.maxOutput } : {}),
-          ...(m.contextWindowTokens > 0 ? { contextWindow: m.contextWindowTokens } : {}),
-        })),
-    }));
+      models: isCodexOAuthService(ep.id)
+        ? await codexOAuthModelInfos().catch(() => endpointModelInfos(ep))
+        : endpointModelInfos(ep),
+    })));
 
     return c.json({ groups });
   });
@@ -2016,6 +2212,23 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
   app.get("/api/v1/services/:service/models", async (c) => {
     const service = c.req.param("service");
     const refresh = c.req.query("refresh") === "1";
+    if (isCodexOAuthService(service)) {
+      const status = await getCodexOAuthStatus();
+      if (!status.connected) return c.json({ models: [] });
+
+      const cacheKey = `${CODEX_OAUTH_SERVICE_ID}::runtime`;
+      if (!refresh) {
+        const cached = modelListCache.get(cacheKey);
+        if (cached && Date.now() - cached.at < 10 * 60 * 1000) {
+          return c.json({ models: cached.models });
+        }
+      }
+
+      const models = await codexOAuthModelInfos();
+      modelListCache.set(cacheKey, { models, at: Date.now() });
+      return c.json({ models });
+    }
+
     const secrets = await loadSecrets(root);
     const apiKey = c.req.query("apiKey") || secrets.services[service]?.apiKey || "";
 

--- a/packages/studio/src/pages/BookDetail.tsx
+++ b/packages/studio/src/pages/BookDetail.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from "../hooks/use-i18n";
 import type { SSEMessage } from "../hooks/use-sse";
 import { useColors } from "../hooks/use-colors";
 import { deriveBookActivity, shouldRefetchBookView } from "../hooks/use-book-activity";
+import { useChatStore } from "../store/chat";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import {
   ChevronLeft,
@@ -108,6 +109,11 @@ export function BookDetail({
   const [settingsStatus, setSettingsStatus] = useState<BookStatus | null>(null);
   const [exportFormat, setExportFormat] = useState<ExportFormat>("txt");
   const [exportApprovedOnly, setExportApprovedOnly] = useState(false);
+  const selectedModel = useChatStore((s) => s.selectedModel);
+  const selectedService = useChatStore((s) => s.selectedService);
+  const selectedLlm = selectedService && selectedModel
+    ? { service: selectedService, model: selectedModel }
+    : undefined;
   const activity = useMemo(() => deriveBookActivity(sse.messages, bookId), [bookId, sse.messages]);
   const writing = writeRequestPending || activity.writing;
   const drafting = draftRequestPending || activity.drafting;
@@ -140,7 +146,7 @@ export function BookDetail({
   const handleWriteNext = async () => {
     setWriteRequestPending(true);
     try {
-      await postApi(`/books/${bookId}/write-next`);
+      await postApi(`/books/${bookId}/write-next`, selectedLlm);
     } catch (e) {
       setWriteRequestPending(false);
       alert(e instanceof Error ? e.message : "Failed");
@@ -150,7 +156,7 @@ export function BookDetail({
   const handleDraft = async () => {
     setDraftRequestPending(true);
     try {
-      await postApi(`/books/${bookId}/draft`);
+      await postApi(`/books/${bookId}/draft`, selectedLlm);
     } catch (e) {
       setDraftRequestPending(false);
       alert(e instanceof Error ? e.message : "Failed");

--- a/packages/studio/src/pages/Dashboard.tsx
+++ b/packages/studio/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { fetchJson, useApi, postApi } from "../hooks/use-api";
 import { useEffect, useMemo, useState, useRef } from "react";
 import { useServiceStore } from "../store/service";
+import { useChatStore } from "../store/chat";
 import type { SSEMessage } from "../hooks/use-sse";
 import type { Theme } from "../hooks/use-theme";
 import type { TFunction } from "../hooks/use-i18n";
@@ -134,6 +135,11 @@ export function Dashboard({ nav, sse, theme, t }: { nav: Nav; sse: { messages: R
   const writingBooks = useMemo(() => deriveActiveBookIds(sse.messages), [sse.messages]);
   const serviceStoreServices = useServiceStore((s) => s.services);
   const fetchServices = useServiceStore((s) => s.fetchServices);
+  const selectedModel = useChatStore((s) => s.selectedModel);
+  const selectedService = useChatStore((s) => s.selectedService);
+  const selectedLlm = selectedService && selectedModel
+    ? { service: selectedService, model: selectedModel }
+    : undefined;
   useEffect(() => { void fetchServices(); }, [fetchServices]);
   const hasServices = serviceStoreServices.some((s) => s.connected);
 
@@ -275,7 +281,7 @@ export function Dashboard({ nav, sse, theme, t }: { nav: Nav; sse: { messages: R
                 <div className="flex items-center gap-3 shrink-0 ml-6">
                   <button
                     onClick={async () => {
-                      try { await postApi(`/books/${book.id}/write-next`); }
+                      try { await postApi(`/books/${book.id}/write-next`, selectedLlm); }
                       catch (e) { alert(e instanceof Error ? e.message : "Write failed"); }
                     }}
                     disabled={isWriting}

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   type ServiceDetailConnectionStatus as ConnectionStatus,
   type ServiceDetailDetectedConfig as DetectedConfig,
   type ServiceDetailModelInfo as ModelInfo,
+  type ServiceDetailRuntimeAuthStatus as RuntimeAuthStatus,
   type ServiceDetailVerifiedProbe as VerifiedProbe,
 } from "./service-detail-state";
 
@@ -43,6 +44,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
 
   const svc = services.find((s) => s.service === serviceId);
   const isCustom = serviceId === "custom" || serviceId.startsWith("custom:");
+  const usesRuntimeAuth = svc?.authKind === "codexOAuth" || serviceId === "codexOAuth";
   const persistedCustomName = serviceId.startsWith("custom:") ? decodeURIComponent(serviceId.slice("custom:".length)) : "";
 
   // -- Local form state --
@@ -56,6 +58,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [detectedModel, setDetectedModel] = useState<string>("");
   const [detectedConfig, setDetectedConfig] = useState<DetectedConfig | null>(null);
   const [verifiedProbe, setVerifiedProbe] = useState<VerifiedProbe | null>(null);
+  const [runtimeAuthStatus, setRuntimeAuthStatus] = useState<RuntimeAuthStatus | null>(null);
 
   // -- Unified connection status --
   const [status, setStatus] = useState<ConnectionStatus>({ state: "idle" });
@@ -79,6 +82,12 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
     return () => { cancelled = true; };
   }, [isCustom, persistedCustomName, serviceId]);
 
+  useEffect(() => {
+    if (!usesRuntimeAuth) return;
+    setApiFormat("responses");
+    setStream(true);
+  }, [usesRuntimeAuth]);
+
   const resolvedCustomName = persistedCustomName || customName.trim() || "Custom";
   const effectiveServiceId = isCustom ? `custom:${resolvedCustomName}` : serviceId;
   const label = isCustom ? (customName || persistedCustomName || "自定义服务") : (svc?.label ?? serviceId);
@@ -99,6 +108,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         setApiKey(result.apiKey);
         setDetectedModel(result.detectedModel);
         setDetectedConfig(result.detectedConfig);
+        setRuntimeAuthStatus(result.runtimeAuthStatus);
         setStatus(result.status);
         if (result.status.state === "connected") {
           setStoreModels(effectiveServiceId, result.status.models);
@@ -129,7 +139,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   // -- Handlers --
   const handleTest = async () => {
     const trimmedKey = apiKey.trim();
-    if (!trimmedKey && !isCustom) {
+    if (!trimmedKey && !isCustom && !usesRuntimeAuth) {
       setStatus({ state: "error", message: "请先输入 API Key" });
       return;
     }
@@ -203,6 +213,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
       const result = await saveServiceConfig({
         effectiveServiceId,
         serviceId,
+        ...(usesRuntimeAuth ? { authKind: "codexOAuth" as const } : {}),
         isCustom,
         resolvedCustomName,
         apiKey: trimmedKey,
@@ -269,20 +280,37 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
           </div>
         )}
 
-        {/* API Key */}
-        <Field label="API Key">
-          <div className="relative">
-            <input
-              type={showKey ? "text" : "password"} value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)} placeholder="sk-..."
-              className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 pr-10 text-sm font-mono"
-            />
-            <button type="button" onClick={() => setShowKey((v) => !v)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors">
-              {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
-            </button>
+        {usesRuntimeAuth ? (
+          <div className="rounded-lg border border-border/60 bg-secondary/20 px-3 py-3 text-sm">
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-medium">Codex OAuth</span>
+              <span className={runtimeAuthStatus?.connected ? "text-emerald-500" : "text-muted-foreground"}>
+                {runtimeAuthStatus?.connected ? "已登录" : "未登录"}
+              </span>
+            </div>
+            <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+              {runtimeAuthStatus?.accountId && <p>账号：{runtimeAuthStatus.accountId}</p>}
+              {runtimeAuthStatus?.expiresAt && <p>过期时间：{new Date(runtimeAuthStatus.expiresAt).toLocaleString()}</p>}
+              {runtimeAuthStatus?.authPath && <p className="font-mono break-all">认证文件：{runtimeAuthStatus.authPath}</p>}
+              {runtimeAuthStatus?.message && <p>{runtimeAuthStatus.message}</p>}
+              {!runtimeAuthStatus?.message && !runtimeAuthStatus?.connected && <p>请先在终端运行 codex login。</p>}
+            </div>
           </div>
-        </Field>
+        ) : (
+          <Field label="API Key">
+            <div className="relative">
+              <input
+                type={showKey ? "text" : "password"} value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)} placeholder="sk-..."
+                className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 pr-10 text-sm font-mono"
+              />
+              <button type="button" onClick={() => setShowKey((v) => !v)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors">
+                {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            </div>
+          </Field>
+        )}
 
         {/* Actions + feedback */}
         <div className="flex items-center gap-2">
@@ -323,6 +351,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
             <select
               value={apiFormat}
               onChange={(e) => setApiFormat(e.target.value as "chat" | "responses")}
+              disabled={usesRuntimeAuth}
               className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm"
             >
               <option value="chat">Chat / Completions</option>
@@ -336,6 +365,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
                 type="checkbox"
                 checked={stream}
                 onChange={(e) => setStream(e.target.checked)}
+                disabled={usesRuntimeAuth}
               />
               <span>{stream ? "开启" : "关闭"}</span>
             </label>

--- a/packages/studio/src/pages/service-detail-state.test.ts
+++ b/packages/studio/src/pages/service-detail-state.test.ts
@@ -279,6 +279,56 @@ describe("saveServiceConfig", () => {
     ]);
     expect(result.status).toEqual({ state: "connected", models: [{ id: "qwen3.6:35b-a3b" }] });
   });
+
+  it("saves Codex OAuth config without persisting a project secret", async () => {
+    const calls: string[] = [];
+    const bodies: unknown[] = [];
+    const fetchJsonImpl = vi.fn(async (path: string, init?: { body?: string }) => {
+      calls.push(path);
+      if (init?.body) bodies.push(JSON.parse(init.body));
+      if (path === "/services/codexOAuth/test") {
+        return {
+          ok: true,
+          models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
+          selectedModel: "gpt-5.5",
+          detected: { apiFormat: "responses", stream: true },
+        };
+      }
+      if (path === "/services/config") return { ok: true };
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const result = await saveServiceConfig({
+      effectiveServiceId: "codexOAuth",
+      serviceId: "codexOAuth",
+      authKind: "codexOAuth",
+      isCustom: false,
+      resolvedCustomName: "",
+      apiKey: "",
+      baseUrl: "",
+      apiFormat: "responses",
+      stream: true,
+      temperature: "1",
+      detectedModel: "",
+      fetchJsonImpl: fetchJsonImpl as never,
+    });
+
+    expect(calls).toEqual([
+      "/services/codexOAuth/test",
+      "/services/config",
+    ]);
+    expect(bodies).toEqual([
+      { apiKey: "", apiFormat: "responses", stream: true },
+      {
+        service: "codexOAuth",
+        defaultModel: "gpt-5.5",
+        services: [
+          { service: "codexOAuth", temperature: 1, apiFormat: "responses", stream: true },
+        ],
+      },
+    ]);
+    expect(result.status).toEqual({ state: "connected", models: [{ id: "gpt-5.5", name: "GPT-5.5" }] });
+  });
 });
 
 describe("deleteServiceConfig", () => {

--- a/packages/studio/src/pages/service-detail-state.ts
+++ b/packages/studio/src/pages/service-detail-state.ts
@@ -12,6 +12,17 @@ export interface ServiceDetailDetectedConfig {
   readonly modelsSource?: "api" | "fallback";
 }
 
+export interface ServiceDetailRuntimeAuthStatus {
+  readonly authKind?: "apiKey" | "codexOAuth";
+  readonly connected?: boolean;
+  readonly authMode?: string;
+  readonly accountId?: string;
+  readonly expiresAt?: string;
+  readonly lastRefresh?: string;
+  readonly authPath?: string;
+  readonly message?: string;
+}
+
 export type ServiceDetailConnectionStatus =
   | { state: "idle" }
   | { state: "testing" }
@@ -74,9 +85,10 @@ export async function rehydrateServiceConnectionStatus(args: {
   readonly status: ServiceDetailConnectionStatus;
   readonly detectedModel: string;
   readonly detectedConfig: ServiceDetailDetectedConfig | null;
+  readonly runtimeAuthStatus: ServiceDetailRuntimeAuthStatus | null;
 }> {
   const fetchJsonImpl = args.fetchJsonImpl ?? fetchJson;
-  const secret = await fetchJsonImpl<{ apiKey?: string }>(
+  const secret = await fetchJsonImpl<{ apiKey?: string } & ServiceDetailRuntimeAuthStatus>(
     `/services/${encodeURIComponent(args.effectiveServiceId)}/secret`,
   );
   const apiKey = String(secret.apiKey ?? "");
@@ -86,6 +98,7 @@ export async function rehydrateServiceConnectionStatus(args: {
     status: { state: "idle" },
     detectedModel: "",
     detectedConfig: null,
+    runtimeAuthStatus: secret.authKind === "codexOAuth" ? secret : null,
   };
 }
 
@@ -106,6 +119,7 @@ export function matchServiceConfigEntryForDetail(
 export async function saveServiceConfig(args: {
   readonly effectiveServiceId: string;
   readonly serviceId: string;
+  readonly authKind?: "apiKey" | "codexOAuth";
   readonly isCustom: boolean;
   readonly resolvedCustomName: string;
   readonly apiKey: string;
@@ -124,8 +138,9 @@ export async function saveServiceConfig(args: {
   const fetchJsonImpl = args.fetchJsonImpl ?? fetchJson;
   const trimmedKey = args.apiKey.trim();
   const trimmedBaseUrl = args.baseUrl.trim();
+  const usesRuntimeAuth = args.authKind === "codexOAuth";
 
-  if (!trimmedKey && !args.isCustom) {
+  if (!trimmedKey && !args.isCustom && !usesRuntimeAuth) {
     return {
       status: { state: "error", message: "请先输入 API Key" },
       detectedModel: "",
@@ -189,11 +204,13 @@ export async function saveServiceConfig(args: {
   const savedStream = typeof detectedConfig?.stream === "boolean" ? detectedConfig.stream : args.stream;
   const savedBaseUrl = args.isCustom ? (detectedConfig?.baseUrl ?? trimmedBaseUrl) : undefined;
 
-  await fetchJsonImpl(`/services/${encodeURIComponent(args.effectiveServiceId)}/secret`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ apiKey: trimmedKey }),
-  });
+  if (!usesRuntimeAuth) {
+    await fetchJsonImpl(`/services/${encodeURIComponent(args.effectiveServiceId)}/secret`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiKey: trimmedKey }),
+    });
+  }
 
   await fetchJsonImpl("/services/config", {
     method: "PUT",

--- a/packages/studio/src/store/service/types.ts
+++ b/packages/studio/src/store/service/types.ts
@@ -9,7 +9,12 @@ export interface ServiceInfo {
   readonly service: string;
   readonly label: string;
   readonly group?: EndpointGroup;
+  readonly authKind?: "apiKey" | "codexOAuth";
   readonly connected: boolean;
+  readonly accountId?: string;
+  readonly expiresAt?: string;
+  readonly authPath?: string;
+  readonly message?: string;
 }
 
 export interface ModelInfo {


### PR DESCRIPTION
## Summary

- Added Codex OAuth as a keyless LLM provider backed by local `CODEX_HOME/auth.json`.
- Wired Codex OAuth through CLI setup, core LLM/runtime auth, Studio service management, model discovery, and write/draft model selection.
- Added coverage for OAuth status parsing, runtime headers, provider resolution, Studio APIs, and service save flows.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [x] Test
- [ ] Performance

## Motivation (optional)

Use an existing local Codex ChatGPT OAuth login as InkOS runtime credentials while keeping project service config keyless.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/llm/codex-oauth.ts` | Adds Codex OAuth status parsing, header generation, token expiry checks, and live model discovery. |
| `packages/core/src/llm/providers/endpoints/codexOAuth.ts` | Registers the `codexOAuth` provider and default `gpt-5.5` model card. |
| `packages/core/src/llm/provider.ts` | Routes Codex OAuth through `openai-codex` transport, injects runtime auth, and adapts Codex Responses options. |
| `packages/core/src/agent/agent-session.ts` | Passes Codex OAuth runtime credentials into pi-agent sessions and includes headers in cache identity. |
| `packages/core/src/llm/service-presets.ts` / `service-resolver.ts` | Supports keyless Codex OAuth model listing and service model resolution. |
| `packages/core/src/utils/effective-llm-config.ts` | Allows Codex OAuth configs to resolve without a stored API key. |
| `packages/core/src/index.ts` | Exports Codex OAuth helpers and types. |
| `packages/core/src/llm/providers/index.ts` / `types.ts` | Adds Codex OAuth to the provider registry and provider schema types. |
| `packages/cli/src/tui/setup.ts` | Adds `codexOAuth` to interactive setup, writes keyless env config, and detects usable keyless config. |
| `packages/studio/src/api/server.ts` | Adds Codex OAuth service status, secret, model, probe, and write-next fallback handling. |
| `packages/studio/src/pages/ServiceDetailPage.tsx` / `service-detail-state.ts` | Shows runtime auth status and saves Codex OAuth config as a keyless service. |
| `packages/studio/src/pages/BookDetail.tsx` / `Dashboard.tsx` | Sends selected service/model overrides into draft and write-next actions. |
| `packages/studio/src/store/service/types.ts` | Extends service metadata with runtime auth status fields. |
| `packages/**/__tests__/*` | Adds and updates tests for Codex OAuth auth, provider resolution, Studio API behavior, CLI setup, and schema coverage. |

## Usage (optional)

```bash
codex login
inkos tui
# Provider: codexOAuth
# Model: gpt-5.5
```

Generated env config:

```env
INKOS_LLM_PROVIDER=openai
INKOS_LLM_SERVICE=codexOAuth
INKOS_LLM_BASE_URL=https://chatgpt.com/backend-api/codex
INKOS_LLM_MODEL=gpt-5.5
INKOS_LLM_API_FORMAT=responses
INKOS_LLM_STREAM=true
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all existing + new tests)
- [ ] Manual verification: select Codex OAuth in Studio, confirm login status, test connection, save config, then run draft/write-next with the selected model.

## Breaking changes (optional)

Public API, CLI flags, and config format remain compatible.
