### PR TITLE
[codex] Unify Studio service model picker sources

### DIFF
--- a/packages/core/src/__tests__/list-models.test.ts
+++ b/packages/core/src/__tests__/list-models.test.ts
@@ -30,6 +30,12 @@ describe("listModelsForService (B8)", () => {
     expect(models.some((m) => m.id.includes("image"))).toBe(false);
   });
 
+  it("minimax static fallback includes MiniMax-M3", async () => {
+    const models = await listModelsForService("minimax");
+    expect(models[0]?.id).toBe("MiniMax-M3");
+    expect(models.some((m) => m.id === "MiniMax-M3")).toBe(true);
+  });
+
   it("custom service 走 live probe + bank 补元数据", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/core/src/llm/providers/endpoints/minimax.ts
+++ b/packages/core/src/llm/providers/endpoints/minimax.ts
@@ -24,6 +24,7 @@ export const MINIMAX: InkosEndpoint = {
   defaultTemperature: 0.9,
   writingTemperature: 0.9,
   models: [
+    { id: "MiniMax-M3", maxOutput: 131072, contextWindowTokens: 204800, enabled: true },
     { id: "MiniMax-M2.7", maxOutput: 131072, contextWindowTokens: 204800, enabled: true, releasedAt: "2026-03-18" },
     { id: "MiniMax-M2.7-highspeed", maxOutput: 131072, contextWindowTokens: 204800, releasedAt: "2026-03-18" },
     { id: "MiniMax-M2.5", maxOutput: 131072, contextWindowTokens: 204800, releasedAt: "2026-02-12" },

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -29,7 +29,7 @@ export const SERVICE_PRESETS: Record<string, ServicePreset> = {
     temperatureRange: [0, 2],
     defaultTemperature: 0.9,
     writingTemperature: 0.9,
-    knownModels: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2.1-highspeed", "MiniMax-M2"],
+    knownModels: ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2.1-highspeed", "MiniMax-M2"],
   },
   bailian:     {
     providerFamily: "anthropic",

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -987,12 +987,15 @@ describe("createStudioServer daemon lifecycle", () => {
     });
   });
 
-  it("returns connected bank model groups from the local bank", async () => {
+  it("returns connected model groups from the unified service model resolver", async () => {
     loadSecretsMock.mockResolvedValue({
       services: {
         moonshot: { apiKey: "sk-moonshot" },
       },
     });
+    listModelsForServiceMock.mockResolvedValueOnce([
+      { id: "moonshot-live", name: "moonshot-live", contextWindow: 65536, maxOutput: 8192 },
+    ]);
 
     const { createStudioServer } = await import("./server.js");
     const app = createStudioServer(cloneProjectConfig() as never, root);
@@ -1002,11 +1005,12 @@ describe("createStudioServer daemon lifecycle", () => {
     const body = await response.json() as { groups: Array<{ service: string; models: Array<{ id: string }> }> };
     expect(body.groups.map((g) => g.service)).toEqual(["moonshot"]);
     expect(body.groups[0]?.models).toEqual([
-      { id: "moonshot-model", name: "moonshot-model", maxOutput: 4096, contextWindow: 32768 },
+      { id: "moonshot-live", name: "moonshot-live", maxOutput: 8192, contextWindow: 65536 },
     ]);
+    expect(listModelsForServiceMock).toHaveBeenCalledWith("moonshot", "sk-moonshot");
   });
 
-  it("filters non-text models out of connected bank model groups", async () => {
+  it("filters non-text models out of connected model groups", async () => {
     loadSecretsMock.mockResolvedValue({
       services: {
         google: { apiKey: "sk-google" },
@@ -1017,13 +1021,14 @@ describe("createStudioServer daemon lifecycle", () => {
         id: "google",
         label: "Google Gemini",
         group: "overseas",
-        models: [
-          { id: "gemini-2.5-flash", maxOutput: 65536, contextWindowTokens: 1114112, enabled: true },
-          { id: "gemini-3.1-flash-image-preview", maxOutput: 32768, contextWindowTokens: 163840, enabled: true },
-          { id: "text-embedding-004", maxOutput: 2048, contextWindowTokens: 2048, enabled: true },
-        ],
+        models: [],
       },
     ] as never);
+    listModelsForServiceMock.mockResolvedValueOnce([
+      { id: "gemini-2.5-flash", name: "gemini-2.5-flash", contextWindow: 1114112 },
+      { id: "gemini-3.1-flash-image-preview", name: "gemini-3.1-flash-image-preview", contextWindow: 163840 },
+      { id: "text-embedding-004", name: "text-embedding-004", contextWindow: 2048 },
+    ]);
 
     const { createStudioServer } = await import("./server.js");
     const app = createStudioServer(cloneProjectConfig() as never, root);

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -2865,18 +2865,18 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const endpoints = getAllEndpoints()
       .filter((ep) => ep.id !== "custom" && Boolean(secrets.services[ep.id]?.apiKey));
 
-    const groups = endpoints.map((ep) => ({
-      service: ep.id,
-      label: ep.label,
-      models: ep.models
-        .filter((m) => m.enabled !== false)
-        .filter((m) => isTextChatModelId(m.id))
-        .map((m) => ({
+    const groups = await Promise.all(endpoints.map(async (ep) => {
+      const enriched = await listModelsForService(ep.id, secrets.services[ep.id]?.apiKey);
+      return {
+        service: ep.id,
+        label: ep.label,
+        models: filterTextChatModels(enriched).map((m) => ({
           id: m.id,
-          name: m.id,
-          ...(typeof m.maxOutput === "number" ? { maxOutput: m.maxOutput } : {}),
-          ...(m.contextWindowTokens > 0 ? { contextWindow: m.contextWindowTokens } : {}),
+          name: m.name,
+          ...(m.maxOutput !== undefined ? { maxOutput: m.maxOutput } : {}),
+          ...(m.contextWindow > 0 ? { contextWindow: m.contextWindow } : {}),
         })),
+      };
     }));
 
     return c.json({ groups });


### PR DESCRIPTION
## Summary
- Route the Studio `/api/v1/services/models` endpoint through `listModelsForService` so the chat/write model picker uses the same live/enriched model resolver as service detail flows.
- Add `MiniMax-M3` to the MiniMax fallback model bank and legacy known model list.
- Update regression coverage for the unified service model resolver path and MiniMax fallback ordering.

## Root cause
The service detail/test flow can see refreshed provider models, but the chat/write model picker was fed by `/services/models`, which only read each provider's static `ep.models` bank. That let configured/new provider models drift from the writing surface.

## Validation
- Compared the PR branch against `Narcooo/inkos:master`; diff is one commit touching the intended 5 files.
- Local test execution was not run because this environment could not complete a repository clone; the patch was applied through GitHub's Git Data API after targeted source inspection.