### PR TITLE
[codex] add MCP external-agent mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test-project/
 .gstack/
 .worktrees/
 docs/*
+!docs/mcp.md
 novel-to-comic-research.docx
 .pnpm-store/
 tmp/

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ inkos doctor
 - **开始创作入口**：长篇小说、短篇小说、同人创作、番外创作、仿写创作、续写创作、分支互动、开放世界都可以从 Studio 顶部入口进入。
 - **TUI 仪表盘**：`inkos tui` 进入终端全屏交互，适合键盘流用户。
 - **外部 Agent 入口**：`inkos interact --json --message "..."` 仍是 OpenClaw / 其他 agent 的结构化入口。
+- **MCP mode**：`inkos-mcp` 作为 stdio MCP server，让 Codex / Claude Code 在不替代 Studio / CLI 的前提下操作 InkOS 项目；需要 LLM 的生成、导入整理、续写和 truth/state 更新由外部 agent 自己完成，默认不要求 InkOS LLM API Key。详见 [docs/mcp.md](docs/mcp.md)。
 - **原子命令保留**：`plan` / `compose` / `draft` / `audit` / `revise` / `write next` 仍适合脚本和高级用户。
 
 ### 写第一本书

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,132 @@
+# InkOS MCP Mode
+
+InkOS MCP mode adds a stdio MCP server for external agent tools such as Codex and Claude Code. It does not replace Studio, TUI, CLI, or the OpenClaw Skill. Those entrypoints keep their existing behavior and may still use InkOS' internal LLM configuration.
+
+MCP mode is an **external-agent mode**: when a task needs generation, analysis, import settlement, continuation, or truth/state drafting, the connected agent tool's LLM does that work. InkOS MCP is responsible for project discovery, deterministic import, context bundling, file write-back, export, diagnosis, and index repair.
+
+## Install And Configure
+
+The package is published as `@actalk/inkos-mcp` and exposes:
+
+```bash
+inkos-mcp
+```
+
+Codex MCP config example:
+
+```json
+{
+  "mcpServers": {
+    "inkos": {
+      "command": "inkos-mcp",
+      "args": [],
+      "cwd": "/path/to/your/inkos/project"
+    }
+  }
+}
+```
+
+Claude Code stdio MCP config example:
+
+```json
+{
+  "mcpServers": {
+    "inkos": {
+      "command": "inkos-mcp",
+      "cwd": "/path/to/your/inkos/project"
+    }
+  }
+}
+```
+
+Start the MCP server from an InkOS project directory, or configure `cwd` to point at one. Then tell the external agent:
+
+```text
+我要通过 MCP 使用 InkOS
+```
+
+The agent should first call `inkos_project_status`, then `inkos_list_books`, and then ask what you want to do.
+
+## LLM Policy
+
+Default MCP mode does not require an InkOS LLM API Key. It does not read `.inkos/secrets.json`, project `.env`, or user `.env` secrets, and it does not run model connectivity checks.
+
+The external agent should use these MCP tools for LLM-backed work:
+
+- `inkos_agent_create_book_plan`
+- `inkos_agent_commit_book`
+- `inkos_agent_import_plan`
+- `inkos_agent_continue_plan`
+- `inkos_agent_commit_chapter`
+
+In this flow, the MCP server returns a stable task package and expected output shape. The external agent generates the text or truth/state content, then calls the corresponding commit/write tool. This keeps Studio/CLI intact while allowing Codex or Claude Code to perform the LLM portion through their own model session.
+
+Deterministic no-LLM tools are still available:
+
+- `inkos_import_preview`
+- `inkos_import_commit`
+- `inkos_get_context_bundle`
+- `inkos_update_control_doc`
+- `inkos_write_agent_chapter`
+- `inkos_export_book`
+- `inkos_diagnose_import`
+- `inkos_repair_project_index`
+
+`inkos_get_context_bundle` uses `maxChars` and `chapterWindow`, and it does not return the whole book by default. If an external agent needs exact full text, it should read a precise chapter resource such as:
+
+```text
+inkos://book/{bookId}/chapter/{chapterNumber}
+```
+
+## Create A Book
+
+1. Call `inkos_agent_create_book_plan` with a title and optional brief.
+2. The external agent generates foundation content such as author intent, current focus, story bible, rules, style notes, current state, and hooks.
+3. Call `inkos_agent_commit_book` with the generated foundation files.
+4. Call `inkos_inspect_book` to confirm the book is registered and readable.
+
+This provides the MCP equivalent of Studio's guided creation flow without requiring InkOS' internal LLM provider.
+
+## Import Existing Novels
+
+1. Put a `.txt` / `.md` file or a directory of chapter files inside the InkOS project.
+2. Call `inkos_import_preview` with `sourcePath`.
+3. Review recognized chapter titles, counts, short chapters, duplicates, and suggestions.
+4. Call `inkos_import_commit` with `mode: "new-book"`, `"append"`, or `"replace"` to register chapters deterministically.
+5. If you want Studio-style import settlement, call `inkos_agent_import_plan`. The external agent uses the returned task and chapter resources to draft truth/state, summaries, hooks, and style notes.
+6. Write generated control docs through `inkos_update_control_doc` or subsequent agent commit tools.
+7. Call `inkos_inspect_book`.
+
+`needsAgentSettlement: true` means chapters are registered and readable, but fine-grained truth/state extraction still needs an external agent settlement step. In MCP mode, that step should be done by the connected agent tool, not by asking the user to configure an InkOS API Key.
+
+## Continue Existing Books
+
+1. Call `inkos_agent_continue_plan` or `inkos_get_context_bundle`.
+2. The external agent writes the next chapter from the bounded context bundle.
+3. Call `inkos_agent_commit_chapter` with chapter text, summary, and any generated truth/state updates.
+4. Export or inspect as needed.
+
+Chapters written through `inkos_agent_commit_chapter` are recorded as external-agent generated. If the agent does not provide structured truth/state updates, InkOS marks the chapter as needing settlement instead of pretending that settlement happened.
+
+## Resources
+
+MCP mode exposes these resources:
+
+- `inkos://project/manifest`
+- `inkos://books`
+- `inkos://book/{bookId}/manifest`
+- `inkos://book/{bookId}/chapters`
+- `inkos://book/{bookId}/chapter/{chapterNumber}`
+- `inkos://book/{bookId}/context/continue`
+
+Secrets, `.env`, and `.inkos/secrets.json` are not exposed.
+
+## Prompts
+
+- `inkos_start`: start with project status and a Studio-style operation menu.
+- `inkos_import_existing_novel`: preview first, commit deterministic chapters, then run external-agent settlement if needed.
+- `inkos_continue_existing_book`: get a bounded context bundle, generate with the external agent, and write back through MCP.
+
+## Current Limits
+
+MCP mode reuses InkOS project files and indexes, but it does not call the internal Studio pipeline by default. The quality of generated foundation files, truth/state settlement, and chapter continuation depends on the external agent's output. Complex extraction can be less precise than a purpose-built InkOS internal agent run unless the external agent is prompted to produce equivalent structured files.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",
     "audit:semantic-patterns": "node scripts/audit-semantic-patterns.mjs",
-    "verify:publish-manifests": "node scripts/verify-no-workspace-protocol.mjs packages/core packages/cli packages/studio",
+    "verify:publish-manifests": "node scripts/verify-no-workspace-protocol.mjs packages/core packages/cli packages/studio packages/mcp",
     "benchmark:studio-e2e": "node scripts/studio-e2e-benchmark.mjs",
     "release": "pnpm build && pnpm test"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@actalk/inkos-mcp",
+  "version": "1.5.0",
+  "description": "InkOS MCP server for external-agent import, context, write-back, and export workflows",
+  "type": "module",
+  "bin": {
+    "inkos-mcp": "dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "!dist/__tests__"
+  ],
+  "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Narcooo/inkos.git",
+    "directory": "packages/mcp"
+  },
+  "scripts": {
+    "prepare:workspace-core": "pnpm --filter @actalk/inkos-core build",
+    "prepack": "node ../../scripts/prepare-package-for-publish.mjs",
+    "postpack": "node ../../scripts/restore-package-json.mjs",
+    "prepublishOnly": "node ../../scripts/verify-no-workspace-protocol.mjs .",
+    "prebuild": "pnpm run prepare:workspace-core",
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "pretypecheck": "pnpm run prepare:workspace-core",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@actalk/inkos-core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/mcp/src/__tests__/mcp-service.test.ts
+++ b/packages/mcp/src/__tests__/mcp-service.test.ts
@@ -1,0 +1,425 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInkosMcpService } from "../mcp-service.js";
+
+const now = "2026-01-01T00:00:00.000Z";
+
+describe("InkOS MCP external-agent service", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "inkos-mcp-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("reports non-project and project status without writing files", async () => {
+    const service = createInkosMcpService({ cwd: root });
+
+    const nonProject = await service.projectStatus();
+
+    expect(nonProject.isInkosProject).toBe(false);
+    expect(nonProject.manifestExists).toBe(false);
+    expect(nonProject.recommendedActions).toContain("进入已有 InkOS 项目目录，或先用 inkos init 初始化项目。");
+    await expect(stat(join(root, "books"))).rejects.toThrow();
+
+    await createProject(root);
+    await createBook(root, "river", "河灯", [
+      { number: 1, title: "旧港", content: "林月在旧港看见河灯。", status: "imported" },
+    ]);
+
+    const project = await service.projectStatus();
+
+    expect(project.isInkosProject).toBe(true);
+    expect(project.projectRoot).toBe(root);
+    expect(project.booksCount).toBe(1);
+    expect(project.books).toEqual([
+      expect.objectContaining({ bookId: "river", title: "河灯", chapterCount: 1 }),
+    ]);
+    expect(project.problems).toEqual([]);
+  });
+
+  it("previews a single txt file with Chinese and English chapter headings", async () => {
+    await createProject(root);
+    const sourcePath = join(root, "novel.txt");
+    await writeFile(sourcePath, [
+      "第001章 旧港",
+      "",
+      "林月在旧港看见河灯。",
+      "",
+      "Chapter 2: Fog",
+      "",
+      "The fog crossed the bridge.",
+    ].join("\n"), "utf-8");
+    const service = createInkosMcpService({ cwd: root });
+
+    const preview = await service.importPreview({ sourcePath });
+
+    expect(preview.ok).toBe(true);
+    expect(preview.chapterCount).toBe(2);
+    expect(preview.chapters.map((chapter) => chapter.title)).toEqual(["旧港", "Fog"]);
+    expect(preview.chapters[0]?.wordCount).toBeGreaterThan(0);
+    expect(preview.unrecognizedReason).toBeUndefined();
+  });
+
+  it("previews a directory of chapter files in natural chapter order", async () => {
+    await createProject(root);
+    const sourcePath = join(root, "chapters-src");
+    await mkdir(sourcePath);
+    await writeFile(join(sourcePath, "10_finale.md"), "# 第10章 终局\n\n终局正文。", "utf-8");
+    await writeFile(join(sourcePath, "2_middle.txt"), "第2章 中段\n\n中段正文。", "utf-8");
+    await writeFile(join(sourcePath, "001_start.txt"), "第一章 开端\n\n开端正文。", "utf-8");
+    const service = createInkosMcpService({ cwd: root });
+
+    const preview = await service.importPreview({ sourcePath });
+
+    expect(preview.ok).toBe(true);
+    expect(preview.chapters.map((chapter) => chapter.title)).toEqual(["开端", "中段", "终局"]);
+    expect(preview.chapters.map((chapter) => chapter.sourceFile)).toEqual([
+      "001_start.txt",
+      "2_middle.txt",
+      "10_finale.md",
+    ]);
+  });
+
+  it("commits a deterministic no-LLM import that listBooks and inspectBook can read", async () => {
+    await createProject(root);
+    const sourcePath = join(root, "novel.txt");
+    await writeFile(sourcePath, [
+      "第1章 旧港",
+      "",
+      "林月在旧港看见河灯。",
+      "",
+      "第2章 暗潮",
+      "",
+      "暗潮从桥底涌来。",
+    ].join("\n"), "utf-8");
+    const service = createInkosMcpService({ cwd: root });
+
+    const committed = await service.importCommit({
+      sourcePath,
+      title: "河灯",
+      mode: "new-book",
+    });
+
+    expect(committed.dryRun).toBe(false);
+    expect(committed.importedCount).toBe(2);
+    expect(committed.bookId).toBe("河灯");
+    expect(committed.modifiedFiles).toEqual(expect.arrayContaining([
+      "books/河灯/book.json",
+      "books/河灯/chapters/index.json",
+      "books/河灯/story/import-report.md",
+    ]));
+
+    const listed = await service.listBooks();
+    expect(listed.books).toEqual([
+      expect.objectContaining({
+        bookId: "河灯",
+        title: "河灯",
+        chapterCount: 2,
+        lastChapterNumber: 2,
+      }),
+    ]);
+
+    const inspected = await service.inspectBook({ bookId: "河灯" });
+    expect(inspected.metadata.title).toBe("河灯");
+    expect(inspected.chapters.map((chapter) => chapter.title)).toEqual(["旧港", "暗潮"]);
+    expect(inspected.controlDocs.author_intent).toBe(true);
+    expect(inspected.riskHints).toContain("deterministic_import_needs_agent_settlement");
+  });
+
+  it("keeps context bundles within the requested character budget", async () => {
+    await createProject(root);
+    await createBook(root, "river", "河灯", [
+      { number: 1, title: "旧港", content: "一".repeat(200), status: "imported" },
+      { number: 2, title: "暗潮", content: "二".repeat(200), status: "imported" },
+      { number: 3, title: "桥影", content: "三".repeat(200), status: "imported" },
+    ]);
+    const service = createInkosMcpService({ cwd: root });
+
+    const bundle = await service.getContextBundle({
+      bookId: "river",
+      purpose: "continue",
+      chapterWindow: 3,
+      maxChars: 180,
+    });
+
+    expect(bundle.budget.maxChars).toBe(180);
+    expect(bundle.budget.usedChars).toBeLessThanOrEqual(180);
+    expect(bundle.recentChapters.length).toBeGreaterThan(0);
+    expect(bundle.instructions).toContain("external agent");
+  });
+
+  it("writes an external-agent chapter and updates the chapter index", async () => {
+    await createProject(root);
+    await createBook(root, "river", "河灯", [
+      { number: 1, title: "旧港", content: "林月在旧港看见河灯。", status: "imported" },
+    ]);
+    const service = createInkosMcpService({ cwd: root });
+
+    const written = await service.writeAgentChapter({
+      bookId: "river",
+      title: "新潮",
+      content: "新潮推着河灯向城门漂去。",
+      summary: "林月发现新的潮水。",
+      approve: true,
+    });
+
+    expect(written.chapterNumber).toBe(2);
+    expect(written.status).toBe("approved");
+    expect(written.needsSettlement).toBe(true);
+    expect(written.modifiedFiles).toEqual(expect.arrayContaining([
+      "books/river/chapters/0002_新潮.md",
+      "books/river/chapters/index.json",
+      "books/river/story/import-report.md",
+    ]));
+
+    const index = JSON.parse(await readFile(join(root, "books", "river", "chapters", "index.json"), "utf-8"));
+    expect(index).toEqual(expect.arrayContaining([
+      expect.objectContaining({ number: 2, title: "新潮", status: "approved" }),
+    ]));
+  });
+
+  it("diagnoses and repairs chapter files that exist but are missing from index", async () => {
+    await createProject(root);
+    await createBook(root, "river", "河灯", [
+      { number: 1, title: "旧港", content: "林月在旧港看见河灯。", status: "imported" },
+    ]);
+    await writeFile(
+      join(root, "books", "river", "chapters", "0002_暗潮.md"),
+      "# 第2章 暗潮\n\n暗潮从桥底涌来。",
+      "utf-8",
+    );
+    const service = createInkosMcpService({ cwd: root });
+
+    const diagnosis = await service.diagnoseImport({ bookId: "river" });
+    expect(diagnosis.unindexedChapterFiles).toEqual([
+      expect.objectContaining({ chapterNumber: 2, file: "0002_暗潮.md" }),
+    ]);
+    expect(diagnosis.recommendedTool).toBe("inkos_repair_project_index");
+
+    const dryRun = await service.repairProjectIndex({ bookId: "river", dryRun: true });
+    expect(dryRun.dryRun).toBe(true);
+    expect(dryRun.modifiedFiles).toEqual([]);
+    let index = JSON.parse(await readFile(join(root, "books", "river", "chapters", "index.json"), "utf-8"));
+    expect(index).toHaveLength(1);
+
+    const repaired = await service.repairProjectIndex({ bookId: "river", dryRun: false });
+    expect(repaired.modifiedFiles).toEqual(["books/river/chapters/index.json"]);
+    index = JSON.parse(await readFile(join(root, "books", "river", "chapters", "index.json"), "utf-8"));
+    expect(index).toEqual(expect.arrayContaining([
+      expect.objectContaining({ number: 2, title: "暗潮", status: "imported" }),
+    ]));
+  });
+
+  it("exports a book through the existing export artifact path", async () => {
+    await createProject(root);
+    await createBook(root, "river", "河灯", [
+      { number: 1, title: "旧港", content: "林月在旧港看见河灯。", status: "approved" },
+    ]);
+    const service = createInkosMcpService({ cwd: root });
+
+    const exported = await service.exportBook({ bookId: "river", format: "md" });
+
+    expect(exported.format).toBe("md");
+    expect(exported.chaptersExported).toBe(1);
+    await expect(readFile(exported.outputPath, "utf-8")).resolves.toContain("林月在旧港看见河灯。");
+  });
+
+  it("advertises agent-mediated Studio workflows without requiring InkOS LLM config", async () => {
+    await createProject(root);
+    const service = createInkosMcpService({ cwd: root });
+
+    const started = await service.getStarted();
+
+    expect(started.availableOperations).toEqual(expect.arrayContaining([
+      "Agent 代理创建书籍基础设定",
+      "Agent 代理导入并整理 truth/state",
+      "Agent 代理续写下一章",
+    ]));
+    expect(started.llmPolicy).toContain("由外部 agent 工具的 LLM 完成");
+    expect(started.llmPolicy).not.toContain("需要 InkOS LLM 配置");
+  });
+
+  it("prepares and commits an agent-mediated book foundation without InkOS LLM config", async () => {
+    await createProject(root);
+    const createPipeline = vi.fn();
+    const service = createInkosMcpService({
+      cwd: root,
+      createPipeline,
+    });
+
+    const plan = await service.agentCreateBookPlan({
+      title: "河灯",
+      bookId: "river",
+      brief: "水乡悬疑长篇。",
+    });
+
+    expect(createPipeline).not.toHaveBeenCalled();
+    expect(plan.mode).toBe("agent-mediated");
+    expect(plan.requiresInkosLlm).toBe(false);
+    expect(plan.agentTask.kind).toBe("create_book_foundation");
+
+    const committed = await service.agentCommitBook({
+      title: "河灯",
+      bookId: "river",
+      foundationFiles: {
+        authorIntent: "# 作者意图\n\n写一部水乡悬疑。",
+        currentFocus: "# 当前聚焦\n\n第一卷围绕河灯失踪案。",
+        storyBible: "# Story Bible\n\n林月是验尸官。",
+        currentState: "林月抵达旧港。",
+      },
+    });
+
+    expect(committed.requiresInkosLlm).toBe(false);
+    expect(committed.modifiedFiles).toEqual(expect.arrayContaining([
+      "books/river/book.json",
+      "books/river/chapters/index.json",
+      "books/river/story/author_intent.md",
+      "books/river/story/current_focus.md",
+      "books/river/story/story_bible.md",
+      "books/river/story/state/current_state.md",
+    ]));
+    const listed = await service.listBooks();
+    expect(listed.books).toEqual([
+      expect.objectContaining({ bookId: "river", title: "河灯", chapterCount: 0 }),
+    ]);
+    await expect(readFile(join(root, "books", "river", "story", "story_bible.md"), "utf-8"))
+      .resolves.toContain("林月是验尸官");
+  });
+
+  it("prepares an agent-mediated import task without creating an InkOS LLM pipeline", async () => {
+    await createProject(root);
+    await createBook(root, "river", "河灯", []);
+    const sourcePath = join(root, "novel.txt");
+    await writeFile(sourcePath, "第1章 旧港\n\n林月在旧港看见河灯。", "utf-8");
+    const createPipeline = vi.fn();
+    const service = createInkosMcpService({
+      cwd: root,
+      createPipeline,
+    });
+
+    const result = await service.agentImportPlan({
+      bookId: "river",
+      sourcePath,
+      importMode: "continuation",
+    });
+
+    expect(createPipeline).not.toHaveBeenCalled();
+    expect(result.mode).toBe("agent-mediated");
+    expect(result.requiresInkosLlm).toBe(false);
+    expect(result.agentTask.kind).toBe("import_settlement");
+    expect(result.agentTask.instructions).toContain("外部 agent");
+    expect(result.chapters).toEqual([{ number: 1, title: "旧港", wordCount: 10, charCount: 10 }]);
+  });
+
+  it("prepares agent-mediated continuation context and commits the agent chapter output", async () => {
+    await createProject(root);
+    await createBook(root, "river", "河灯", [
+      { number: 1, title: "旧港", content: "林月在旧港看见河灯。", status: "approved" },
+    ]);
+    const createPipeline = vi.fn();
+    const service = createInkosMcpService({
+      cwd: root,
+      createPipeline,
+    });
+
+    const plan = await service.agentContinuePlan({ bookId: "river", chapterWindow: 1, maxChars: 1200 });
+    expect(createPipeline).not.toHaveBeenCalled();
+    expect(plan.mode).toBe("agent-mediated");
+    expect(plan.agentTask.kind).toBe("continue_chapter");
+    expect(plan.nextChapterNumber).toBe(2);
+
+    const committed = await service.agentCommitChapter({
+      bookId: "river",
+      chapterNumber: 2,
+      title: "新潮",
+      content: "新潮推着河灯向城门漂去。",
+      truthFiles: {
+        currentState: "林月追踪河灯，潮水异常。",
+        pendingHooks: "- 河灯来源未知。",
+      },
+      summary: "林月发现新潮。",
+    });
+
+    expect(committed.requiresInkosLlm).toBe(false);
+    expect(committed.modifiedFiles).toEqual(expect.arrayContaining([
+      "books/river/chapters/0002_新潮.md",
+      "books/river/chapters/index.json",
+      "books/river/story/state/current_state.md",
+      "books/river/story/pending_hooks.md",
+    ]));
+    await expect(readFile(join(root, "books", "river", "story", "state", "current_state.md"), "utf-8"))
+      .resolves.toContain("潮水异常");
+  });
+});
+
+async function createProject(projectRoot: string): Promise<void> {
+  await writeFile(join(projectRoot, "inkos.json"), JSON.stringify({
+    name: "MCP Test",
+    version: "0.1.0",
+    language: "zh",
+    llm: {
+      provider: "custom",
+      service: "custom",
+      configSource: "studio",
+      baseUrl: "https://example.invalid/v1",
+      apiKey: "",
+      model: "no-llm",
+    },
+  }, null, 2), "utf-8");
+}
+
+async function createBook(
+  projectRoot: string,
+  bookId: string,
+  title: string,
+  chapters: ReadonlyArray<{
+    readonly number: number;
+    readonly title: string;
+    readonly content: string;
+    readonly status: "imported" | "approved";
+  }>,
+): Promise<void> {
+  const bookDir = join(projectRoot, "books", bookId);
+  const chaptersDir = join(bookDir, "chapters");
+  const storyDir = join(bookDir, "story");
+  await mkdir(chaptersDir, { recursive: true });
+  await mkdir(storyDir, { recursive: true });
+  await writeFile(join(bookDir, "book.json"), JSON.stringify({
+    id: bookId,
+    title,
+    platform: "other",
+    genre: "other",
+    status: "active",
+    targetChapters: 200,
+    chapterWordCount: 3000,
+    language: "zh",
+    createdAt: now,
+    updatedAt: now,
+  }, null, 2), "utf-8");
+  await writeFile(join(storyDir, "author_intent.md"), "# 作者意图\n\n写一部河灯悬疑。\n", "utf-8");
+  await writeFile(join(storyDir, "current_focus.md"), "# 当前聚焦\n\n追踪河灯。\n", "utf-8");
+  await writeFile(join(storyDir, "pending_hooks.md"), "# Pending Hooks\n\n- 河灯来源未知。\n", "utf-8");
+  await writeFile(join(storyDir, "style_guide.md"), "# Style Notes\n\n克制、悬疑。\n", "utf-8");
+  await mkdir(join(storyDir, "state"), { recursive: true });
+  await writeFile(join(storyDir, "state", "manifest.json"), JSON.stringify({ version: 1 }, null, 2), "utf-8");
+  await writeFile(join(chaptersDir, "index.json"), JSON.stringify(chapters.map((chapter) => ({
+    number: chapter.number,
+    title: chapter.title,
+    status: chapter.status,
+    wordCount: chapter.content.length,
+    createdAt: now,
+    updatedAt: now,
+    auditIssues: [],
+    lengthWarnings: [],
+  })), null, 2), "utf-8");
+  for (const chapter of chapters) {
+    const file = `${String(chapter.number).padStart(4, "0")}_${chapter.title}.md`;
+    await writeFile(join(chaptersDir, file), `# 第${chapter.number}章 ${chapter.title}\n\n${chapter.content}`, "utf-8");
+  }
+}

--- a/packages/mcp/src/agent-workflow.ts
+++ b/packages/mcp/src/agent-workflow.ts
@@ -1,0 +1,337 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import {
+  assertSafeBookId,
+  deriveBookIdFromTitle,
+  StateManager,
+  type BookConfig,
+} from "@actalk/inkos-core";
+import { parseImportSource } from "./import-service.js";
+import {
+  appendImportReport,
+  countWords,
+  exists,
+  inferLanguage,
+  resolveBookId,
+  safeProjectPath,
+  writeIfMissing,
+} from "./utils.js";
+import type {
+  AgentCommitBookInput,
+  AgentCommitBookResult,
+  AgentCommitChapterInput,
+  AgentCommitChapterResult,
+  AgentContinuePlanInput,
+  AgentContinuePlanResult,
+  AgentCreateBookPlanInput,
+  AgentCreateBookPlanResult,
+  AgentFoundationFileName,
+  AgentImportPlanInput,
+  AgentImportPlanResult,
+  AgentTask,
+  AgentTruthFileName,
+  ContextBundleInput,
+  ContextBundleResult,
+  ResolvedProject,
+  WriteAgentChapterInput,
+  WriteAgentChapterResult,
+} from "./types.js";
+
+type ContextBundleLoader = (input: ContextBundleInput) => Promise<ContextBundleResult>;
+type ChapterWriter = (input: WriteAgentChapterInput) => Promise<WriteAgentChapterResult>;
+
+export async function agentCreateBookPlan(
+  project: ResolvedProject,
+  input: AgentCreateBookPlanInput,
+): Promise<AgentCreateBookPlanResult> {
+  const bookId = resolveNewBookId(input.title, input.bookId);
+  const state = new StateManager(project.projectRoot);
+  if (await exists(join(state.bookDir(bookId), "book.json"))) {
+    throw new Error(`Book "${bookId}" already exists.`);
+  }
+  return {
+    summary: `已准备《${input.title}》的外部 agent 建书基础设定任务。`,
+    mode: "agent-mediated",
+    requiresInkosLlm: false,
+    bookId,
+    title: input.title,
+    agentTask: createBookFoundationTask(input),
+    brief: input.brief,
+  };
+}
+
+export async function agentCommitBook(
+  project: ResolvedProject,
+  input: AgentCommitBookInput,
+): Promise<AgentCommitBookResult> {
+  const bookId = resolveNewBookId(input.title, input.bookId);
+  const state = new StateManager(project.projectRoot);
+  const bookDir = state.bookDir(bookId);
+  const dryRun = input.dryRun === true;
+  const modifiedFiles = plannedBookFiles(bookId, input.foundationFiles);
+  if (await exists(join(bookDir, "book.json"))) {
+    throw new Error(`Book "${bookId}" already exists.`);
+  }
+  if (!dryRun) {
+    const now = new Date().toISOString();
+    await mkdir(join(bookDir, "chapters"), { recursive: true });
+    await mkdir(join(bookDir, "story", "state"), { recursive: true });
+    const book: BookConfig = {
+      id: bookId,
+      title: input.title,
+      platform: input.platform ?? "other",
+      genre: input.genre ?? "other",
+      status: "active",
+      targetChapters: input.targetChapters ?? 200,
+      chapterWordCount: input.chapterWordCount ?? 3000,
+      language: input.language ?? "zh",
+      createdAt: now,
+      updatedAt: now,
+    };
+    await writeFile(join(bookDir, "book.json"), JSON.stringify(book, null, 2), "utf-8");
+    await writeFile(join(bookDir, "chapters", "index.json"), "[]\n", "utf-8");
+    await writeFoundationFiles(bookDir, input.foundationFiles);
+    await appendImportReport(project.projectRoot, bookId, [
+      "## Agent Mediated Book Foundation",
+      "",
+      "- requires_inkos_llm: false",
+      "- generated_by: external MCP agent",
+    ]);
+  }
+  return {
+    summary: dryRun ? `Dry run: 将创建《${input.title}》。` : `已创建《${input.title}》。`,
+    mode: "agent-mediated",
+    requiresInkosLlm: false,
+    dryRun,
+    bookId,
+    modifiedFiles: dryRun ? [] : modifiedFiles,
+  };
+}
+
+export async function agentImportPlan(
+  project: ResolvedProject,
+  input: AgentImportPlanInput,
+): Promise<AgentImportPlanResult> {
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const sourcePath = safeProjectPath(project.projectRoot, input.sourcePath);
+  const parsed = await parseImportSource(sourcePath, project.projectRoot, input);
+  if (parsed.chapters.length === 0) {
+    throw new Error("No chapters recognized. Run inkos_import_preview and adjust splitPattern first.");
+  }
+  const excerptBudget = input.maxChars ?? 12_000;
+  const sourceExcerpt = parsed.chapters
+    .map((chapter, index) => `## ${index + 1}. ${chapter.title}\n\n${chapter.content}`)
+    .join("\n\n---\n\n")
+    .slice(0, excerptBudget);
+
+  return {
+    summary: `已准备 ${parsed.chapters.length} 章的外部 agent 导入整理任务。`,
+    mode: "agent-mediated",
+    requiresInkosLlm: false,
+    bookId,
+    importMode: input.importMode ?? "continuation",
+    agentTask: importSettlementTask(),
+    chapters: parsed.chapters.map((chapter, index) => ({
+      number: index + 1,
+      title: chapter.title,
+      wordCount: countWords(chapter.content, inferLanguage(chapter.content)),
+      charCount: chapter.content.length,
+    })),
+    sourceExcerpt,
+  };
+}
+
+export async function agentContinuePlan(
+  project: ResolvedProject,
+  input: AgentContinuePlanInput,
+  loadContextBundle: ContextBundleLoader,
+): Promise<AgentContinuePlanResult> {
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const state = new StateManager(project.projectRoot);
+  const index = await state.loadChapterIndex(bookId);
+  const nextChapterNumber = index.reduce((max, chapter) => Math.max(max, chapter.number), 0) + 1;
+  const contextBundle = await loadContextBundle({
+    bookId,
+    purpose: "continue",
+    chapterWindow: input.chapterWindow ?? 3,
+    maxChars: input.maxChars ?? 12_000,
+  });
+  return {
+    summary: `已准备第 ${nextChapterNumber} 章的外部 agent 续写任务。`,
+    mode: "agent-mediated",
+    requiresInkosLlm: false,
+    bookId,
+    nextChapterNumber,
+    agentTask: continueChapterTask(nextChapterNumber),
+    contextBundle,
+  };
+}
+
+export async function agentCommitChapter(
+  project: ResolvedProject,
+  input: AgentCommitChapterInput,
+  writeChapter: ChapterWriter,
+): Promise<AgentCommitChapterResult> {
+  const written = await writeChapter(input);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const storyDir = join(state.bookDir(bookId), "story");
+  const modified = [...written.modifiedFiles];
+  if (input.truthFiles) {
+    for (const [name, content] of Object.entries(input.truthFiles) as Array<[AgentTruthFileName, string]>) {
+      const rel = truthFilePath(name);
+      const target = join(storyDir, rel);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, `${content.trimEnd()}\n`, "utf-8");
+      modified.push(relative(project.projectRoot, target));
+    }
+  }
+  await writeIfMissing(join(storyDir, "state", "manifest.json"), JSON.stringify({ agentMediated: true }, null, 2));
+  const report = await appendImportReport(project.projectRoot, bookId, [
+    `## Agent Mediated Chapter ${written.chapterNumber}`,
+    "",
+    "- requires_inkos_llm: false",
+    "- generated_by: external MCP agent",
+    `- summary: ${input.summary ?? "(not provided)"}`,
+  ]);
+  modified.push(report);
+  return {
+    ...written,
+    summary: `已提交外部 agent 生成的第 ${written.chapterNumber} 章和 truth/state 更新。`,
+    mode: "agent-mediated",
+    requiresInkosLlm: false,
+    modifiedFiles: [...new Set(modified)],
+  };
+}
+
+function importSettlementTask(): AgentTask {
+  return {
+    kind: "import_settlement",
+    instructions: "外部 agent 读取章节摘录与必要 chapter resource，整理可写回 InkOS 的基础设定、当前状态、伏笔、章节摘要和风格说明。不要调用 InkOS 内部 LLM API。",
+    expectedOutputSchema: {
+      truthFiles: {
+        currentState: "string",
+        pendingHooks: "string",
+        chapterSummaries: "string",
+        styleNotes: "string",
+        notes: "string",
+      },
+      recommendedNextAction: "string",
+    },
+  };
+}
+
+function createBookFoundationTask(input: AgentCreateBookPlanInput): AgentTask {
+  return {
+    kind: "create_book_foundation",
+    instructions: [
+      "外部 agent 根据用户意图生成 InkOS 建书基础文件；不要调用 InkOS 内部 LLM API。",
+      "生成后调用 inkos_agent_commit_book 写入 book.json、章节索引和 story 控制文档。",
+      "基础设定应尽量覆盖 Studio 建书时会产生的长期控制信息：作者意图、当前焦点、故事圣经、规则、风格和初始状态。",
+    ].join("\n"),
+    expectedOutputSchema: {
+      title: input.title,
+      genre: input.genre ?? "string",
+      language: input.language ?? "zh",
+      foundationFiles: {
+        authorIntent: "string",
+        currentFocus: "string",
+        storyBible: "string",
+        bookRules: "string",
+        styleNotes: "string",
+        currentState: "string",
+        pendingHooks: "string",
+        notes: "string",
+      },
+    },
+  };
+}
+
+function continueChapterTask(chapterNumber: number): AgentTask {
+  return {
+    kind: "continue_chapter",
+    instructions: `外部 agent 基于 contextBundle 生成第 ${chapterNumber} 章正文，并同时返回摘要和必要 truth/state 增量。生成后调用 inkos_agent_commit_chapter 写回。`,
+    expectedOutputSchema: {
+      title: "string",
+      content: "string",
+      summary: "string",
+      truthFiles: {
+        currentState: "string",
+        pendingHooks: "string",
+        chapterSummaries: "string",
+      },
+    },
+  };
+}
+
+function truthFilePath(name: AgentTruthFileName): string {
+  switch (name) {
+    case "currentState":
+      return "state/current_state.md";
+    case "pendingHooks":
+      return "pending_hooks.md";
+    case "authorIntent":
+      return "author_intent.md";
+    case "currentFocus":
+      return "current_focus.md";
+    case "notes":
+      return "notes.md";
+    case "styleNotes":
+      return "style_guide.md";
+    case "chapterSummaries":
+      return "chapter_summaries.md";
+  }
+}
+
+function resolveNewBookId(title: string, bookId?: string): string {
+  const id = bookId?.trim() || deriveBookIdFromTitle(title);
+  assertSafeBookId(id);
+  return id;
+}
+
+function plannedBookFiles(bookId: string, files?: Partial<Record<AgentFoundationFileName, string>>): ReadonlyArray<string> {
+  return [
+    `books/${bookId}/book.json`,
+    `books/${bookId}/chapters/index.json`,
+    `books/${bookId}/story/import-report.md`,
+    ...Object.keys(files ?? {}).map((name) => `books/${bookId}/story/${foundationFilePath(name as AgentFoundationFileName)}`),
+  ];
+}
+
+async function writeFoundationFiles(
+  bookDir: string,
+  files?: Partial<Record<AgentFoundationFileName, string>>,
+): Promise<void> {
+  const storyDir = join(bookDir, "story");
+  await writeIfMissing(join(storyDir, "author_intent.md"), "# 作者意图\n\n（由外部 agent 或用户补充。）\n");
+  await writeIfMissing(join(storyDir, "current_focus.md"), "# 当前聚焦\n\n（由外部 agent 或用户补充。）\n");
+  await writeIfMissing(join(storyDir, "notes.md"), "# Notes\n\n");
+  await writeIfMissing(join(storyDir, "state", "manifest.json"), JSON.stringify({ agentMediated: true }, null, 2));
+  if (!files) return;
+  for (const [name, content] of Object.entries(files) as Array<[AgentFoundationFileName, string]>) {
+    const target = join(storyDir, foundationFilePath(name));
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, `${content.trimEnd()}\n`, "utf-8");
+  }
+}
+
+function foundationFilePath(name: AgentFoundationFileName): string {
+  switch (name) {
+    case "authorIntent":
+      return "author_intent.md";
+    case "currentFocus":
+      return "current_focus.md";
+    case "notes":
+      return "notes.md";
+    case "storyBible":
+      return "story_bible.md";
+    case "bookRules":
+      return "book_rules.md";
+    case "styleNotes":
+      return "style_guide.md";
+    case "currentState":
+      return "state/current_state.md";
+    case "pendingHooks":
+      return "pending_hooks.md";
+  }
+}

--- a/packages/mcp/src/import-service.ts
+++ b/packages/mcp/src/import-service.ts
@@ -1,0 +1,186 @@
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import {
+  splitChapters,
+  type BookConfig,
+  type ChapterMeta,
+} from "@actalk/inkos-core";
+import {
+  appendImportReport,
+  countWords,
+  exists,
+  inferLanguage,
+  naturalCompare,
+  removeChapterMarkdown,
+  safeProjectPath,
+  sanitizeTitle,
+  stripMarkdownHeading,
+  titleFromFile,
+  writeIfMissing,
+} from "./utils.js";
+import type {
+  ImportMode,
+  ImportPreviewInput,
+  ParsedChapter,
+  PreviewChapter,
+} from "./types.js";
+
+export async function parseImportSource(
+  sourcePath: string,
+  projectRoot: string,
+  input: ImportPreviewInput,
+): Promise<{ readonly sourceKind: "file" | "directory"; readonly chapters: ReadonlyArray<ParsedChapter> }> {
+  const info = await stat(sourcePath);
+  if (info.isDirectory()) {
+    return { sourceKind: "directory", chapters: await parseDirectorySource(sourcePath, projectRoot, input) };
+  }
+  const text = await readFile(sourcePath, input.encoding ?? "utf-8");
+  return { sourceKind: "file", chapters: parseTextFile(text, input.splitPattern) };
+}
+
+export function toPreviewChapter(chapter: ParsedChapter, number: number): PreviewChapter {
+  const wordCount = countWords(chapter.content, inferLanguage(chapter.content));
+  return {
+    number,
+    title: chapter.title,
+    wordCount,
+    charCount: chapter.content.length,
+    sourceFile: chapter.sourceFile,
+    tooShort: wordCount < 50,
+  };
+}
+
+export async function writeImportedBook(input: {
+  readonly projectRoot: string;
+  readonly bookId: string;
+  readonly bookDir: string;
+  readonly title: string;
+  readonly mode: ImportMode;
+  readonly chapters: ReadonlyArray<ParsedChapter>;
+  readonly startNumber: number;
+  readonly existingIndex: ReadonlyArray<ChapterMeta>;
+  readonly sourcePath: string;
+}): Promise<void> {
+  const now = new Date().toISOString();
+  const chaptersDir = join(input.bookDir, "chapters");
+  await mkdir(chaptersDir, { recursive: true });
+  await ensureBookConfig(input.bookDir, input.bookId, input.title, now);
+  await ensureBasicStoryFiles(input.bookDir);
+  if (input.mode === "replace") {
+    await removeChapterMarkdown(chaptersDir);
+  }
+  const entries = await writeChapterFiles(input.bookDir, input.chapters, input.startNumber);
+  const updatedIndex = input.mode === "append"
+    ? [...input.existingIndex, ...entries]
+    : entries;
+  await writeFile(join(chaptersDir, "index.json"), JSON.stringify(updatedIndex, null, 2), "utf-8");
+  await appendImportReport(input.projectRoot, input.bookId, [
+    "## Deterministic Import",
+    "",
+    `- source: ${relative(input.projectRoot, input.sourcePath)}`,
+    `- mode: ${input.mode}`,
+    `- imported_chapters: ${input.chapters.length}`,
+    "- no_llm: true",
+    "- needs_agent_settlement: true",
+  ]);
+}
+
+export function plannedImportFiles(bookId: string, count: number, startNumber: number): ReadonlyArray<string> {
+  const files = [
+    `books/${bookId}/book.json`,
+    `books/${bookId}/chapters/index.json`,
+    `books/${bookId}/story/author_intent.md`,
+    `books/${bookId}/story/current_focus.md`,
+    `books/${bookId}/story/import-report.md`,
+  ];
+  for (let i = 0; i < count; i++) {
+    files.push(`books/${bookId}/chapters/${String(startNumber + i).padStart(4, "0")}_*.md`);
+  }
+  return files;
+}
+
+async function parseDirectorySource(
+  sourcePath: string,
+  projectRoot: string,
+  input: ImportPreviewInput,
+): Promise<ReadonlyArray<ParsedChapter>> {
+  const entries = (await readdir(sourcePath))
+    .filter((file) => file.endsWith(".txt") || file.endsWith(".md"))
+    .sort(naturalCompare);
+  const chapters: ParsedChapter[] = [];
+  for (const entry of entries) {
+    const fullPath = safeProjectPath(projectRoot, join(sourcePath, entry));
+    const text = await readFile(fullPath, input.encoding ?? "utf-8");
+    const split = parseTextFile(text, input.splitPattern);
+    if (split.length > 0) {
+      chapters.push(...split.map((chapter) => ({ ...chapter, sourceFile: entry })));
+    } else {
+      chapters.push({ title: titleFromFile(entry), content: stripMarkdownHeading(text), sourceFile: entry });
+    }
+  }
+  return chapters;
+}
+
+function parseTextFile(text: string, splitPattern?: string): ReadonlyArray<ParsedChapter> {
+  return splitChapters(text, splitPattern)
+    .map((chapter) => ({ title: chapter.title, content: chapter.content }))
+    .filter((chapter) => chapter.content.trim().length > 0);
+}
+
+async function ensureBookConfig(bookDir: string, bookId: string, title: string, now: string): Promise<void> {
+  const path = join(bookDir, "book.json");
+  if (await exists(path)) return;
+  await mkdir(bookDir, { recursive: true });
+  const book: BookConfig = {
+    id: bookId,
+    title,
+    platform: "other",
+    genre: "other",
+    status: "active",
+    targetChapters: 200,
+    chapterWordCount: 3000,
+    language: "zh",
+    createdAt: now,
+    updatedAt: now,
+  };
+  await writeFile(path, JSON.stringify(book, null, 2), "utf-8");
+}
+
+async function ensureBasicStoryFiles(bookDir: string): Promise<void> {
+  const storyDir = join(bookDir, "story");
+  await mkdir(join(storyDir, "state"), { recursive: true });
+  await mkdir(join(storyDir, "runtime"), { recursive: true });
+  await mkdir(join(storyDir, "outline"), { recursive: true });
+  await writeIfMissing(join(storyDir, "author_intent.md"), "# 作者意图\n\n（由外部 agent 或用户补充。）\n");
+  await writeIfMissing(join(storyDir, "current_focus.md"), "# 当前聚焦\n\n（导入后请补充接下来 1-3 章重点。）\n");
+  await writeIfMissing(join(storyDir, "notes.md"), "# Notes\n\n");
+  await writeIfMissing(join(storyDir, "state", "manifest.json"), JSON.stringify({ noLlmImport: true, needsAgentSettlement: true }, null, 2));
+}
+
+async function writeChapterFiles(
+  bookDir: string,
+  chapters: ReadonlyArray<ParsedChapter>,
+  startNumber: number,
+): Promise<ReadonlyArray<ChapterMeta>> {
+  const now = new Date().toISOString();
+  const chaptersDir = join(bookDir, "chapters");
+  const entries: ChapterMeta[] = [];
+  for (let index = 0; index < chapters.length; index++) {
+    const chapter = chapters[index]!;
+    const number = startNumber + index;
+    const filePath = join(chaptersDir, `${String(number).padStart(4, "0")}_${sanitizeTitle(chapter.title)}.md`);
+    await writeFile(filePath, `# 第${number}章 ${chapter.title}\n\n${chapter.content.trimEnd()}\n`, "utf-8");
+    entries.push({
+      number,
+      title: chapter.title,
+      status: "imported",
+      wordCount: countWords(chapter.content, inferLanguage(chapter.content)),
+      createdAt: now,
+      updatedAt: now,
+      auditIssues: [],
+      lengthWarnings: [],
+      reviewNote: "deterministic no-LLM import; needs_agent_settlement=true",
+    });
+  }
+  return entries;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { runStdioServer } from "./server.js";
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runStdioServer().catch((error) => {
+    process.stderr.write(`[inkos-mcp] ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}
+
+export { createInkosMcpServer, runStdioServer } from "./server.js";
+export { createInkosMcpService } from "./mcp-service.js";
+export type {
+  AgentCommitBookInput,
+  AgentCommitBookResult,
+  AgentCommitChapterInput,
+  AgentCommitChapterResult,
+  AgentContinuePlanInput,
+  AgentContinuePlanResult,
+  AgentCreateBookPlanInput,
+  AgentCreateBookPlanResult,
+  AgentFoundationFileName,
+  AgentImportPlanInput,
+  AgentImportPlanResult,
+  AgentTask,
+  AgentTruthFileName,
+  ContextBundleInput,
+  ContextBundleResult,
+  DiagnoseImportResult,
+  ExportBookInput,
+  ExportBookResult,
+  ImportCommitInput,
+  ImportCommitResult,
+  ImportPreviewInput,
+  ImportPreviewResult,
+  InkosMcpService,
+  InspectBookResult,
+  ListBooksResult,
+  ProjectStatus,
+  RepairProjectIndexResult,
+  UpdateControlDocInput,
+  UpdateControlDocResult,
+  WriteAgentChapterInput,
+  WriteAgentChapterResult,
+} from "./types.js";

--- a/packages/mcp/src/mcp-service.ts
+++ b/packages/mcp/src/mcp-service.ts
@@ -1,0 +1,723 @@
+import { mkdir, readFile, readdir, writeFile, copyFile } from "node:fs/promises";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import {
+  assertSafeBookId,
+  deriveBookIdFromTitle,
+  StateManager,
+  writeExportArtifact,
+  type ChapterMeta,
+  type ChapterStatus,
+} from "@actalk/inkos-core";
+import {
+  agentCommitBook as runAgentCommitBook,
+  agentCommitChapter as runAgentCommitChapter,
+  agentContinuePlan as runAgentContinuePlan,
+  agentCreateBookPlan as runAgentCreateBookPlan,
+  agentImportPlan as runAgentImportPlan,
+} from "./agent-workflow.js";
+import {
+  parseImportSource,
+  plannedImportFiles,
+  toPreviewChapter,
+  writeImportedBook,
+} from "./import-service.js";
+import {
+  appendImportReport,
+  countWords,
+  createBudget,
+  exists,
+  findDuplicates,
+  inferLanguage,
+  jsonResource,
+  nextIndexNumber,
+  parseBookResource,
+  resolveBookId,
+  safeProjectPath,
+  sanitizeTitle,
+  stripMarkdownHeading,
+  titleFromFile,
+  titleFromMarkdown,
+  upsertIndex,
+} from "./utils.js";
+import type {
+  Budget,
+  BookSummary,
+  ChapterFile,
+  ChapterInspection,
+  ChapterSnippet,
+  ContextBundleInput,
+  ContextBundleResult,
+  ControlDocName,
+  DiagnoseImportResult,
+  ExportBookInput,
+  ExportBookResult,
+  ImportCommitInput,
+  ImportCommitResult,
+  ImportPreviewInput,
+  ImportPreviewResult,
+  InkosMcpService,
+  InkosMcpServiceOptions,
+  InspectBookResult,
+  ListBooksResult,
+  ProjectStatus,
+  RepairProjectIndexResult,
+  ResolvedProject,
+  UpdateControlDocInput,
+  UpdateControlDocResult,
+  WriteAgentChapterInput,
+  WriteAgentChapterResult,
+} from "./types.js";
+
+export function createInkosMcpService(options: InkosMcpServiceOptions = {}): InkosMcpService {
+  const cwd = resolve(options.cwd ?? process.cwd());
+
+  return {
+    getStarted: () => getStarted(cwd),
+    projectStatus: () => projectStatus(cwd),
+    listBooks: () => listBooks(cwd),
+    inspectBook: (input = {}) => inspectBook(cwd, input),
+    importPreview: (input) => importPreview(cwd, input),
+    importCommit: (input) => importCommit(cwd, input),
+    getContextBundle: (input) => getContextBundle(cwd, input),
+    updateControlDoc: (input) => updateControlDoc(cwd, input),
+    writeAgentChapter: (input) => writeAgentChapter(cwd, input),
+    exportBook: (input) => exportBook(cwd, input),
+    diagnoseImport: (input = {}) => diagnoseImport(cwd, input),
+    repairProjectIndex: (input = {}) => repairProjectIndex(cwd, input),
+    agentCreateBookPlan: async (input) => runAgentCreateBookPlan(await requireProject(cwd), input),
+    agentCommitBook: async (input) => runAgentCommitBook(await requireProject(cwd), input),
+    agentImportPlan: async (input) => runAgentImportPlan(await requireProject(cwd), input),
+    agentContinuePlan: async (input) => runAgentContinuePlan(await requireProject(cwd), input, (contextInput) => getContextBundle(cwd, contextInput)),
+    agentCommitChapter: async (input) => runAgentCommitChapter(await requireProject(cwd), input, (chapterInput) => writeAgentChapter(cwd, chapterInput)),
+    readResource: (uri) => readResource(cwd, uri),
+  };
+}
+
+async function getStarted(cwd: string): Promise<Record<string, unknown>> {
+  const status = await projectStatus(cwd);
+  return {
+    summary: status.isInkosProject
+      ? `已识别 InkOS 项目：${status.booksCount} 本书。`
+      : "当前目录不是 InkOS 项目。",
+    mode: "external-agent",
+    llmPolicy: "MCP 模式中需要 LLM 的生成、分析、settlement 由外部 agent 工具的 LLM 完成；InkOS MCP 不要求 InkOS LLM API Key，也不读取 .inkos/secrets.json。",
+    availableOperations: [
+      "Agent 代理创建书籍基础设定",
+      "Agent 代理导入并整理 truth/state",
+      "Agent 代理续写下一章",
+      "Agent 代理提交章节和 truth/state",
+      "导入已有小说",
+      "继续已有项目",
+      "查看项目和书籍列表",
+      "查看章节",
+      "读取续写上下文",
+      "更新作者意图 / 当前焦点 / 项目说明",
+      "写入外部 agent 生成的新章节",
+      "导出作品",
+      "诊断项目问题",
+      "修复章节索引",
+    ],
+    projectStatus: status,
+    agentMediatedTools: [
+      "inkos_agent_create_book_plan",
+      "inkos_agent_commit_book",
+      "inkos_agent_import_plan",
+      "inkos_agent_continue_plan",
+      "inkos_agent_commit_chapter",
+    ],
+    noLlmTools: [
+      "inkos_import_preview",
+      "inkos_import_commit",
+      "inkos_get_context_bundle",
+      "inkos_write_agent_chapter",
+      "inkos_repair_project_index",
+    ],
+    recommendedNextActions: status.recommendedActions,
+  };
+}
+
+async function projectStatus(cwd: string): Promise<ProjectStatus> {
+  const project = await resolveProject(cwd);
+  if (!project.isInkosProject) {
+    return {
+      summary: "未发现 inkos.json；当前目录不是 InkOS 项目。",
+      projectRoot: project.projectRoot,
+      isInkosProject: false,
+      manifestExists: false,
+      booksCount: 0,
+      books: [],
+      problems: [],
+      recommendedActions: ["进入已有 InkOS 项目目录，或先用 inkos init 初始化项目。"],
+    };
+  }
+
+  const books = await collectBookSummaries(project.projectRoot);
+  const problems = await collectProjectProblems(project.projectRoot, books);
+  return {
+    summary: `InkOS 项目 ${project.projectRoot}，检测到 ${books.length} 本书。`,
+    projectRoot: project.projectRoot,
+    isInkosProject: true,
+    manifestExists: true,
+    booksCount: books.length,
+    books,
+    problems,
+    recommendedActions: recommendProjectActions(books, problems),
+  };
+}
+
+async function listBooks(cwd: string): Promise<ListBooksResult> {
+  const project = await requireProject(cwd);
+  const books = await collectBookSummaries(project.projectRoot);
+  return {
+    summary: books.length > 0 ? `检测到 ${books.length} 本书。` : "当前项目还没有书籍。",
+    projectRoot: project.projectRoot,
+    books,
+  };
+}
+
+async function inspectBook(cwd: string, input: { readonly bookId?: string; readonly maxChars?: number }): Promise<InspectBookResult> {
+  const project = await requireProject(cwd);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const book = await state.loadBookConfig(bookId);
+  const index = await state.loadChapterIndex(bookId);
+  const files = await chapterFileLookup(state.bookDir(bookId));
+  const maxChars = input.maxChars ?? 8_000;
+  const snippets = await recentSnippets(state.bookDir(bookId), index, files, 3, maxChars);
+  const controlDocs = await controlDocPresence(state.bookDir(bookId));
+  const storyStateExists = await exists(join(state.bookDir(bookId), "story", "state"));
+
+  return {
+    summary: `《${book.title}》包含 ${index.length} 个已登记章节。`,
+    metadata: book,
+    chapters: index.map((chapter) => ({
+      number: chapter.number,
+      title: chapter.title,
+      status: chapter.status,
+      wordCount: chapter.wordCount,
+      file: files.get(chapter.number)?.file,
+    })),
+    recentChapterSnippets: snippets,
+    controlDocs,
+    storyStateExists,
+    riskHints: buildRiskHints(controlDocs, storyStateExists),
+  };
+}
+
+async function importPreview(cwd: string, input: ImportPreviewInput): Promise<ImportPreviewResult> {
+  const project = await requireProject(cwd);
+  const sourcePath = safeProjectPath(project.projectRoot, input.sourcePath);
+  const parsed = await parseImportSource(sourcePath, project.projectRoot, input);
+  const duplicates = findDuplicates(parsed.chapters.map((chapter) => chapter.title));
+  const previewChapters = parsed.chapters.map((chapter, index) => toPreviewChapter(chapter, index + 1));
+  const shortChapters = previewChapters.filter((chapter) => chapter.tooShort);
+  const ok = previewChapters.length > 0;
+  const suggestions = ok
+    ? ["确认章节识别结果后调用 inkos_import_commit。"]
+    : ["检查章节标题是否独占一行，或传入 splitPattern，例如 ^第\\s*\\d+\\s*章。"];
+
+  return {
+    summary: ok ? `识别到 ${previewChapters.length} 个章节。` : "未识别到章节。",
+    ok,
+    sourcePath,
+    sourceKind: parsed.sourceKind,
+    chapterCount: previewChapters.length,
+    chapters: previewChapters,
+    anomalies: [
+      ...duplicates.map((title) => `重复章节标题：${title}`),
+      ...shortChapters.map((chapter) => `章节过短：${chapter.number} ${chapter.title}`),
+    ],
+    duplicateTitles: duplicates,
+    shortChapters,
+    unrecognizedReason: ok ? undefined : "没有匹配到支持的章节标题或目录内没有 .txt/.md 文件。",
+    suggestions,
+  };
+}
+
+async function importCommit(cwd: string, input: ImportCommitInput): Promise<ImportCommitResult> {
+  const project = await requireProject(cwd);
+  const sourcePath = safeProjectPath(project.projectRoot, input.sourcePath);
+  const parsed = await parseImportSource(sourcePath, project.projectRoot, input);
+  if (parsed.chapters.length === 0) {
+    throw new Error("No chapters recognized. Run inkos_import_preview and adjust splitPattern first.");
+  }
+
+  const dryRun = input.dryRun === true;
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveImportBookId(project.projectRoot, input, sourcePath);
+  assertSafeBookId(bookId);
+  const bookDir = state.bookDir(bookId);
+  const existingIndex = input.mode === "new-book" ? [] : await state.loadChapterIndex(bookId);
+  const startNumber = input.mode === "append" ? nextIndexNumber(existingIndex) : 1;
+  const title = input.title?.trim() || input.bookId?.trim() || basename(sourcePath, extname(sourcePath));
+  const modifiedFiles = plannedImportFiles(bookId, parsed.chapters.length, startNumber);
+  const totalWords = parsed.chapters.reduce((sum, chapter) => sum + countWords(chapter.content, "zh"), 0);
+
+  if (!dryRun) {
+    await writeImportedBook({
+      projectRoot: project.projectRoot,
+      bookId,
+      bookDir,
+      title,
+      mode: input.mode,
+      chapters: parsed.chapters,
+      startNumber,
+      existingIndex,
+      sourcePath,
+    });
+  }
+
+  return {
+    summary: dryRun
+      ? `Dry run: 将向 ${bookId} 导入 ${parsed.chapters.length} 章。`
+      : `已向 ${bookId} 导入 ${parsed.chapters.length} 章。`,
+    dryRun,
+    bookId,
+    mode: input.mode,
+    importedCount: parsed.chapters.length,
+    totalWords,
+    nextChapter: startNumber + parsed.chapters.length,
+    needsAgentSettlement: true,
+    modifiedFiles: dryRun ? [] : modifiedFiles,
+  };
+}
+
+async function getContextBundle(cwd: string, input: ContextBundleInput): Promise<ContextBundleResult> {
+  const project = await requireProject(cwd);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const book = (await collectBookSummaries(project.projectRoot)).find((entry) => entry.bookId === bookId);
+  if (!book) throw new Error(`Book "${bookId}" not found.`);
+
+  const bookDir = state.bookDir(bookId);
+  const budget = createBudget(input.maxChars ?? 12_000);
+  const authorIntent = await takeOptionalFile(budget, join(bookDir, "story", "author_intent.md"));
+  const currentFocus = await takeOptionalFile(budget, join(bookDir, "story", "current_focus.md"));
+  const recentSummaries = await takeOptionalFile(budget, join(bookDir, "story", "chapter_summaries.md"));
+  const pendingHooks = await takeOptionalFile(budget, join(bookDir, "story", "pending_hooks.md"));
+  const styleNotes = await takeOptionalFile(budget, join(bookDir, "story", "style_guide.md"));
+  const index = await state.loadChapterIndex(bookId);
+  const files = await chapterFileLookup(bookDir);
+  const recentChapters = await budgetedSnippets(budget, bookDir, index, files, input.chapterWindow ?? 3);
+  const characterStateFiles = await budgetedStateFiles(budget, bookDir);
+
+  return {
+    summary: `已为 ${input.purpose} 整理上下文，预算 ${budget.used}/${budget.max} 字符。`,
+    purpose: input.purpose,
+    book,
+    author_intent: authorIntent,
+    current_focus: currentFocus,
+    recentSummaries,
+    recentChapters,
+    characterStateFiles,
+    pendingHooks,
+    styleNotes,
+    recommendedNextAction: input.purpose === "continue"
+      ? "外部 agent 生成下一章后调用 inkos_write_agent_chapter 写回。"
+      : "按目的读取精确章节 resource，避免一次加载整本书。",
+    instructions: "Use this stable bundle as external agent context. Do not call InkOS internal LLM tools; generate or revise text yourself, then write results back through MCP.",
+    budget: { maxChars: budget.max, usedChars: budget.used },
+  };
+}
+
+async function updateControlDoc(cwd: string, input: UpdateControlDocInput): Promise<UpdateControlDocResult> {
+  const project = await requireProject(cwd);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const storyDir = join(state.bookDir(bookId), "story");
+  await mkdir(storyDir, { recursive: true });
+  const fileName = input.doc === "notes" ? "notes.md" : `${input.doc}.md`;
+  const target = join(storyDir, fileName);
+  const relTarget = relative(project.projectRoot, target);
+  let backupPath: string | undefined;
+
+  if (await exists(target)) {
+    backupPath = join(storyDir, ".mcp-backups", `${fileName}.${Date.now()}.bak`);
+    await mkdir(dirname(backupPath), { recursive: true });
+    await copyFile(target, backupPath);
+  }
+
+  const content = input.append && await exists(target)
+    ? `${await readFile(target, "utf-8").then((raw) => raw.trimEnd())}\n\n${input.content.trimEnd()}\n`
+    : `${input.content.trimEnd()}\n`;
+  await writeFile(target, content, "utf-8");
+
+  return {
+    summary: `已更新 ${input.doc}。`,
+    bookId,
+    doc: input.doc,
+    path: target,
+    backupPath,
+    modifiedFiles: [relTarget, ...(backupPath ? [relative(project.projectRoot, backupPath)] : [])],
+  };
+}
+
+async function writeAgentChapter(cwd: string, input: WriteAgentChapterInput): Promise<WriteAgentChapterResult> {
+  const project = await requireProject(cwd);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const book = await state.loadBookConfig(bookId);
+  const index = await state.loadChapterIndex(bookId);
+  const chapterNumber = input.chapterNumber ?? nextIndexNumber(index);
+  const title = input.title?.trim() || `第${chapterNumber}章`;
+  const status: ChapterStatus = input.approve ? "approved" : "ready-for-review";
+  const wordCount = countWords(input.content, (book.language ?? "zh") === "en" ? "en" : "zh");
+  const bookDir = state.bookDir(bookId);
+  const chaptersDir = join(bookDir, "chapters");
+  await mkdir(chaptersDir, { recursive: true });
+  const filePath = join(chaptersDir, `${String(chapterNumber).padStart(4, "0")}_${sanitizeTitle(title)}.md`);
+  const heading = (book.language ?? "zh") === "en" ? `# Chapter ${chapterNumber}: ${title}` : `# 第${chapterNumber}章 ${title}`;
+  await writeFile(filePath, `${heading}\n\n${input.content.trimEnd()}\n`, "utf-8");
+
+  const now = new Date().toISOString();
+  const entry: ChapterMeta = {
+    number: chapterNumber,
+    title,
+    status,
+    wordCount,
+    createdAt: now,
+    updatedAt: now,
+    auditIssues: [],
+    lengthWarnings: [],
+    reviewNote: "external-agent generated chapter; needs_settlement=true",
+  };
+  await state.saveChapterIndex(bookId, upsertIndex(index, entry));
+  const reportRel = await appendImportReport(project.projectRoot, bookId, [
+    `## External Agent Chapter ${chapterNumber}`,
+    "",
+    `- title: ${title}`,
+    `- status: ${status}`,
+    `- summary: ${input.summary ?? "(not provided)"}`,
+    `- notes: ${input.notes ?? "(not provided)"}`,
+    "- needs_settlement: true",
+  ]);
+
+  return {
+    summary: `已写入外部 agent 章节 ${chapterNumber}。`,
+    bookId,
+    chapterNumber,
+    title,
+    wordCount,
+    status,
+    needsSettlement: true,
+    filePath,
+    modifiedFiles: [
+      relative(project.projectRoot, filePath),
+      `books/${bookId}/chapters/index.json`,
+      reportRel,
+    ],
+  };
+}
+
+async function exportBook(cwd: string, input: ExportBookInput): Promise<ExportBookResult> {
+  const project = await requireProject(cwd);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const outputPath = input.outputPath
+    ? safeProjectPath(project.projectRoot, input.outputPath)
+    : join(project.projectRoot, `${bookId}_export.${input.format}`);
+  const result = await writeExportArtifact(state, bookId, {
+    format: input.format,
+    outputPath,
+  });
+  return {
+    summary: `已导出 ${result.chaptersExported} 章。`,
+    bookId,
+    format: input.format,
+    outputPath: result.outputPath,
+    chaptersExported: result.chaptersExported,
+    totalWords: result.totalWords,
+    modifiedFiles: [relative(project.projectRoot, result.outputPath)],
+  };
+}
+
+async function diagnoseImport(cwd: string, input: { readonly bookId?: string }): Promise<DiagnoseImportResult> {
+  const project = await requireProject(cwd);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const bookDir = state.bookDir(bookId);
+  const index = await state.loadChapterIndex(bookId);
+  const files = [...(await chapterFileLookup(bookDir)).values()];
+  const indexedNumbers = new Set(index.map((chapter) => chapter.number));
+  const fileNumbers = new Set(files.map((file) => file.number));
+  const unindexed = files
+    .filter((file) => !indexedNumbers.has(file.number))
+    .map((file) => ({ chapterNumber: file.number, file: file.file }));
+  const missingChapterFiles = index
+    .filter((chapter) => !fileNumbers.has(chapter.number))
+    .map((chapter) => chapter.number);
+  const missingFiles = await requiredBookFiles(bookDir);
+  const storyStateExists = await exists(join(bookDir, "story", "state"));
+  const importReportExists = await exists(join(bookDir, "story", "import-report.md"));
+
+  return {
+    summary: unindexed.length > 0
+      ? `发现 ${unindexed.length} 个章节文件未登记。`
+      : "未发现章节文件未登记问题。",
+    bookId,
+    missingFiles,
+    indexProblems: missingChapterFiles.map((number) => `index references missing chapter file: ${number}`),
+    unindexedChapterFiles: unindexed,
+    missingChapterFiles,
+    importReportExists,
+    storyStateExists,
+    autoFixable: unindexed.length > 0 ? ["chapter_index_missing_entries"] : [],
+    recommendedTool: unindexed.length > 0 ? "inkos_repair_project_index" : undefined,
+  };
+}
+
+async function repairProjectIndex(cwd: string, input: { readonly bookId?: string; readonly dryRun?: boolean }): Promise<RepairProjectIndexResult> {
+  const project = await requireProject(cwd);
+  const dryRun = input.dryRun ?? true;
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, input.bookId);
+  const bookDir = state.bookDir(bookId);
+  const index = await state.loadChapterIndex(bookId);
+  const indexedNumbers = new Set(index.map((chapter) => chapter.number));
+  const files = [...(await chapterFileLookup(bookDir)).values()].filter((file) => !indexedNumbers.has(file.number));
+  const repaired = await Promise.all(files.map((file) => chapterInspectionFromFile(file)));
+  const plannedFiles = repaired.length > 0 ? [`books/${bookId}/chapters/index.json`] : [];
+
+  if (!dryRun && repaired.length > 0) {
+    const now = new Date().toISOString();
+    const additions: ChapterMeta[] = repaired.map((chapter) => ({
+      number: chapter.number,
+      title: chapter.title,
+      status: "imported",
+      wordCount: chapter.wordCount,
+      createdAt: now,
+      updatedAt: now,
+      auditIssues: [],
+      lengthWarnings: [],
+      reviewNote: "repaired by inkos_repair_project_index; needs_settlement=true",
+    }));
+    await state.saveChapterIndex(bookId, [...index, ...additions].sort((a, b) => a.number - b.number));
+  }
+
+  return {
+    summary: dryRun
+      ? `Dry run: 将修复 ${repaired.length} 个索引条目。`
+      : `已修复 ${repaired.length} 个索引条目。`,
+    bookId,
+    dryRun,
+    repairedEntries: repaired,
+    plannedFiles,
+    modifiedFiles: dryRun ? [] : plannedFiles,
+  };
+}
+
+async function readResource(cwd: string, uri: string): Promise<{ readonly mimeType: string; readonly text: string }> {
+  const project = await requireProject(cwd);
+  if (uri === "inkos://project/manifest") {
+    return jsonResource(await readFile(join(project.projectRoot, "inkos.json"), "utf-8"));
+  }
+  if (uri === "inkos://books") {
+    return jsonResource(JSON.stringify(await listBooks(cwd), null, 2));
+  }
+  const parsed = parseBookResource(uri);
+  const state = new StateManager(project.projectRoot);
+  const bookId = await resolveBookId(project.projectRoot, parsed.bookId);
+  if (parsed.kind === "manifest") {
+    return jsonResource(await readFile(join(state.bookDir(bookId), "book.json"), "utf-8"));
+  }
+  if (parsed.kind === "chapters") {
+    return jsonResource(JSON.stringify(await state.loadChapterIndex(bookId), null, 2));
+  }
+  if (parsed.kind === "context") {
+    return jsonResource(JSON.stringify(await getContextBundle(cwd, { bookId, purpose: "continue" }), null, 2));
+  }
+  const files = await chapterFileLookup(state.bookDir(bookId));
+  const file = files.get(parsed.chapterNumber);
+  if (!file) throw new Error(`Chapter ${parsed.chapterNumber} not found.`);
+  return { mimeType: "text/markdown; charset=utf-8", text: await readFile(file.path, "utf-8") };
+}
+
+async function resolveProject(cwd: string): Promise<ResolvedProject> {
+  let cursor = resolve(cwd);
+  while (true) {
+    if (await exists(join(cursor, "inkos.json"))) {
+      return { cwd, projectRoot: cursor, isInkosProject: true };
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) {
+      return { cwd, projectRoot: cwd, isInkosProject: false };
+    }
+    cursor = parent;
+  }
+}
+
+async function requireProject(cwd: string): Promise<ResolvedProject> {
+  const project = await resolveProject(cwd);
+  if (!project.isInkosProject) {
+    throw new Error(`No inkos.json found from ${cwd}. Start inkos-mcp inside an InkOS project.`);
+  }
+  return project;
+}
+
+async function collectBookSummaries(projectRoot: string): Promise<ReadonlyArray<BookSummary>> {
+  const state = new StateManager(projectRoot);
+  const bookIds = await state.listBooks();
+  const books = await Promise.all(bookIds.map(async (bookId) => {
+    const book = await state.loadBookConfig(bookId);
+    const index = await state.loadChapterIndex(bookId);
+    return {
+      bookId,
+      title: book.title,
+      genre: book.genre,
+      language: book.language,
+      chapterCount: index.length,
+      lastChapterNumber: index.reduce((max, chapter) => Math.max(max, chapter.number), 0),
+      approximateWordCount: index.reduce((sum, chapter) => sum + chapter.wordCount, 0),
+      status: book.status,
+    };
+  }));
+  return books.sort((a, b) => a.bookId.localeCompare(b.bookId, "zh-Hans-CN"));
+}
+
+async function collectProjectProblems(projectRoot: string, books: ReadonlyArray<BookSummary>): Promise<ReadonlyArray<string>> {
+  const state = new StateManager(projectRoot);
+  const problems: string[] = [];
+  for (const book of books) {
+    const diagnosis = await diagnoseBook(state, book.bookId);
+    problems.push(...diagnosis.map((problem) => `${book.bookId}: ${problem}`));
+  }
+  return problems;
+}
+
+async function diagnoseBook(state: StateManager, bookId: string): Promise<ReadonlyArray<string>> {
+  const bookDir = state.bookDir(bookId);
+  const missing = await requiredBookFiles(bookDir);
+  const files = await chapterFileLookup(bookDir);
+  const index = await state.loadChapterIndex(bookId);
+  const indexed = new Set(index.map((chapter) => chapter.number));
+  return [
+    ...missing.map((file) => `missing ${file}`),
+    ...[...files.values()]
+      .filter((file) => !indexed.has(file.number))
+      .map((file) => `chapter file not indexed ${file.file}`),
+  ];
+}
+
+async function requiredBookFiles(bookDir: string): Promise<ReadonlyArray<string>> {
+  const required = [
+    "book.json",
+    "chapters/index.json",
+    "story/author_intent.md",
+    "story/current_focus.md",
+  ];
+  const missing: string[] = [];
+  for (const rel of required) {
+    if (!await exists(join(bookDir, rel))) missing.push(rel);
+  }
+  return missing;
+}
+
+function recommendProjectActions(books: ReadonlyArray<BookSummary>, problems: ReadonlyArray<string>): ReadonlyArray<string> {
+  if (problems.length > 0) return ["先调用 inkos_diagnose_import，再按建议调用 inkos_repair_project_index。"];
+  if (books.length === 0) return ["调用 inkos_import_preview / inkos_import_commit 导入已有小说，或在 Studio/CLI 新建书籍。"];
+  return ["调用 inkos_list_books 查看书籍，或调用 inkos_get_context_bundle 准备续写。"];
+}
+
+async function resolveImportBookId(projectRoot: string, input: ImportCommitInput, sourcePath: string): Promise<string> {
+  if (input.mode === "new-book") {
+    return input.bookId ?? (deriveBookIdFromTitle(input.title ?? basename(sourcePath, extname(sourcePath))) || `book-${Date.now().toString(36)}`);
+  }
+  return resolveBookId(projectRoot, input.bookId);
+}
+
+async function chapterFileLookup(bookDir: string): Promise<ReadonlyMap<number, ChapterFile>> {
+  const chaptersDir = join(bookDir, "chapters");
+  const files = await readdir(chaptersDir).catch(() => [] as string[]);
+  const lookup = new Map<number, ChapterFile>();
+  for (const file of files) {
+    const match = file.match(/^(\d{4})_.*\.md$/);
+    if (!match) continue;
+    const number = Number.parseInt(match[1]!, 10);
+    lookup.set(number, { number, file, path: join(chaptersDir, file) });
+  }
+  return lookup;
+}
+
+async function recentSnippets(
+  bookDir: string,
+  index: ReadonlyArray<ChapterMeta>,
+  files: ReadonlyMap<number, ChapterFile>,
+  window: number,
+  maxChars: number,
+): Promise<ReadonlyArray<ChapterSnippet>> {
+  const budget = createBudget(maxChars);
+  return budgetedSnippets(budget, bookDir, index, files, window);
+}
+
+async function budgetedSnippets(
+  budget: Budget,
+  _bookDir: string,
+  index: ReadonlyArray<ChapterMeta>,
+  files: ReadonlyMap<number, ChapterFile>,
+  window: number,
+): Promise<ReadonlyArray<ChapterSnippet>> {
+  const chapters = [...index].sort((a, b) => a.number - b.number).slice(-Math.max(1, window));
+  const snippets: ChapterSnippet[] = [];
+  for (const chapter of chapters) {
+    const file = files.get(chapter.number);
+    if (!file || budget.remaining <= 0) continue;
+    const raw = await readFile(file.path, "utf-8");
+    const slice = budget.take(raw, Math.min(700, Math.floor(budget.remaining / 2) || budget.remaining));
+    if (!slice) continue;
+    snippets.push({
+      number: chapter.number,
+      title: chapter.title,
+      head: slice,
+      tail: raw.length > slice.length && budget.remaining > 0 ? budget.take(raw.slice(-300), 300) : "",
+    });
+  }
+  return snippets;
+}
+
+async function budgetedStateFiles(
+  budget: Budget,
+  bookDir: string,
+): Promise<ReadonlyArray<{ readonly path: string; readonly excerpt: string }>> {
+  const stateDir = join(bookDir, "story", "state");
+  const files = await readdir(stateDir).catch(() => [] as string[]);
+  const result: Array<{ path: string; excerpt: string }> = [];
+  for (const file of files.filter((entry) => entry.endsWith(".json") || entry.endsWith(".md")).sort()) {
+    if (budget.remaining <= 0) break;
+    const fullPath = join(stateDir, file);
+    const excerpt = budget.take(await readFile(fullPath, "utf-8"), Math.min(500, budget.remaining));
+    if (excerpt) result.push({ path: `story/state/${file}`, excerpt });
+  }
+  return result;
+}
+
+async function takeOptionalFile(budget: Budget, path: string): Promise<string | undefined> {
+  if (!await exists(path) || budget.remaining <= 0) return undefined;
+  return budget.take(await readFile(path, "utf-8"), Math.min(1_000, budget.remaining));
+}
+
+async function chapterInspectionFromFile(file: ChapterFile): Promise<ChapterInspection> {
+  const raw = await readFile(file.path, "utf-8");
+  return {
+    number: file.number,
+    title: titleFromMarkdown(raw) || titleFromFile(file.file),
+    status: "imported",
+    wordCount: countWords(stripMarkdownHeading(raw), inferLanguage(raw)),
+    file: file.file,
+  };
+}
+
+async function controlDocPresence(bookDir: string): Promise<Record<ControlDocName, boolean>> {
+  return {
+    author_intent: await exists(join(bookDir, "story", "author_intent.md")),
+    current_focus: await exists(join(bookDir, "story", "current_focus.md")),
+    notes: await exists(join(bookDir, "story", "notes.md")),
+  };
+}
+
+function buildRiskHints(controlDocs: Record<ControlDocName, boolean>, storyStateExists: boolean): ReadonlyArray<string> {
+  const hints = ["deterministic_import_needs_agent_settlement"];
+  if (!controlDocs.author_intent) hints.push("missing_author_intent");
+  if (!controlDocs.current_focus) hints.push("missing_current_focus");
+  if (!storyStateExists) hints.push("missing_structured_story_state");
+  return hints;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,395 @@
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { createInkosMcpService } from "./mcp-service.js";
+import type {
+  AgentCommitBookInput,
+  AgentCommitChapterInput,
+  AgentContinuePlanInput,
+  AgentCreateBookPlanInput,
+  AgentImportPlanInput,
+  ContextBundleInput,
+  ExportBookInput,
+  ImportCommitInput,
+  ImportPreviewInput,
+  InkosMcpService,
+  UpdateControlDocInput,
+  WriteAgentChapterInput,
+} from "./types.js";
+
+export function createInkosMcpServer(options: { readonly cwd?: string } = {}): McpServer {
+  const service = createInkosMcpService({ cwd: options.cwd });
+  const server = new McpServer({
+    name: "inkos-mcp",
+    version: "1.5.0",
+  });
+
+  registerTools(server, service);
+  registerResources(server, service);
+  registerPrompts(server);
+
+  return server;
+}
+
+export async function runStdioServer(options: { readonly cwd?: string } = {}): Promise<void> {
+  const server = createInkosMcpServer(options);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+function registerTools(server: McpServer, service: InkosMcpService): void {
+  tool(server, "inkos_get_started", "Return InkOS MCP external-agent mode instructions, current project status, and recommended next actions.", {}, () => service.getStarted());
+  tool(server, "inkos_project_status", "Read current InkOS project status without writes or LLM calls.", {}, () => service.projectStatus());
+  tool(server, "inkos_list_books", "List books in the current InkOS project without LLM calls.", {}, () => service.listBooks());
+  tool(
+    server,
+    "inkos_agent_create_book_plan",
+    "Prepare a book-foundation task for the external agent LLM. Does not call InkOS internal LLM.",
+    {
+      title: z.string(),
+      bookId: z.string().optional(),
+      brief: z.string().optional(),
+      genre: z.string().optional(),
+      language: z.enum(["zh", "en"]).optional(),
+      platform: z.enum(["tomato", "feilu", "qidian", "other"]).optional(),
+    },
+    (input) => service.agentCreateBookPlan(input as unknown as AgentCreateBookPlanInput),
+  );
+  tool(
+    server,
+    "inkos_agent_commit_book",
+    "Create an InkOS book from external-agent generated foundation files. Does not call InkOS internal LLM.",
+    {
+      title: z.string(),
+      bookId: z.string().optional(),
+      genre: z.string().optional(),
+      language: z.enum(["zh", "en"]).optional(),
+      platform: z.enum(["tomato", "feilu", "qidian", "other"]).optional(),
+      targetChapters: z.number().int().min(1).optional(),
+      chapterWordCount: z.number().int().min(1).optional(),
+      foundationFiles: z.object({
+        authorIntent: z.string().optional(),
+        currentFocus: z.string().optional(),
+        notes: z.string().optional(),
+        storyBible: z.string().optional(),
+        bookRules: z.string().optional(),
+        styleNotes: z.string().optional(),
+        currentState: z.string().optional(),
+        pendingHooks: z.string().optional(),
+      }).optional(),
+      dryRun: z.boolean().optional(),
+    },
+    (input) => service.agentCommitBook(input as unknown as AgentCommitBookInput),
+  );
+  tool(
+    server,
+    "inkos_agent_import_plan",
+    "Prepare an import settlement task for the external agent LLM. Does not call InkOS internal LLM.",
+    {
+      sourcePath: z.string(),
+      bookId: z.string().optional(),
+      splitPattern: z.string().optional(),
+      encoding: z.string().optional(),
+      resumeFrom: z.number().int().min(1).optional(),
+      importMode: z.enum(["continuation", "series"]).optional(),
+      maxChars: z.number().int().min(500).max(100_000).optional(),
+    },
+    (input) => service.agentImportPlan(input as unknown as AgentImportPlanInput),
+  );
+  tool(
+    server,
+    "inkos_agent_continue_plan",
+    "Prepare a continuation task and bounded context bundle for the external agent LLM.",
+    {
+      bookId: z.string().optional(),
+      chapterWindow: z.number().int().min(1).max(20).optional(),
+      maxChars: z.number().int().min(500).max(100_000).optional(),
+    },
+    (input) => service.agentContinuePlan(input as unknown as AgentContinuePlanInput),
+  );
+  tool(
+    server,
+    "inkos_agent_commit_chapter",
+    "Commit external-agent generated chapter text and truth/state updates. Does not call InkOS internal LLM.",
+    {
+      bookId: z.string().optional(),
+      chapterNumber: z.number().int().min(1).optional(),
+      title: z.string().optional(),
+      content: z.string(),
+      summary: z.string().optional(),
+      notes: z.string().optional(),
+      approve: z.boolean().optional(),
+      truthFiles: z.object({
+        currentState: z.string().optional(),
+        pendingHooks: z.string().optional(),
+        authorIntent: z.string().optional(),
+        currentFocus: z.string().optional(),
+        notes: z.string().optional(),
+        styleNotes: z.string().optional(),
+        chapterSummaries: z.string().optional(),
+      }).optional(),
+    },
+    (input) => service.agentCommitChapter(input as unknown as AgentCommitChapterInput),
+  );
+  tool(
+    server,
+    "inkos_inspect_book",
+    "Inspect one book's metadata, chapter index, recent snippets, control docs, and import risks.",
+    {
+      bookId: z.string().optional(),
+      maxChars: z.number().int().min(500).max(50_000).optional(),
+    },
+    (input) => service.inspectBook(input),
+  );
+  tool(
+    server,
+    "inkos_import_preview",
+    "Preview deterministic no-LLM import from a .txt/.md file or directory. Does not write files.",
+    {
+      sourcePath: z.string(),
+      bookId: z.string().optional(),
+      splitPattern: z.string().optional(),
+      encoding: z.string().optional(),
+    },
+    (input) => service.importPreview(input as unknown as ImportPreviewInput),
+  );
+  tool(
+    server,
+    "inkos_import_commit",
+    "Commit deterministic no-LLM import into an InkOS book and write an import report.",
+    {
+      sourcePath: z.string(),
+      bookId: z.string().optional(),
+      title: z.string().optional(),
+      splitPattern: z.string().optional(),
+      encoding: z.string().optional(),
+      mode: z.enum(["append", "replace", "new-book"]),
+      dryRun: z.boolean().optional(),
+    },
+    (input) => service.importCommit(input as unknown as ImportCommitInput),
+  );
+  tool(
+    server,
+    "inkos_get_context_bundle",
+    "Build a budgeted context bundle for an external agent. Does not call InkOS internal LLM.",
+    {
+      bookId: z.string().optional(),
+      purpose: z.enum(["continue", "revise", "summarize", "inspect"]),
+      chapterWindow: z.number().int().min(1).max(20).optional(),
+      maxChars: z.number().int().min(500).max(100_000).optional(),
+    },
+    (input) => service.getContextBundle(input as unknown as ContextBundleInput),
+  );
+  tool(
+    server,
+    "inkos_update_control_doc",
+    "Update author intent, current focus, or notes with a traceable backup.",
+    {
+      bookId: z.string().optional(),
+      doc: z.enum(["author_intent", "current_focus", "notes"]),
+      content: z.string(),
+      append: z.boolean().optional(),
+    },
+    (input) => service.updateControlDoc(input as unknown as UpdateControlDocInput),
+  );
+  tool(
+    server,
+    "inkos_write_agent_chapter",
+    "Write a chapter generated by an external agent into InkOS and update the chapter index.",
+    {
+      bookId: z.string().optional(),
+      title: z.string().optional(),
+      chapterNumber: z.number().int().min(1).optional(),
+      content: z.string(),
+      summary: z.string().optional(),
+      notes: z.string().optional(),
+      approve: z.boolean().optional(),
+    },
+    (input) => service.writeAgentChapter(input as unknown as WriteAgentChapterInput),
+  );
+  tool(
+    server,
+    "inkos_export_book",
+    "Export an InkOS book through existing export artifact logic without LLM calls.",
+    {
+      bookId: z.string().optional(),
+      format: z.enum(["md", "txt", "epub"]),
+      outputPath: z.string().optional(),
+    },
+    (input) => service.exportBook(input as unknown as ExportBookInput),
+  );
+  tool(
+    server,
+    "inkos_diagnose_import",
+    "Diagnose import/read failures such as missing chapter index entries or control docs.",
+    { bookId: z.string().optional() },
+    (input) => service.diagnoseImport(input),
+  );
+  tool(
+    server,
+    "inkos_repair_project_index",
+    "Repair chapter index entries for existing chapter files. Dry run defaults to true.",
+    {
+      bookId: z.string().optional(),
+      dryRun: z.boolean().optional(),
+    },
+    (input) => service.repairProjectIndex(input),
+  );
+}
+
+function registerResources(server: McpServer, service: InkosMcpService): void {
+  server.registerResource(
+    "inkos_project_manifest",
+    "inkos://project/manifest",
+    {
+      title: "InkOS project manifest",
+      description: "Current project inkos.json. Secrets and .env files are not exposed.",
+      mimeType: "application/json",
+    },
+    async (uri) => resourceResult(uri.href, await service.readResource("inkos://project/manifest")),
+  );
+  server.registerResource(
+    "inkos_books",
+    "inkos://books",
+    {
+      title: "InkOS books",
+      description: "List of books in the current InkOS project.",
+      mimeType: "application/json",
+    },
+    async (uri) => resourceResult(uri.href, await service.readResource("inkos://books")),
+  );
+  server.registerResource(
+    "inkos_book_manifest",
+    new ResourceTemplate("inkos://book/{bookId}/manifest", { list: undefined }),
+    {
+      title: "InkOS book manifest",
+      description: "A book's book.json manifest.",
+      mimeType: "application/json",
+    },
+    async (uri) => resourceResult(uri.href, await service.readResource(uri.href)),
+  );
+  server.registerResource(
+    "inkos_book_chapters",
+    new ResourceTemplate("inkos://book/{bookId}/chapters", { list: undefined }),
+    {
+      title: "InkOS book chapters",
+      description: "A book's chapters/index.json metadata.",
+      mimeType: "application/json",
+    },
+    async (uri) => resourceResult(uri.href, await service.readResource(uri.href)),
+  );
+  server.registerResource(
+    "inkos_book_chapter",
+    new ResourceTemplate("inkos://book/{bookId}/chapter/{chapterNumber}", { list: undefined }),
+    {
+      title: "InkOS chapter markdown",
+      description: "Exact chapter markdown by chapter number.",
+      mimeType: "text/markdown",
+    },
+    async (uri) => resourceResult(uri.href, await service.readResource(uri.href)),
+  );
+  server.registerResource(
+    "inkos_book_context_continue",
+    new ResourceTemplate("inkos://book/{bookId}/context/continue", { list: undefined }),
+    {
+      title: "InkOS continue context",
+      description: "Budgeted default continuation context bundle.",
+      mimeType: "application/json",
+    },
+    async (uri) => resourceResult(uri.href, await service.readResource(uri.href)),
+  );
+}
+
+function registerPrompts(server: McpServer): void {
+  server.registerPrompt(
+    "inkos_start",
+    {
+      title: "Start InkOS MCP",
+      description: "Guide an external agent to start with project status and a Studio-style operation menu.",
+    },
+    () => promptText([
+      "你正在通过 InkOS MCP external-agent mode 操作项目。",
+      "先调用 inkos_project_status，再调用 inkos_list_books。",
+      "然后用中文列出 Studio 风格的可用操作：创建书籍、导入已有小说、继续写作、查看项目、读取上下文、更新控制文档、写回章节、导出、诊断和修复。",
+      "需要 LLM 的生成、分析、settlement 都由当前外部 agent 自己完成；不要要求用户配置 InkOS LLM API Key。",
+      "Agent-mediated 工具可用：inkos_agent_create_book_plan、inkos_agent_commit_book、inkos_agent_import_plan、inkos_agent_continue_plan、inkos_agent_commit_chapter。",
+      "确定性读写工具可用：inkos_import_preview、inkos_import_commit、inkos_get_context_bundle、inkos_update_control_doc、inkos_write_agent_chapter、inkos_export_book、inkos_diagnose_import、inkos_repair_project_index。",
+      "不要一上来调用写作或写入工具；先询问用户下一步要做什么。",
+    ].join("\n")),
+  );
+  server.registerPrompt(
+    "inkos_import_existing_novel",
+    {
+      title: "Import Existing Novel",
+      description: "Guide agent-mediated import preview, commit, and settlement for an existing novel.",
+    },
+    () => promptText([
+      "询问用户 sourcePath、目标 bookId、导入模式，以及是否需要你整理 truth/state。",
+      "先调用 inkos_import_preview 展示章节数量、标题、异常和建议。",
+      "用户确认后调用 inkos_import_commit，把章节确定性注册进 InkOS 项目。",
+      "如果需要 Studio 风格的导入整理，调用 inkos_agent_import_plan 获取 settlement 任务；由外部 agent 读取上下文并生成 truth/state 文档内容。",
+      "生成后用 inkos_update_control_doc 或 inkos_agent_commit_chapter 的 truthFiles 写回必要控制文档；不要调用 InkOS 内部 LLM。",
+      "导入后调用 inkos_inspect_book，确认章节索引和控制文档可读。",
+    ].join("\n")),
+  );
+  server.registerPrompt(
+    "inkos_continue_existing_book",
+    {
+      title: "Continue Existing Book",
+      description: "Guide external-agent chapter continuation with context bundle and write-back.",
+    },
+    () => promptText([
+      "先调用 inkos_agent_continue_plan 或 inkos_get_context_bundle 获取预算内上下文。",
+      "外部 agent 基于 context bundle 自己生成下一章正文、摘要和必要 truth/state 增量。",
+      "调用 inkos_agent_commit_chapter 写回章节和 agent 生成的 truth/state；不要调用 InkOS 内部 LLM。",
+      "如果需要全文，优先读取精确 chapter resource，不要一次加载整本书。",
+    ].join("\n")),
+  );
+}
+
+function tool<T extends Record<string, unknown>>(
+  server: McpServer,
+  name: string,
+  description: string,
+  inputSchema: Record<string, z.ZodTypeAny>,
+  handler: (input: T) => Promise<unknown>,
+): void {
+  server.registerTool(
+    name,
+    { description, inputSchema },
+    async (input) => {
+      const result = await handler(input as T);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}
+
+function resourceResult(uri: string, resource: { readonly mimeType: string; readonly text: string }): { contents: Array<{ uri: string; mimeType: string; text: string }> } {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: resource.mimeType,
+        text: resource.text,
+      },
+    ],
+  };
+}
+
+function promptText(text: string): { messages: Array<{ role: "user"; content: { type: "text"; text: string } }> } {
+  return {
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text },
+      },
+    ],
+  };
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,390 @@
+import type {
+  BookConfig,
+  ChapterMeta,
+  ChapterStatus,
+} from "@actalk/inkos-core";
+
+export type ImportMode = "append" | "replace" | "new-book";
+export type ContextPurpose = "continue" | "revise" | "summarize" | "inspect";
+export type ControlDocName = "author_intent" | "current_focus" | "notes";
+export type ExportFormat = "md" | "txt" | "epub";
+
+export interface InkosMcpService {
+  getStarted(): Promise<Record<string, unknown>>;
+  projectStatus(): Promise<ProjectStatus>;
+  listBooks(): Promise<ListBooksResult>;
+  inspectBook(input?: { readonly bookId?: string; readonly maxChars?: number }): Promise<InspectBookResult>;
+  importPreview(input: ImportPreviewInput): Promise<ImportPreviewResult>;
+  importCommit(input: ImportCommitInput): Promise<ImportCommitResult>;
+  getContextBundle(input: ContextBundleInput): Promise<ContextBundleResult>;
+  updateControlDoc(input: UpdateControlDocInput): Promise<UpdateControlDocResult>;
+  writeAgentChapter(input: WriteAgentChapterInput): Promise<WriteAgentChapterResult>;
+  exportBook(input: ExportBookInput): Promise<ExportBookResult>;
+  diagnoseImport(input?: { readonly bookId?: string }): Promise<DiagnoseImportResult>;
+  repairProjectIndex(input?: { readonly bookId?: string; readonly dryRun?: boolean }): Promise<RepairProjectIndexResult>;
+  agentCreateBookPlan(input: AgentCreateBookPlanInput): Promise<AgentCreateBookPlanResult>;
+  agentCommitBook(input: AgentCommitBookInput): Promise<AgentCommitBookResult>;
+  agentImportPlan(input: AgentImportPlanInput): Promise<AgentImportPlanResult>;
+  agentContinuePlan(input: AgentContinuePlanInput): Promise<AgentContinuePlanResult>;
+  agentCommitChapter(input: AgentCommitChapterInput): Promise<AgentCommitChapterResult>;
+  readResource(uri: string): Promise<{ readonly mimeType: string; readonly text: string }>;
+}
+
+export interface InkosMcpServiceOptions {
+  readonly cwd?: string;
+  readonly createPipeline?: unknown;
+}
+
+export interface ProjectStatus {
+  readonly summary: string;
+  readonly projectRoot: string;
+  readonly isInkosProject: boolean;
+  readonly manifestExists: boolean;
+  readonly booksCount: number;
+  readonly books: ReadonlyArray<BookSummary>;
+  readonly problems: ReadonlyArray<string>;
+  readonly recommendedActions: ReadonlyArray<string>;
+}
+
+export interface BookSummary {
+  readonly bookId: string;
+  readonly title: string;
+  readonly genre: string;
+  readonly language?: string;
+  readonly chapterCount: number;
+  readonly lastChapterNumber: number;
+  readonly approximateWordCount: number;
+  readonly status: string;
+}
+
+export interface ListBooksResult {
+  readonly summary: string;
+  readonly projectRoot: string;
+  readonly books: ReadonlyArray<BookSummary>;
+}
+
+export interface InspectBookResult {
+  readonly summary: string;
+  readonly metadata: BookConfig;
+  readonly chapters: ReadonlyArray<ChapterInspection>;
+  readonly recentChapterSnippets: ReadonlyArray<ChapterSnippet>;
+  readonly controlDocs: Record<ControlDocName, boolean>;
+  readonly storyStateExists: boolean;
+  readonly riskHints: ReadonlyArray<string>;
+}
+
+export interface ChapterInspection {
+  readonly number: number;
+  readonly title: string;
+  readonly status: string;
+  readonly wordCount: number;
+  readonly file?: string;
+}
+
+export interface ChapterSnippet {
+  readonly number: number;
+  readonly title: string;
+  readonly head: string;
+  readonly tail: string;
+}
+
+export interface ImportPreviewInput {
+  readonly sourcePath: string;
+  readonly bookId?: string;
+  readonly splitPattern?: string;
+  readonly encoding?: BufferEncoding;
+}
+
+export interface ImportPreviewResult {
+  readonly summary: string;
+  readonly ok: boolean;
+  readonly sourcePath: string;
+  readonly sourceKind: "file" | "directory";
+  readonly chapterCount: number;
+  readonly chapters: ReadonlyArray<PreviewChapter>;
+  readonly anomalies: ReadonlyArray<string>;
+  readonly duplicateTitles: ReadonlyArray<string>;
+  readonly shortChapters: ReadonlyArray<PreviewChapter>;
+  readonly unrecognizedReason?: string;
+  readonly suggestions: ReadonlyArray<string>;
+}
+
+export interface PreviewChapter {
+  readonly number: number;
+  readonly title: string;
+  readonly wordCount: number;
+  readonly charCount: number;
+  readonly sourceFile?: string;
+  readonly tooShort: boolean;
+}
+
+export interface ImportCommitInput extends ImportPreviewInput {
+  readonly title?: string;
+  readonly mode: ImportMode;
+  readonly dryRun?: boolean;
+}
+
+export interface ImportCommitResult {
+  readonly summary: string;
+  readonly dryRun: boolean;
+  readonly bookId: string;
+  readonly mode: ImportMode;
+  readonly importedCount: number;
+  readonly totalWords: number;
+  readonly nextChapter: number;
+  readonly needsAgentSettlement: boolean;
+  readonly modifiedFiles: ReadonlyArray<string>;
+}
+
+export interface ContextBundleInput {
+  readonly bookId?: string;
+  readonly purpose: ContextPurpose;
+  readonly chapterWindow?: number;
+  readonly maxChars?: number;
+}
+
+export interface ContextBundleResult {
+  readonly summary: string;
+  readonly purpose: ContextPurpose;
+  readonly book: BookSummary;
+  readonly author_intent?: string;
+  readonly current_focus?: string;
+  readonly recentSummaries?: string;
+  readonly recentChapters: ReadonlyArray<ChapterSnippet>;
+  readonly characterStateFiles: ReadonlyArray<{ readonly path: string; readonly excerpt: string }>;
+  readonly pendingHooks?: string;
+  readonly styleNotes?: string;
+  readonly recommendedNextAction: string;
+  readonly instructions: string;
+  readonly budget: { readonly maxChars: number; readonly usedChars: number };
+}
+
+export interface UpdateControlDocInput {
+  readonly bookId?: string;
+  readonly doc: ControlDocName;
+  readonly content: string;
+  readonly append?: boolean;
+}
+
+export interface UpdateControlDocResult {
+  readonly summary: string;
+  readonly bookId: string;
+  readonly doc: ControlDocName;
+  readonly path: string;
+  readonly backupPath?: string;
+  readonly modifiedFiles: ReadonlyArray<string>;
+}
+
+export interface WriteAgentChapterInput {
+  readonly bookId?: string;
+  readonly title?: string;
+  readonly chapterNumber?: number;
+  readonly content: string;
+  readonly summary?: string;
+  readonly notes?: string;
+  readonly approve?: boolean;
+}
+
+export interface WriteAgentChapterResult {
+  readonly summary: string;
+  readonly bookId: string;
+  readonly chapterNumber: number;
+  readonly title: string;
+  readonly wordCount: number;
+  readonly status: ChapterStatus;
+  readonly needsSettlement: boolean;
+  readonly filePath: string;
+  readonly modifiedFiles: ReadonlyArray<string>;
+}
+
+export interface ExportBookInput {
+  readonly bookId?: string;
+  readonly format: ExportFormat;
+  readonly outputPath?: string;
+}
+
+export interface ExportBookResult {
+  readonly summary: string;
+  readonly bookId: string;
+  readonly format: ExportFormat;
+  readonly outputPath: string;
+  readonly chaptersExported: number;
+  readonly totalWords: number;
+  readonly modifiedFiles: ReadonlyArray<string>;
+}
+
+export interface DiagnoseImportResult {
+  readonly summary: string;
+  readonly bookId: string;
+  readonly missingFiles: ReadonlyArray<string>;
+  readonly indexProblems: ReadonlyArray<string>;
+  readonly unindexedChapterFiles: ReadonlyArray<UnindexedChapterFile>;
+  readonly missingChapterFiles: ReadonlyArray<number>;
+  readonly importReportExists: boolean;
+  readonly storyStateExists: boolean;
+  readonly autoFixable: ReadonlyArray<string>;
+  readonly recommendedTool?: string;
+}
+
+export interface RepairProjectIndexResult {
+  readonly summary: string;
+  readonly bookId: string;
+  readonly dryRun: boolean;
+  readonly repairedEntries: ReadonlyArray<ChapterInspection>;
+  readonly plannedFiles: ReadonlyArray<string>;
+  readonly modifiedFiles: ReadonlyArray<string>;
+}
+
+export interface AgentImportPlanInput extends ImportPreviewInput {
+  readonly bookId?: string;
+  readonly resumeFrom?: number;
+  readonly importMode?: "continuation" | "series";
+  readonly maxChars?: number;
+}
+
+export interface AgentTask {
+  readonly kind: "create_book_foundation" | "import_settlement" | "continue_chapter";
+  readonly instructions: string;
+  readonly expectedOutputSchema: Record<string, unknown>;
+}
+
+export interface AgentCreateBookPlanInput {
+  readonly title: string;
+  readonly bookId?: string;
+  readonly brief?: string;
+  readonly genre?: string;
+  readonly language?: BookConfig["language"];
+  readonly platform?: BookConfig["platform"];
+}
+
+export interface AgentCreateBookPlanResult {
+  readonly summary: string;
+  readonly mode: "agent-mediated";
+  readonly requiresInkosLlm: false;
+  readonly bookId: string;
+  readonly title: string;
+  readonly agentTask: AgentTask;
+  readonly brief?: string;
+}
+
+export interface AgentCommitBookInput {
+  readonly title: string;
+  readonly bookId?: string;
+  readonly genre?: string;
+  readonly language?: BookConfig["language"];
+  readonly platform?: BookConfig["platform"];
+  readonly targetChapters?: number;
+  readonly chapterWordCount?: number;
+  readonly foundationFiles?: Partial<Record<AgentFoundationFileName, string>>;
+  readonly dryRun?: boolean;
+}
+
+export type AgentFoundationFileName =
+  | "authorIntent"
+  | "currentFocus"
+  | "notes"
+  | "storyBible"
+  | "bookRules"
+  | "styleNotes"
+  | "currentState"
+  | "pendingHooks";
+
+export interface AgentCommitBookResult {
+  readonly summary: string;
+  readonly mode: "agent-mediated";
+  readonly requiresInkosLlm: false;
+  readonly dryRun: boolean;
+  readonly bookId: string;
+  readonly modifiedFiles: ReadonlyArray<string>;
+}
+
+export interface AgentImportPlanResult {
+  readonly summary: string;
+  readonly mode: "agent-mediated";
+  readonly requiresInkosLlm: false;
+  readonly bookId: string;
+  readonly importMode: "continuation" | "series";
+  readonly agentTask: AgentTask;
+  readonly chapters: ReadonlyArray<{ readonly number: number; readonly title: string; readonly wordCount: number; readonly charCount: number }>;
+  readonly sourceExcerpt: string;
+}
+
+export interface AgentContinuePlanInput {
+  readonly bookId?: string;
+  readonly chapterWindow?: number;
+  readonly maxChars?: number;
+}
+
+export interface AgentContinuePlanResult {
+  readonly summary: string;
+  readonly mode: "agent-mediated";
+  readonly requiresInkosLlm: false;
+  readonly bookId: string;
+  readonly nextChapterNumber: number;
+  readonly agentTask: AgentTask;
+  readonly contextBundle: ContextBundleResult;
+}
+
+export interface AgentCommitChapterInput {
+  readonly bookId?: string;
+  readonly chapterNumber?: number;
+  readonly title?: string;
+  readonly content: string;
+  readonly summary?: string;
+  readonly notes?: string;
+  readonly approve?: boolean;
+  readonly truthFiles?: Partial<Record<AgentTruthFileName, string>>;
+}
+
+export type AgentTruthFileName =
+  | "currentState"
+  | "pendingHooks"
+  | "authorIntent"
+  | "currentFocus"
+  | "notes"
+  | "styleNotes"
+  | "chapterSummaries";
+
+export interface AgentCommitChapterResult extends WriteAgentChapterResult {
+  readonly summary: string;
+  readonly mode: "agent-mediated";
+  readonly requiresInkosLlm: false;
+}
+
+export interface ResolvedProject {
+  readonly cwd: string;
+  readonly projectRoot: string;
+  readonly isInkosProject: boolean;
+}
+
+export interface ParsedChapter {
+  readonly title: string;
+  readonly content: string;
+  readonly sourceFile?: string;
+}
+
+export interface ChapterFile {
+  readonly number: number;
+  readonly file: string;
+  readonly path: string;
+}
+
+export interface UnindexedChapterFile {
+  readonly chapterNumber: number;
+  readonly file: string;
+}
+
+export type Budget = {
+  readonly max: number;
+  used: number;
+  readonly remaining: number;
+  take(text: string, limit?: number): string;
+};
+
+export type BookResource = {
+  readonly bookId: string;
+  readonly kind: "manifest" | "chapters" | "chapter" | "context";
+  readonly chapterNumber: number;
+};
+
+export type ChapterIndex = ReadonlyArray<ChapterMeta>;

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -1,0 +1,147 @@
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import {
+  countChapterLength,
+  assertSafeBookId,
+  resolveLengthCountingMode,
+  safeChildPath,
+  StateManager,
+  type ChapterMeta,
+} from "@actalk/inkos-core";
+import type { BookResource, Budget } from "./types.js";
+
+export function createBudget(max: number): Budget {
+  return {
+    max,
+    used: 0,
+    get remaining() {
+      return Math.max(0, max - this.used);
+    },
+    take(text: string, limit?: number) {
+      const allowed = Math.min(this.remaining, limit ?? this.remaining);
+      if (allowed <= 0) return "";
+      const value = text.slice(0, allowed);
+      this.used += value.length;
+      return value;
+    },
+  };
+}
+
+export function safeProjectPath(projectRoot: string, requestedPath: string): string {
+  if (isAbsolute(requestedPath)) {
+    const rel = relative(resolve(projectRoot), resolve(requestedPath));
+    if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return resolve(requestedPath);
+    throw new Error(`Path traversal blocked: ${requestedPath}`);
+  }
+  return safeChildPath(projectRoot, requestedPath);
+}
+
+export function nextIndexNumber(index: ReadonlyArray<ChapterMeta>): number {
+  return index.reduce((max, chapter) => Math.max(max, chapter.number), 0) + 1;
+}
+
+export function upsertIndex(index: ReadonlyArray<ChapterMeta>, entry: ChapterMeta): ReadonlyArray<ChapterMeta> {
+  const found = index.find((chapter) => chapter.number === entry.number);
+  const next = found
+    ? index.map((chapter) => chapter.number === entry.number ? { ...entry, createdAt: chapter.createdAt } : chapter)
+    : [...index, entry];
+  return next.sort((a, b) => a.number - b.number);
+}
+
+export function countWords(content: string, language: "zh" | "en"): number {
+  return countChapterLength(content, resolveLengthCountingMode(language));
+}
+
+export function inferLanguage(content: string): "zh" | "en" {
+  return /[\u4e00-\u9fff]/u.test(content) ? "zh" : "en";
+}
+
+export function sanitizeTitle(title: string): string {
+  return (title || "untitled")
+    .replace(/[/\\?%*:|"<>]/g, "")
+    .replace(/\s+/g, "_")
+    .slice(0, 50) || "untitled";
+}
+
+export function titleFromFile(file: string): string {
+  return basename(file, extname(file)).replace(/^\d+[_\-\s]*/, "").trim() || "Untitled";
+}
+
+export function titleFromMarkdown(markdown: string): string {
+  return markdown.match(/^#\s+(?:第\d+章\s+|Chapter\s+\d+:\s*)?(.+)$/m)?.[1]?.trim() ?? "";
+}
+
+export function stripMarkdownHeading(markdown: string): string {
+  return markdown.replace(/^#\s+.+\n+/, "").trim();
+}
+
+export function findDuplicates(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+export function naturalCompare(a: string, b: string): number {
+  return a.localeCompare(b, "zh-Hans-CN", { numeric: true, sensitivity: "base" });
+}
+
+export async function removeChapterMarkdown(chaptersDir: string): Promise<void> {
+  const files = await readdir(chaptersDir).catch(() => [] as string[]);
+  await Promise.all(files.filter((file) => /^\d{4}_.*\.md$/.test(file)).map((file) => rm(join(chaptersDir, file), { force: true })));
+}
+
+export async function appendImportReport(projectRoot: string, bookId: string, lines: ReadonlyArray<string>): Promise<string> {
+  const reportPath = join(projectRoot, "books", bookId, "story", "import-report.md");
+  await mkdir(dirname(reportPath), { recursive: true });
+  const existing = await readFile(reportPath, "utf-8").catch(() => "# Import Report\n");
+  await writeFile(reportPath, `${existing.trimEnd()}\n\n${lines.join("\n")}\n`, "utf-8");
+  return relative(projectRoot, reportPath);
+}
+
+export async function writeIfMissing(path: string, content: string): Promise<void> {
+  if (!await exists(path)) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content, "utf-8");
+  }
+}
+
+export async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseBookResource(uri: string): BookResource {
+  const match = uri.match(/^inkos:\/\/book\/([^/]+)\/(manifest|chapters|context\/continue|chapter\/(\d+))$/);
+  if (!match) throw new Error(`Unsupported InkOS MCP resource: ${uri}`);
+  const kindRaw = match[2]!;
+  return {
+    bookId: decodeURIComponent(match[1]!),
+    kind: kindRaw === "context/continue" ? "context" : kindRaw.startsWith("chapter/") ? "chapter" : kindRaw as "manifest" | "chapters",
+    chapterNumber: match[3] ? Number.parseInt(match[3], 10) : 0,
+  };
+}
+
+export function jsonResource(text: string): { readonly mimeType: string; readonly text: string } {
+  return { mimeType: "application/json", text };
+}
+
+export async function resolveBookId(projectRoot: string, bookId?: string): Promise<string> {
+  const state = new StateManager(projectRoot);
+  const books = await state.listBooks();
+  if (bookId) {
+    assertSafeBookId(bookId);
+    if (!books.includes(bookId)) throw new Error(`Book "${bookId}" not found.`);
+    return bookId;
+  }
+  if (books.length === 1) return books[0]!;
+  if (books.length === 0) throw new Error("No books found.");
+  throw new Error(`Multiple books found: ${books.join(", ")}. Specify bookId.`);
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@actalk/inkos-core": resolve(__dirname, "../core/src/index.ts"),
+    },
+  },
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,28 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)
 
+  packages/mcp:
+    dependencies:
+      '@actalk/inkos-core':
+        specifier: workspace:*
+        version: link:../core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.13(@types/node@22.19.15)(typescript@5.9.3))(tsx@4.21.0)
+
   packages/studio:
     dependencies:
       '@actalk/inkos-core':


### PR DESCRIPTION
## Summary
- add a new @actalk/inkos-mcp workspace package with stdio MCP server and inkos-mcp bin
- expose MCP tools/resources/prompts for project status, book inspection, deterministic import, context bundling, write-back, export, diagnosis, and index repair
- add agent-mediated create/import/continue workflows so Codex/Claude Code handle LLM generation and settlement while InkOS manages project files
- document MCP mode and clarify that default MCP flows do not require InkOS LLM API keys or read secrets

## Test plan
- pnpm build
- pnpm test
- pnpm typecheck
- pnpm verify:publish-manifests
- node -e "import('./packages/mcp/dist/index.js').then(() => console.log('import-ok'))"

## Breaking changes
None. Existing Studio, CLI, TUI, and OpenClaw interaction paths remain unchanged.