### PR TITLE
feat: use global defaultModel as pipeline model for chapter generation

### DIFF
--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -1729,7 +1729,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     const logger = createLogger({ tag: "studio", sinks: [scopedSseSink, consoleSink] });
     return {
       client: overrides?.client ?? createLLMClient(currentConfig.llm),
-      model: overrides?.model ?? currentConfig.llm.model,
+      model: overrides?.model ?? currentConfig.llm.defaultModel ?? currentConfig.llm.model,
       projectRoot: root,
       defaultLLMConfig: currentConfig.llm,
       foundationReviewRetries: currentConfig.foundation?.reviewRetries ?? 2,


### PR DESCRIPTION
## Summary

`buildPipelineConfig()` now prefers `llm.defaultModel` over `llm.model` when resolving the model for pipeline operations (chapter generation, book creation, drafts).

This allows users to control which model is used for chapter generation via the services config UI.

## Changes

- `packages/studio/src/api/server.ts`: Updated `buildPipelineConfig()` to use `currentConfig.llm.defaultModel ?? currentConfig.llm.model` instead of just `currentConfig.llm.model`

## Motivation

In conversations, users can explicitly choose which model to use for generation/audit. However, when clicking the "Write Next Chapter" or "Draft Only" buttons in the book management interface, the model used was not controllable — it always used the project's configured `llm.model`, ignoring the `defaultModel` setting in the services config UI.

Closes #311
