### PR TITLE
fix: preserve bookId when proposed action creates new session

### DIFF
--- a/packages/studio/src/pages/ChatPage.tsx
+++ b/packages/studio/src/pages/ChatPage.tsx
@@ -500,9 +500,10 @@ export function ChatPage({ activeBookId, mode = activeBookId ? "book" : "book-cr
       });
       return;
     }
-    const targetSessionId = await createSession(null, details.targetSessionKind, targetPlayMode);
+    const targetSessionId = await createSession(activeBookId ?? null, details.targetSessionKind, targetPlayMode);
     autoScrollPinnedRef.current = true;
     await sendMessage(targetSessionId, details.instruction ?? "", {
+      activeBookId,
       sessionKind: details.targetSessionKind,
       playMode: targetPlayMode,
       actionSource: "button",


### PR DESCRIPTION
Fixes #312

## Summary

When handleProposedAction creates a new session (non-sameSession path), ctiveBookId was not passed to createSession() or sendMessage(). This caused the server to compute gentBookId = null, and after switching channels (e.g. due to an upstream error), the agent cache was evicted and a new Agent was created with 
ull bookId — making the auditor throw:

> auditor requires bookId when there is no active book

## Fix

In ChatPage.tsx, pass ctiveBookId through both createSession() and sendMessage() in the new-session branch of handleProposedAction:

- createSession(activeBookId ?? null, ...) instead of createSession(null, ...)
- Added ctiveBookId to the sendMessage() options object

This ensures the book context is preserved when a proposed action creates a new session and the user subsequently switches channels.

## Testing

- Typecheck passes
- Build passes
- Core tests pass (2 pre-existing flaky failures unrelated to this change)