### PR TITLE
feat: add AgnesAI provider support

### DIFF
--- a/packages/core/src/__tests__/providers-group.test.ts
+++ b/packages/core/src/__tests__/providers-group.test.ts
@@ -13,7 +13,7 @@ describe("InkosEndpoint.group", () => {
 
     expect(byGroup("overseas")).toEqual(["anthropic", "google", "mistral", "openai", "xai"].sort());
     expect(byGroup("china")).toEqual([
-      "ai360", "baichuan", "bailian", "deepseek", "hunyuan", "internlm", "longcat",
+      "agnesai", "ai360", "baichuan", "bailian", "deepseek", "hunyuan", "internlm", "longcat",
       "minimax", "moonshot", "sensenova", "spark", "stepfun", "tencentcloud",
       "volcengine", "wenxin", "xiaomimimo", "zeroone", "zhipu",
     ].sort());

--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -90,6 +90,19 @@ describe("providers structural integrity", () => {
     expect(getEndpoint("minimax")?.baseUrl).toBe("https://api.minimaxi.com/v1");
   });
 
+  it("AgnesAI uses the OpenAI-compatible gateway and stays in the China group", () => {
+    const agnes = getEndpoint("agnesai");
+    expect(agnes).toMatchObject({
+      label: "AgnesAI",
+      group: "china",
+      api: "openai-completions",
+      baseUrl: "https://apihub.agnes-ai.com/v1",
+      checkModel: "agnes-2.0-flash",
+    });
+    expect(agnes?.models.some((model) => model.id === "agnes-2.0-flash" && model.enabled !== false)).toBe(true);
+    expect(agnes?.models.some((model) => model.id === "agnes-image-2.1-flash" && model.status === "nonText")).toBe(true);
+  });
+
   it("B2：中国原厂批次 2 全部收录（6 个）", () => {
     const ids = getAllEndpoints().map((p) => p.id);
     for (const id of ["spark", "sensenova", "tencentcloud", "xiaomimimo", "longcat", "internlm"]) {
@@ -120,9 +133,9 @@ describe("providers structural integrity", () => {
     expect(getEndpoint("newapi")?.baseUrl).toBe("");
   });
 
-  it("B4：总 provider 数 = 30（不含 CodingPlan 分组，R5 删 qwen / higress 且精简聚合入口后）", () => {
+  it("B4：总 provider 数 = 31（不含 CodingPlan 分组，R5 删 qwen / higress 且精简聚合入口后）", () => {
     const nonCoding = getAllEndpoints().filter((p) => p.group !== "codingPlan");
-    expect(nonCoding.length).toBe(30);
+    expect(nonCoding.length).toBe(31);
   });
 
   it("B6：CodingPlan 8 个 provider 全部收录", () => {
@@ -136,8 +149,8 @@ describe("providers structural integrity", () => {
     }
   });
 
-  it("B6：总 provider 数 = 38 (30 base + 8 CodingPlan)", () => {
-    expect(getAllEndpoints().length).toBe(38);
+  it("B6：总 provider 数 = 39 (31 base + 8 CodingPlan)", () => {
+    expect(getAllEndpoints().length).toBe(39);
   });
 
   it("B6：CodingPlan provider 都走 anthropic-messages", () => {

--- a/packages/core/src/__tests__/service-presets-regression.test.ts
+++ b/packages/core/src/__tests__/service-presets-regression.test.ts
@@ -43,6 +43,23 @@ describe("service-presets regression", () => {
   });
 
   describe("listModelsForService", () => {
+    it("exposes AgnesAI as an OpenAI-compatible provider with text models", async () => {
+      const preset = resolveServicePreset("agnesai");
+      expect(preset).toMatchObject({
+        providerFamily: "openai",
+        api: "openai-completions",
+        baseUrl: "https://apihub.agnes-ai.com/v1",
+      });
+
+      const models = await listModelsForService("agnesai");
+      expect(models.map((m) => m.id)).toEqual(expect.arrayContaining([
+        "agnes-2.0-flash",
+        "agnes-1.5-flash",
+      ]));
+      expect(models.some((m) => m.id.includes("image"))).toBe(false);
+      expect(guessServiceFromBaseUrl("https://apihub.agnes-ai.com/v1")).toBe("agnesai");
+    });
+
     it("exposes kkaiapi as an OpenAI-compatible aggregator with text models", async () => {
       const preset = resolveServicePreset("kkaiapi");
       expect(preset).toMatchObject({

--- a/packages/core/src/__tests__/short-fiction-public.test.ts
+++ b/packages/core/src/__tests__/short-fiction-public.test.ts
@@ -171,6 +171,44 @@ describe("public short-fiction chain", () => {
     }
   });
 
+  it("resolves AgnesAI cover generation from project cover config", async () => {
+    const root = await mkdtemp(join(tmpdir(), "inkos-agnes-cover-"));
+    try {
+      await writeFile(join(root, "inkos.json"), JSON.stringify({
+        name: "agnes-cover-test",
+        version: "0.1.0",
+        language: "zh",
+        llm: {
+          provider: "openai",
+          service: "agnesai",
+          configSource: "studio",
+          baseUrl: "https://apihub.agnes-ai.com/v1",
+          apiKey: "",
+          model: "agnes-2.0-flash",
+          cover: {
+            service: "agnesai",
+            model: "agnes-image-2.1-flash",
+          },
+        },
+        notify: [],
+      }, null, 2), "utf-8");
+      await saveSecrets(root, {
+        services: {
+          "cover:agnesai": { apiKey: "sk-agnes-cover" },
+        },
+      });
+
+      await expect(resolveCoverGenerationRequest({ root })).resolves.toMatchObject({
+        api: "images",
+        baseUrl: "https://apihub.agnes-ai.com/v1",
+        model: "agnes-image-2.1-flash",
+        apiKey: "sk-agnes-cover",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("extracts OpenAI-compatible image generation URLs and base64 payloads", () => {
     expect(extractImagesGenerationImage({
       data: [{ url: "https://api.kkaiapi.com/files/img_abc123.png" }],

--- a/packages/core/src/llm/cover-providers.ts
+++ b/packages/core/src/llm/cover-providers.ts
@@ -1,4 +1,4 @@
-export type CoverProviderId = "kkaiapi" | "openai" | "google";
+export type CoverProviderId = "kkaiapi" | "openai" | "google" | "agnesai";
 
 export interface CoverProviderPreset {
   readonly service: CoverProviderId;
@@ -33,6 +33,14 @@ export const COVER_PROVIDER_PRESETS: readonly CoverProviderPreset[] = [
     api: "gemini",
     defaultModel: "gemini-3.1-flash-image-preview",
     models: ["gemini-3.1-flash-image-preview", "gemini-2.5-flash-image"],
+  },
+  {
+    service: "agnesai",
+    label: "AgnesAI Images",
+    baseUrl: "https://apihub.agnes-ai.com/v1",
+    api: "images",
+    defaultModel: "agnes-image-2.1-flash",
+    models: ["agnes-image-2.1-flash", "agnes-image-2.0-flash"],
   },
 ];
 

--- a/packages/core/src/llm/providers/endpoints/agnesai.ts
+++ b/packages/core/src/llm/providers/endpoints/agnesai.ts
@@ -1,0 +1,49 @@
+/**
+ * AgnesAI
+ *
+ * - GitHub: https://github.com/AgnesAI-Labs/AgnesAI-Models
+ * - OpenAI-compatible base URL: https://apihub.agnes-ai.com/v1
+ *
+ * AgnesAI exposes chat and image-generation models from the same OpenAI-compatible
+ * gateway. Text-capable models are enabled for Studio model selection; image-only
+ * models are listed as nonText so they can be used by cover generation without
+ * polluting chat model menus.
+ */
+import type { InkosEndpoint } from "../types.js";
+
+export const AGNESAI: InkosEndpoint = {
+  id: "agnesai",
+  label: "AgnesAI",
+  group: "china",
+  api: "openai-completions",
+  baseUrl: "https://apihub.agnes-ai.com/v1",
+  modelsBaseUrl: "https://apihub.agnes-ai.com/v1",
+  checkModel: "agnes-2.0-flash",
+  models: [
+    { id: "agnes-2.0-flash", maxOutput: 8192, contextWindowTokens: 1_000_000, enabled: true },
+    { id: "agnes-1.5-flash", maxOutput: 8192, contextWindowTokens: 1_000_000, enabled: true },
+    {
+      id: "agnes-image-2.1-flash",
+      maxOutput: 1,
+      contextWindowTokens: 1,
+      enabled: false,
+      status: "nonText",
+      capabilities: { text: false, imageOutput: true },
+    },
+    {
+      id: "agnes-image-2.0-flash",
+      maxOutput: 1,
+      contextWindowTokens: 1,
+      enabled: false,
+      status: "nonText",
+      capabilities: { text: false, imageOutput: true },
+    },
+    {
+      id: "agnes-video-v2.0",
+      maxOutput: 1,
+      contextWindowTokens: 1,
+      enabled: false,
+      status: "nonText",
+    },
+  ],
+};

--- a/packages/core/src/llm/providers/index.ts
+++ b/packages/core/src/llm/providers/index.ts
@@ -4,6 +4,7 @@ import { OPENAI } from "./endpoints/openai.js";
 import { GOOGLE } from "./endpoints/google.js";
 import { DEEPSEEK } from "./endpoints/deepseek.js";
 import { MINIMAX } from "./endpoints/minimax.js";
+import { AGNESAI } from "./endpoints/agnesai.js";
 // B1
 import { MOONSHOT } from "./endpoints/moonshot.js";
 import { ZHIPU } from "./endpoints/zhipu.js";
@@ -49,7 +50,7 @@ export type { InkosEndpoint, InkosModel, ApiProtocol, EndpointGroup } from "./ty
  * 但 Layer 2 还会按 PROVIDER_PRIORITY 显式排序，所以此处顺序不影响结果。
  */
 const ALL_PROVIDERS: readonly InkosEndpoint[] = [
-  ANTHROPIC, OPENAI, GOOGLE, DEEPSEEK, MINIMAX,
+  ANTHROPIC, OPENAI, GOOGLE, DEEPSEEK, MINIMAX, AGNESAI,
   MOONSHOT, ZHIPU, SILICONCLOUD, BAILIAN, VOLCENGINE, HUNYUAN, BAICHUAN, STEPFUN, WENXIN,
   SPARK, SENSENOVA, TENCENTCLOUD, XIAOMI_MIMO, LONGCAT, INTERNLM,
   ZEROONE, AI360,

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -46,6 +46,7 @@ export const SERVICE_PRESETS: Record<string, ServicePreset> = {
   ppio:        { providerFamily: "openai",    api: "openai-completions", baseUrl: "https://api.ppinfra.com/v3/openai",                  label: "PPIO" },
   openrouter:  { providerFamily: "openai",    api: "openai-responses",   baseUrl: "https://openrouter.ai/api/v1",                       label: "OpenRouter",      piProvider: "openrouter" },
   kkaiapi:     { providerFamily: "openai",    api: "openai-completions", baseUrl: "https://api.kkaiapi.com/v1",                         label: "kkaiapi",         modelsBaseUrl: "https://api.kkaiapi.com/v1" },
+  agnesai:     { providerFamily: "openai",    api: "openai-completions", baseUrl: "https://apihub.agnes-ai.com/v1",                     label: "AgnesAI",         modelsBaseUrl: "https://apihub.agnes-ai.com/v1" },
   ollama:      { providerFamily: "openai",    api: "openai-completions", baseUrl: "http://localhost:11434/v1",                          label: "Ollama (本地)" },
   custom:      { providerFamily: "openai",    api: "openai-completions", baseUrl: "",                                                    label: "自定义端点" },
 };

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -11,7 +11,7 @@ const LLMServiceEntrySchema = z.object({
 });
 
 const LLMCoverConfigSchema = z.object({
-  service: z.enum(["kkaiapi", "openai", "google"]),
+  service: z.enum(["kkaiapi", "openai", "google", "agnesai"]),
   model: z.string().min(1),
 }).optional();
 

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -58,6 +58,7 @@ const SERVICE_PRESETS_MOCK: Record<string, ServicePresetMock> = {
   bailian: { providerFamily: "anthropic", baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic", modelsBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", knownModels: [] as string[] },
   google: { providerFamily: "openai", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", modelsBaseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", knownModels: [] as string[] },
   kkaiapi: { providerFamily: "openai", baseUrl: "https://api.kkaiapi.com/v1", modelsBaseUrl: "https://api.kkaiapi.com/v1", knownModels: [] as string[] },
+  agnesai: { providerFamily: "openai", baseUrl: "https://apihub.agnes-ai.com/v1", modelsBaseUrl: "https://apihub.agnes-ai.com/v1", knownModels: [] as string[] },
   ollama: { providerFamily: "openai", baseUrl: "http://localhost:11434/v1", modelsBaseUrl: "http://localhost:11434/v1", knownModels: [] as string[] },
   custom: { providerFamily: "openai", baseUrl: "", knownModels: [] as string[] },
 };
@@ -92,7 +93,7 @@ const listModelsForServiceMock = vi.fn(async (service: string, apiKey?: string, 
 const endpointIdsByGroup = {
   overseas: ["anthropic", "google", "mistral", "openai", "xai"],
   china: [
-    "ai360", "baichuan", "bailian", "deepseek", "hunyuan", "internlm", "longcat",
+    "agnesai", "ai360", "baichuan", "bailian", "deepseek", "hunyuan", "internlm", "longcat",
     "minimax", "moonshot", "sensenova", "spark", "stepfun", "tencentcloud",
     "volcengine", "wenxin", "xiaomimimo", "zeroone", "zhipu",
   ],
@@ -109,11 +110,18 @@ const endpointMocks = [
     label: id,
     group,
     ...(id === "google" ? { checkModel: "gemini-2.5-flash" } : {}),
+    ...(id === "agnesai" ? { checkModel: "agnes-2.0-flash" } : {}),
     ...(id === "minimax" ? { checkModel: "MiniMax-M2.7" } : {}),
     ...(id === "ollama" ? { checkModel: "llama3.2:3b" } : {}),
     ...(id === "volcengine" ? { checkModel: "doubao-lite-32k" } : {}),
     models: [
-      { id: `${id}-model`, maxOutput: 4096, contextWindowTokens: 32768, enabled: true },
+      ...(id === "agnesai"
+        ? [
+            { id: "agnes-2.0-flash", maxOutput: 8192, contextWindowTokens: 1_000_000, enabled: true },
+            { id: "agnes-1.5-flash", maxOutput: 8192, contextWindowTokens: 1_000_000, enabled: true },
+            { id: "agnes-image-2.1-flash", maxOutput: 1, contextWindowTokens: 1, enabled: false, status: "nonText", capabilities: { text: false, imageOutput: true } },
+          ]
+        : [{ id: `${id}-model`, maxOutput: 4096, contextWindowTokens: 32768, enabled: true }]),
       { id: `${id}-disabled`, maxOutput: 4096, contextWindowTokens: 32768, enabled: false },
     ],
   }))),
@@ -973,14 +981,18 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { services: Array<{ service: string; group?: string; connected: boolean }> };
     const bank = body.services.filter((s) => !s.service.startsWith("custom"));
-    expect(bank.length).toBe(37);
+    expect(bank.length).toBe(38);
     expect(bank.every((s) => typeof s.group === "string")).toBe(true);
     expect(bank.filter((s) => s.group === "overseas")).toHaveLength(5);
-    expect(bank.filter((s) => s.group === "china")).toHaveLength(18);
+    expect(bank.filter((s) => s.group === "china")).toHaveLength(19);
     expect(bank.filter((s) => s.group === "aggregator")).toHaveLength(4);
     expect(bank.filter((s) => s.group === "local")).toHaveLength(2);
     expect(bank.filter((s) => s.group === "codingPlan")).toHaveLength(8);
     expect(bank.filter((s) => s.group === "aggregator").map((s) => s.service)[0]).toBe("kkaiapi");
+    expect(body.services.find((s) => s.service === "agnesai")).toMatchObject({
+      group: "china",
+      connected: false,
+    });
     expect(body.services.find((s) => s.service === "moonshot")?.connected).toBe(true);
     expect(body.services.find((s) => s.service === "custom:内网GPT")).toMatchObject({
       connected: true,
@@ -990,7 +1002,7 @@ describe("createStudioServer daemon lifecycle", () => {
   it("returns connected bank model groups from the local bank", async () => {
     loadSecretsMock.mockResolvedValue({
       services: {
-        moonshot: { apiKey: "sk-moonshot" },
+        agnesai: { apiKey: "sk-agnes" },
       },
     });
 
@@ -1000,9 +1012,10 @@ describe("createStudioServer daemon lifecycle", () => {
     const response = await app.request("http://localhost/api/v1/services/models");
     expect(response.status).toBe(200);
     const body = await response.json() as { groups: Array<{ service: string; models: Array<{ id: string }> }> };
-    expect(body.groups.map((g) => g.service)).toEqual(["moonshot"]);
+    expect(body.groups.map((g) => g.service)).toEqual(["agnesai"]);
     expect(body.groups[0]?.models).toEqual([
-      { id: "moonshot-model", name: "moonshot-model", maxOutput: 4096, contextWindow: 32768 },
+      { id: "agnes-2.0-flash", name: "agnes-2.0-flash", maxOutput: 8192, contextWindow: 1000000 },
+      { id: "agnes-1.5-flash", name: "agnes-1.5-flash", maxOutput: 8192, contextWindow: 1000000 },
     ]);
   });
 
@@ -2142,23 +2155,37 @@ describe("createStudioServer daemon lifecycle", () => {
     const { createStudioServer } = await import("./server.js");
     const app = createStudioServer(cloneProjectConfig() as never, root);
 
+    const configResponse = await app.request("http://localhost/api/v1/cover/config");
+    expect(configResponse.status).toBe(200);
+    await expect(configResponse.json()).resolves.toMatchObject({
+      providers: expect.arrayContaining([
+        expect.objectContaining({
+          service: "agnesai",
+          label: "AgnesAI Images",
+          baseUrl: "https://apihub.agnes-ai.com/v1",
+          defaultModel: "agnes-image-2.1-flash",
+          models: ["agnes-image-2.1-flash", "agnes-image-2.0-flash"],
+        }),
+      ]),
+    });
+
     const saveConfig = await app.request("http://localhost/api/v1/cover/config", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        service: "kkaiapi",
-        model: "gpt-image-2",
+        service: "agnesai",
+        model: "agnes-image-2.1-flash",
       }),
     });
     expect(saveConfig.status).toBe(200);
 
     const raw = JSON.parse(await readFile(join(root, "inkos.json"), "utf-8"));
     expect(raw.llm.cover).toEqual({
-      service: "kkaiapi",
-      model: "gpt-image-2",
+      service: "agnesai",
+      model: "agnes-image-2.1-flash",
     });
 
-    const saveSecret = await app.request("http://localhost/api/v1/cover/secret/kkaiapi", {
+    const saveSecret = await app.request("http://localhost/api/v1/cover/secret/agnesai", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ apiKey: "sk-cover" }),
@@ -2166,7 +2193,7 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(saveSecret.status).toBe(200);
     expect(saveSecretsMock).toHaveBeenCalledWith(root, {
       services: {
-        "cover:kkaiapi": { apiKey: "sk-cover" },
+        "cover:agnesai": { apiKey: "sk-cover" },
       },
     });
   });


### PR DESCRIPTION
## Summary
- Add AgnesAI as an OpenAI-compatible provider in the China provider group.
- Expose Agnes text models for Studio model selection while keeping image/video models out of chat menus.
- Add AgnesAI Images to cover generation presets using the existing `/images/generations` flow and `cover:agnesai` secrets.

## Test Plan
- `..\core\node_modules\.bin\vitest.CMD run src/__tests__/short-fiction-public.test.ts src/__tests__/providers-group.test.ts src/__tests__/providers-schema.test.ts src/__tests__/service-presets-regression.test.ts src/__tests__/list-models.test.ts`
- `node_modules\.bin\vitest.CMD run src/api/server.test.ts`
- `pnpm build`

No API keys or local secrets are included in this PR.