### PR TITLE
fix: use live probe + bank merge for Chat UI model list (#282)

### DIFF
--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -2588,18 +2588,19 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string) {
     const endpoints = getAllEndpoints()
       .filter((ep) => ep.id !== "custom" && Boolean(secrets.services[ep.id]?.apiKey));
 
-    const groups = endpoints.map((ep) => ({
-      service: ep.id,
-      label: ep.label,
-      models: ep.models
-        .filter((m) => m.enabled !== false)
-        .filter((m) => isTextChatModelId(m.id))
-        .map((m) => ({
+    const groups = await Promise.all(endpoints.map(async (ep) => {
+      const apiKey = secrets.services[ep.id]?.apiKey ?? "";
+      const enriched = await listModelsForService(ep.id, apiKey);
+      return {
+        service: ep.id,
+        label: ep.label,
+        models: filterTextChatModels(enriched).map((m) => ({
           id: m.id,
-          name: m.id,
-          ...(typeof m.maxOutput === "number" ? { maxOutput: m.maxOutput } : {}),
-          ...(m.contextWindowTokens > 0 ? { contextWindow: m.contextWindowTokens } : {}),
+          name: m.name,
+          ...(m.maxOutput !== undefined ? { maxOutput: m.maxOutput } : {}),
+          ...(m.contextWindow > 0 ? { contextWindow: m.contextWindow } : {}),
         })),
+      };
     }));
 
     return c.json({ groups });


### PR DESCRIPTION
Fixes #282

## Problem

Models added to SiliconCloud after the hardcoded bank was published (e.g. \deepseek-ai/DeepSeek-V4-Flash\) appear in the Config page's test connection results but are missing from the Chat UI's model picker, making them impossible to select in conversations.

## Root Cause

The \GET /api/v1/services/models\ endpoint (consumed by \ChatPage\) only returned hardcoded bank models from \siliconcloud.ts\. The Config page uses a separate endpoint (\GET /api/v1/services/:service/models\) that performs a live \/models\ probe merged with bank metadata.

## Fix

Changed \GET /api/v1/services/models\ to use \listModelsForService()\ — the same live probe + bank merge function used by the Config page endpoint. This ensures newly available models are discovered at runtime and displayed in the Chat UI.

**Before:** \p.models.filter(enabled).filter(textChat)\ — bank-only, no live discovery
**After:** \wait listModelsForService(ep.id, apiKey)\ → \ilterTextChatModels(enriched)\ — live probe + bank merge with 10-min caching

## Verification

- Typecheck passes for both \@actalk/inkos-core\ and \@actalk/inkos-studio\
- All pre-existing test timeouts confirmed unrelated (fail identically on unmodified code)