### PR TITLE
[codex] add Kimi affiliate quick links

### DIFF
--- a/packages/studio/src/components/ServiceQuickLinks.tsx
+++ b/packages/studio/src/components/ServiceQuickLinks.tsx
@@ -6,10 +6,19 @@ interface ServiceQuickLink {
 }
 
 const SERVICE_QUICK_LINKS: Record<string, ReadonlyArray<ServiceQuickLink>> = {
+  kimicode: [
+    { label: "官网", href: "https://www.kimi.com?aff=inkos" },
+  ],
+  kimiCodingPlan: [
+    { label: "官网", href: "https://www.kimi.com?aff=inkos" },
+  ],
   kkaiapi: [
     { label: "官网", href: "https://kkaiapi.com/" },
     { label: "API 文档", href: "https://kkaiapi.com/docs" },
     { label: "模型/价格", href: "https://kkaiapi.com/models" },
+  ],
+  moonshot: [
+    { label: "开放平台", href: "https://platform.kimi.com?aff=inkos" },
   ],
   openrouter: [
     { label: "API Keys", href: "https://openrouter.ai/keys" },


### PR DESCRIPTION
## Summary
- Add concise Studio quick links for Moonshot, Kimi Code, and Kimi Coding Plan with the `aff=inkos` query string.
- Keep the provider list behavior unchanged, so all existing provider cards remain visible.
- Leave comments, API endpoints, provider registration, and tests unchanged.

## Links Added
- Moonshot: `https://platform.kimi.com?aff=inkos`
- Kimi Code: `https://www.kimi.com?aff=inkos`
- Kimi Coding Plan: `https://www.kimi.com?aff=inkos`

## Validation
- `git diff --check origin/master...HEAD`
- `pnpm typecheck`
- `pnpm build`
- Local Studio browser check at `http://localhost:4567/#/services`
