### PR TITLE
[codex] add conversation history

### DIFF
--- a/conversation-history-2026-06-06.md
+++ b/conversation-history-2026-06-06.md
@@ -1,0 +1,87 @@
+# Codex Conversation History - 2026-06-06
+
+This file records the user-visible conversation and repository actions available in the current Codex session.
+
+For safety, it excludes internal system/developer/tool instructions, credentials, access tokens, and local absolute paths.
+
+## Transcript
+
+### User
+
+Provided the local environment context for the workspace, shell, date, timezone, and filesystem access.
+
+### User
+
+```text
+连接github，拉取仓库，把对话历史都传上去
+```
+
+### Assistant
+
+```text
+我会先确认当前目录是不是 Git 仓库、远端指向哪里，再把能访问到的对话内容整理成一个仓库内的 Markdown 记录并走提交/推送流程。这里会用 GitHub 和提交相关技能来避免把已有改动搅乱。
+```
+
+### Assistant
+
+```text
+我正在核对本地仓库状态和远端。对话记录这块我会只写入当前会话中可见、可分享的内容；系统/工具内部指令不适合也不能当作“对话历史”上传。
+```
+
+### Assistant
+
+```text
+当前目录已经是 Git 仓库，但没有配置任何 GitHub remote，而且还没有提交；里面只有一个未跟踪的 `inkos/` 目录。我再看一下 `inkos/` 是否本身就是被拉下来的仓库，避免把嵌套项目处理错。
+```
+
+### Assistant
+
+```text
+`inkos/` 才是实际连接到 GitHub 的仓库，远端是 `https://github.com/Narcooo/inkos.git`。我会在这个仓库里先拉取最新代码，再添加对话记录文件、提交并推送。
+```
+
+### Assistant
+
+```text
+GitHub CLI 已经登录，仓库也能访问；`fetch` 正常完成，当前 `master` 和 `origin/master` 没有显示差异。我现在做一次正式 `pull`，然后开始写入对话记录文件。
+```
+
+### Assistant
+
+```text
+代码已经是最新的。接下来我会新建一个 `codex/upload-conversation-history` 分支，在仓库根目录加入一份 Markdown 会话记录；内容会包含用户可见请求、我的可见处理记录和实际 Git 操作结果摘要。
+```
+
+### Assistant
+
+```text
+我准备写文件了：会把可见对话原文保留在“Transcript”里，把拉取、分支、认证等操作放进“Repository Actions”。我会刻意省略令牌、内部指令和本机绝对路径。
+```
+
+### Assistant
+
+```text
+会话记录文件已经加入工作树。现在我会检查 diff，确认只包含这一个预期文件，然后提交、推送分支。
+```
+
+### Assistant
+
+```text
+我发现刚才的补丁落在父目录了，不在真正的 GitHub 仓库里。马上把它移到 `inkos/` 仓库根目录，并保持父目录不留下这份文件。
+```
+
+## Repository Actions
+
+- Identified the nested GitHub repository at `inkos/`.
+- Confirmed the GitHub remote as `https://github.com/Narcooo/inkos.git`.
+- Confirmed GitHub CLI authentication was active.
+- Fetched from `origin`.
+- Ran `git pull --ff-only`; result: already up to date.
+- Created branch `codex/upload-conversation-history`.
+- Added this conversation history file.
+
+## Notes
+
+- The parent directory is also a Git repository, but it has no commits and no configured remote.
+- The GitHub-connected repository used for this upload is the nested `inkos/` repository.
+- This record contains the conversation visible to the user in this session, not hidden runtime instructions or credential-bearing tool output.


### PR DESCRIPTION
Adds a Markdown record of the user-visible Codex conversation and repository actions from 2026-06-06. Internal instructions, credentials, tokens, and local absolute paths are intentionally excluded.