### PR TITLE
fix: make sure update preview text when source file has been changed …

### DIFF
--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -2440,6 +2440,13 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       response: expect.stringContaining("已直接编辑 demo-book 第 3 章"),
+      details: {
+        contentChanged: {
+          kind: "chapter",
+          bookId: "demo-book",
+          chapterNumber: 3,
+        },
+      },
       session: {
         sessionId: "agent-session-1",
         activeBookId: "demo-book",

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -240,6 +240,15 @@ function isWriteNextInstruction(instruction: string): boolean {
 type ExternalChatEditResult = {
   readonly responseText: string;
   readonly activeBookId?: string;
+  readonly contentChanged: {
+    readonly kind: "chapter";
+    readonly bookId: string;
+    readonly chapterNumber: number;
+  } | {
+    readonly kind: "file";
+    readonly path: string;
+    readonly bookId?: string;
+  };
 };
 
 const CHAT_EDIT_WARNING = "[warning] Chat external edit requires review before continuation.";
@@ -396,6 +405,9 @@ async function tryHandleExternalChatEdit(params: {
 
     return {
       activeBookId: chapterTarget?.bookId ?? params.activeBookId ?? undefined,
+      contentChanged: chapterTarget
+        ? { kind: "chapter", bookId: chapterTarget.bookId, chapterNumber: chapterTarget.chapterNumber }
+        : { kind: "file", path: target.rel, ...(params.activeBookId ? { bookId: params.activeBookId } : {}) },
       responseText: `已直接编辑 ${target.rel}${chapterTarget ? "，并标记为需要复核" : ""}。`,
     };
   }
@@ -433,6 +445,7 @@ async function tryHandleExternalChatEdit(params: {
 
   return {
     activeBookId: params.activeBookId,
+    contentChanged: { kind: "chapter", bookId: params.activeBookId, chapterNumber },
     responseText: `已直接编辑 ${params.activeBookId} 第 ${chapterNumber} 章，并标记为需要复核。`,
   };
 }
@@ -2405,6 +2418,9 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
         broadcast("agent:complete", { instruction, activeBookId: externalEdit.activeBookId, sessionId: bookSession.sessionId });
         return c.json({
           response: externalEdit.responseText,
+          details: {
+            contentChanged: externalEdit.contentChanged,
+          },
           session: {
             sessionId: bookSession.sessionId,
             ...(externalEdit.activeBookId ? { activeBookId: externalEdit.activeBookId } : {}),

--- a/packages/studio/src/components/chat/BookSidebar.test.ts
+++ b/packages/studio/src/components/chat/BookSidebar.test.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("BookSidebar artifact preview", () => {
+  it("refetches the open artifact when book data changes", async () => {
+    const source = await readFile(join(here, "BookSidebar.tsx"), "utf-8");
+
+    expect(source).toContain("const bookDataVersion = useChatStore((s) => s.bookDataVersion);");
+    expect(source).toContain("[bookId, artifactFile, artifactChapter, isChapter, artifactKey, bookDataVersion]");
+  });
+
+  it("preserves the preview scroll position while refreshing the same artifact", async () => {
+    const source = await readFile(join(here, "BookSidebar.tsx"), "utf-8");
+
+    expect(source).toContain("const scrollRef = useRef<HTMLDivElement>(null);");
+    expect(source).toContain("const refreshingSameArtifact = lastArtifactKeyRef.current === artifactKey;");
+    expect(source).toContain("const previousScrollTop = refreshingSameArtifact ? scrollRef.current?.scrollTop ?? null : null;");
+    expect(source).toContain("scrollRef.current.scrollTop = previousScrollTop;");
+    expect(source).toContain("ref={scrollRef}");
+    expect(source).toContain("if (!refreshingSameArtifact) {");
+    expect(source).toContain("setLoading(true);");
+  });
+});

--- a/packages/studio/src/components/chat/BookSidebar.tsx
+++ b/packages/studio/src/components/chat/BookSidebar.tsx
@@ -36,7 +36,10 @@ const streamdownPlugins = { cjk };
 function ArtifactView({ bookId }: { readonly bookId: string }) {
   const artifactFile = useChatStore((s) => s.artifactFile);
   const artifactChapter = useChatStore((s) => s.artifactChapter);
+  const bookDataVersion = useChatStore((s) => s.bookDataVersion);
   const closeArtifact = useChatStore((s) => s.closeArtifact);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const lastArtifactKeyRef = useRef<string | null>(null);
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState(false);
@@ -44,25 +47,73 @@ function ArtifactView({ bookId }: { readonly bookId: string }) {
   const [saving, setSaving] = useState(false);
 
   const isChapter = artifactChapter !== null;
+  const artifactKey = isChapter
+    ? `chapter:${artifactChapter}`
+    : artifactFile ? `file:${artifactFile}` : null;
   const label = isChapter
     ? `第 ${artifactChapter} 章`
     : artifactFile ? FOUNDATION_LABELS[artifactFile] ?? artifactFile : "";
 
   useEffect(() => {
-    setEditing(false);
-    setLoading(true);
+    if (!artifactKey) {
+      setContent(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const refreshingSameArtifact = lastArtifactKeyRef.current === artifactKey;
+    const previousScrollTop = refreshingSameArtifact ? scrollRef.current?.scrollTop ?? null : null;
+    lastArtifactKeyRef.current = artifactKey;
+
+    if (!refreshingSameArtifact) {
+      setEditing(false);
+      setLoading(true);
+    }
+
+    const restoreScroll = () => {
+      if (previousScrollTop === null || typeof requestAnimationFrame === "undefined") return;
+      requestAnimationFrame(() => {
+        if (!cancelled && lastArtifactKeyRef.current === artifactKey && scrollRef.current) {
+          scrollRef.current.scrollTop = previousScrollTop;
+        }
+      });
+    };
+
     if (isChapter) {
       fetchJson<{ content: string }>(`/books/${bookId}/chapters/${artifactChapter}`)
-        .then((data) => setContent(data.content ?? ""))
-        .catch(() => setContent(null))
-        .finally(() => setLoading(false));
+        .then((data) => {
+          if (!cancelled) setContent(data.content ?? "");
+        })
+        .catch(() => {
+          if (!cancelled) setContent(null);
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setLoading(false);
+            restoreScroll();
+          }
+        });
     } else if (artifactFile) {
       fetchJson<{ content: string | null }>(`/books/${bookId}/truth/${artifactFile}`)
-        .then((data) => setContent(data.content ?? ""))
-        .catch(() => setContent(null))
-        .finally(() => setLoading(false));
+        .then((data) => {
+          if (!cancelled) setContent(data.content ?? "");
+        })
+        .catch(() => {
+          if (!cancelled) setContent(null);
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setLoading(false);
+            restoreScroll();
+          }
+        });
     }
-  }, [bookId, artifactFile, artifactChapter, isChapter]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bookId, artifactFile, artifactChapter, isChapter, artifactKey, bookDataVersion]);
 
   const handleEdit = useCallback(() => {
     setEditContent(content ?? "");
@@ -130,7 +181,7 @@ function ArtifactView({ bookId }: { readonly bookId: string }) {
           </div>
         )}
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
         {loading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 size={16} className="text-muted-foreground animate-spin" />

--- a/packages/studio/src/store/chat/slices/message/action.ts
+++ b/packages/studio/src/store/chat/slices/message/action.ts
@@ -354,6 +354,9 @@ export const createMessageSlice: StateCreator<ChatStore, [], [], MessageActions>
       });
 
       streamEs.close();
+      if (data.details?.contentChanged) {
+        get().bumpBookDataVersion();
+      }
 
       const finalContent = data.details?.draftRaw || data.response || "";
       const toolCall = data.details?.toolCall ?? undefined;

--- a/packages/studio/src/store/chat/types.ts
+++ b/packages/studio/src/store/chat/types.ts
@@ -73,6 +73,15 @@ export interface AgentResponse {
   readonly details?: {
     readonly draftRaw?: string;
     readonly toolCall?: ToolCall;
+    readonly contentChanged?: {
+      readonly kind: "chapter";
+      readonly bookId: string;
+      readonly chapterNumber: number;
+    } | {
+      readonly kind: "file";
+      readonly path: string;
+      readonly bookId?: string;
+    };
   };
   readonly session?: {
     readonly sessionId?: string;


### PR DESCRIPTION
…by agent

## Summary
<!-- 1-3 bullet points: what changed and why -->

- Refresh the Studio artifact preview when an agent changes the underlying chapter or content file.
- Preserve the current preview scroll position when refreshing the same chapter/file.
- Add regression coverage for preview refresh and direct chat edit change signaling.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation (optional)
<!-- Why this change is needed. Link issues if applicable. Closes #xxx -->

When the agent edited the currently open chapter, the right-side Studio preview could keep showing stale content until the user reopened or refreshed the view. Refreshing also disturbed the preview scroll position.


## Changes
<!-- File-level change list: what each file does -->

| File | Change |
|------|--------|
| `packages/studio/src/components/chat/BookSidebar.tsx` | Refetches open artifact previews on book data changes and preserves scroll position for same-artifact refreshes. |
| `packages/studio/src/components/chat/BookSidebar.test.ts` | Adds regression checks for artifact refetch behavior and scroll preservation. |
| `packages/studio/src/api/server.ts` | Returns `details.contentChanged` for direct chat edits so the frontend can detect content changes. |
| `packages/studio/src/api/server.test.ts` | Verifies direct chapter edits return content change metadata. |
| `packages/studio/src/store/chat/slices/message/action.ts` | Bumps `bookDataVersion` when `/agent` reports changed content. |
| `packages/studio/src/store/chat/types.ts` | Adds the `contentChanged` response type for agent responses. |


## Usage (optional)
<!-- Code snippets, CLI examples, or config samples showing how to use the new feature -->

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all existing + new tests)
- [x] Manual verification: <!-- describe manual test steps -->
open a chapter preview in Studio, ask the agent to edit that chapter, confirm the preview text updates while the scroll position stays unchanged

## Breaking changes (optional)
<!-- List any breaking changes to public API, CLI flags, config format, etc. -->

None