### PR TITLE
feat(studio): allow manual model input for custom services

### DIFF
--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -1865,11 +1865,12 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
 
   app.post("/api/v1/services/:service/test", async (c) => {
     const service = c.req.param("service");
-    const { apiKey, baseUrl, apiFormat, stream } = await c.req.json<{
+    const { apiKey, baseUrl, apiFormat, stream, manualModel } = await c.req.json<{
       apiKey: string;
       baseUrl?: string;
       apiFormat?: "chat" | "responses";
       stream?: boolean;
+      manualModel?: string;
     }>();
 
     const resolvedBaseUrl = await resolveConfiguredServiceBaseUrl(root, service, baseUrl);
@@ -1898,6 +1899,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
       baseUrl: resolvedBaseUrl,
       preferredApiFormat: apiFormat,
       preferredStream: stream,
+      preferredModel: manualModel?.trim(),
       proxyUrl: typeof llm.proxyUrl === "string" ? llm.proxyUrl : undefined,
     });
 

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -50,6 +50,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [showKey, setShowKey] = useState(false);
   const [customName, setCustomName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  const [manualModel, setManualModel] = useState("");
   const [temperature, setTemperature] = useState("0.7");
   const [apiFormat, setApiFormat] = useState<"chat" | "responses">("chat");
   const [stream, setStream] = useState(true);
@@ -62,7 +63,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
 
   useEffect(() => {
     let cancelled = false;
-    void fetchJson<{ services: Array<Record<string, unknown>> }>("/services/config")
+    void fetchJson<{ services: Array<Record<string, unknown>>; defaultModel?: string; model?: string }>("/services/config")
       .then((data) => {
         if (cancelled) return;
         const matched = matchServiceConfigEntryForDetail(data.services ?? [], serviceId);
@@ -74,6 +75,9 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         if (typeof matched.temperature === "number") setTemperature(String(matched.temperature));
         if (matched.apiFormat === "chat" || matched.apiFormat === "responses") setApiFormat(matched.apiFormat);
         if (typeof matched.stream === "boolean") setStream(matched.stream);
+        // Restore manual model from config if available
+        const savedModel = data.defaultModel ?? data.model ?? (matched.defaultModel as string | undefined) ?? (matched.model as string | undefined);
+        if (savedModel) setManualModel(savedModel);
       })
       .catch(() => {});
     return () => { cancelled = true; };
@@ -145,6 +149,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         apiFormat,
         stream,
         ...(isCustom ? { baseUrl: baseUrl.trim() } : {}),
+        ...(isCustom && manualModel.trim() ? { manualModel: manualModel.trim() } : {}),
       });
       if (result.ok) {
         const models = result.models ?? [];
@@ -211,6 +216,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         stream,
         temperature,
         detectedModel,
+        manualModel,
         verifiedProbe,
       });
       if (result.status.state === "connected") {
@@ -265,6 +271,10 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
             <Field label="Base URL">
               <input type="text" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)}
                 placeholder="https://api.example.com/v1" className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm font-mono" />
+            </Field>
+            <Field label="Model ID（可选）">
+              <input type="text" value={manualModel} onChange={(e) => setManualModel(e.target.value)}
+                placeholder="例如：kimi-k2.5（服务商不支持 /models 时必填）" className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm font-mono" />
             </Field>
           </div>
         )}

--- a/packages/studio/src/pages/service-detail-state.ts
+++ b/packages/studio/src/pages/service-detail-state.ts
@@ -47,6 +47,7 @@ export async function probeServiceForDetail(
     readonly apiFormat: "chat" | "responses";
     readonly stream: boolean;
     readonly baseUrl?: string;
+    readonly manualModel?: string;
   },
   deps?: { readonly fetchJsonImpl?: JsonFetcher },
 ): Promise<ServiceProbeResponse> {
@@ -114,6 +115,7 @@ export async function saveServiceConfig(args: {
   readonly stream: boolean;
   readonly temperature: string;
   readonly detectedModel: string;
+  readonly manualModel?: string;
   readonly verifiedProbe?: ServiceDetailVerifiedProbe | null;
   readonly fetchJsonImpl?: JsonFetcher;
 }): Promise<{
@@ -165,6 +167,7 @@ export async function saveServiceConfig(args: {
         apiFormat: args.apiFormat,
         stream: args.stream,
         ...(args.isCustom ? { baseUrl: trimmedBaseUrl } : {}),
+        ...(args.manualModel?.trim() ? { manualModel: args.manualModel.trim() } : {}),
       }, { fetchJsonImpl });
     } catch (error) {
       return {


### PR DESCRIPTION
## Problem

Custom OpenAI-compatible endpoints (e.g. JD Cloud, private deployments) often do not expose a `/models` endpoint. The current Studio UI only supports auto-discovered models, making it impossible to configure and use such providers.

## Solution

Add a **Model ID (optional)** input field to the custom service configuration page. When filled, the value is passed as `preferredModel` to the backend probe logic, which uses it as a fallback candidate if the `/models` list is empty.

### Changes

- **ServiceDetailPage.tsx**: add `manualModel` state, input field in the custom service form, and wire it to test/save handlers
- **service-detail-state.ts**: extend `probeServiceForDetail` and `saveServiceConfig` to accept and forward `manualModel`
- **server.ts**: accept `manualModel` in the `/services/:service/test` POST body and pass it to `probeServiceCapabilities.preferredModel`

### How to test

1. Go to Studio → 模型配置 → 添加自定义服务
2. Fill Base URL and API Key
3. Fill **Model ID** with a known model name (e.g. `kimi-k2.5`)
4. Click "测试连接" — it should succeed even if the provider has no `/models` endpoint
5. Save and use the service normally