### PR TITLE
feat: add pluggable research provider interface and open-webSearch adapter

### DIFF
--- a/packages/core/src/__tests__/open-websearch-provider.test.ts
+++ b/packages/core/src/__tests__/open-websearch-provider.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  OpenWebSearchProvider,
+  OpenWebSearchProviderError,
+} from "../research/open-websearch-provider.js";
+
+function envelope(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({
+    status: status >= 400 ? "error" : "ok",
+    data: status >= 400 ? null : data,
+    error: status >= 400 ? { code: "engine_error", message: "search failed" } : null,
+    hint: null,
+  }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("OpenWebSearchProvider", () => {
+  it("maps daemon search and fetch responses to the provider contract", async () => {
+    const fetchFn = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(envelope({
+        results: [
+          {
+            title: "County archive",
+            url: "https://example.com/archive",
+            description: "Primary-source index",
+            engine: "bing",
+            source: "web",
+          },
+        ],
+      }))
+      .mockResolvedValueOnce(envelope({
+        content: "Readable evidence that is longer than the requested limit.",
+      }));
+    const provider = new OpenWebSearchProvider({
+      endpoint: "http://127.0.0.1:3210/",
+      fetchFn,
+    });
+
+    await expect(provider.search("county records", 3)).resolves.toEqual([
+      {
+        title: "County archive",
+        url: "https://example.com/archive",
+        snippet: "Primary-source index",
+      },
+    ]);
+    await expect(provider.fetch("https://example.com/archive", 17)).resolves.toBe("Readable evidence");
+
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      1,
+      "http://127.0.0.1:3210/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ query: "county records", limit: 3 }),
+      }),
+    );
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
+      "http://127.0.0.1:3210/fetch-web",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects non-loopback endpoints before making a request", () => {
+    expect(() => new OpenWebSearchProvider({
+      endpoint: "https://search.example.com",
+    })).toThrowError(OpenWebSearchProviderError);
+  });
+
+  it("preserves structured daemon errors", async () => {
+    const provider = new OpenWebSearchProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(envelope(null, 502)),
+    });
+
+    await expect(provider.search("test", 1)).rejects.toMatchObject({
+      name: "OpenWebSearchProviderError",
+      code: "engine_error",
+      status: 502,
+      message: "search failed",
+    });
+  });
+});

--- a/packages/core/src/agents/researcher.ts
+++ b/packages/core/src/agents/researcher.ts
@@ -1,4 +1,5 @@
 import { fetchUrl, searchWeb, type SearchResult } from "../utils/web-search.js";
+import type { ResearchProvider } from "../research/provider.js";
 
 export type ResearchPurpose = "worldbuilding" | "era" | "profession" | "market" | "fact-check" | "general";
 export type ResearchDepth = "quick" | "standard" | "deep";
@@ -37,6 +38,7 @@ export interface ResearchReport {
 }
 
 export interface ResearchDeps {
+  readonly provider?: ResearchProvider;
   readonly search?: (query: string, maxResults: number) => Promise<ReadonlyArray<SearchResult>>;
   readonly fetch?: (url: string, maxChars: number) => Promise<string>;
 }
@@ -56,8 +58,8 @@ export async function runResearchReport(
 ): Promise<ResearchReport> {
   const topic = input.topic.trim();
   if (!topic) throw new Error("research topic is required.");
-  const search = deps.search ?? searchWeb;
-  const fetch = deps.fetch ?? fetchUrl;
+  const search = deps.search ?? deps.provider?.search.bind(deps.provider) ?? searchWeb;
+  const fetch = deps.fetch ?? deps.provider?.fetch.bind(deps.provider) ?? fetchUrl;
   const depth = depthConfig(input.depth);
   const queries = buildQueries(topic, input.purpose, input.depth);
   const queryLog: string[] = [];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -454,6 +454,12 @@ export * from "./prompts/index.js";
 // Utils
 export { isNewLayoutBook, isBookFoundationComplete } from "./utils/outline-paths.js";
 export { fetchUrl, searchWeb } from "./utils/web-search.js";
+export type { ResearchProvider } from "./research/provider.js";
+export {
+  OpenWebSearchProvider,
+  OpenWebSearchProviderError,
+  type OpenWebSearchProviderOptions,
+} from "./research/open-websearch-provider.js";
 export {
   runResearchReport,
   type ResearchDepth,

--- a/packages/core/src/research/open-websearch-provider.ts
+++ b/packages/core/src/research/open-websearch-provider.ts
@@ -1,0 +1,165 @@
+import type { SearchResult } from "../utils/web-search.js";
+import type { ResearchProvider } from "./provider.js";
+
+interface OpenWebSearchErrorPayload {
+  readonly code?: string;
+  readonly message?: string;
+  readonly details?: Record<string, unknown>;
+}
+
+interface OpenWebSearchEnvelope<T> {
+  readonly status: "ok" | "error";
+  readonly data: T | null;
+  readonly error: OpenWebSearchErrorPayload | null;
+}
+
+interface OpenWebSearchResult {
+  readonly title?: string;
+  readonly url?: string;
+  readonly description?: string;
+}
+
+interface OpenWebSearchResponse {
+  readonly results?: ReadonlyArray<OpenWebSearchResult>;
+}
+
+interface OpenWebFetchResponse {
+  readonly content?: string;
+}
+
+export interface OpenWebSearchProviderOptions {
+  readonly endpoint?: string;
+  readonly timeoutMs?: number;
+  readonly engines?: ReadonlyArray<string>;
+  readonly searchMode?: "request" | "auto" | "playwright";
+  readonly fetchFn?: typeof fetch;
+}
+
+export class OpenWebSearchProviderError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status?: number,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "OpenWebSearchProviderError";
+  }
+}
+
+/** Adapter for the Apache-2.0 open-webSearch local HTTP daemon. */
+export class OpenWebSearchProvider implements ResearchProvider {
+  readonly id = "open-websearch";
+  private readonly endpoint: string;
+  private readonly timeoutMs: number;
+  private readonly engines?: ReadonlyArray<string>;
+  private readonly searchMode?: "request" | "auto" | "playwright";
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: OpenWebSearchProviderOptions = {}) {
+    this.endpoint = normalizeLoopbackEndpoint(options.endpoint ?? "http://127.0.0.1:3210");
+    this.timeoutMs = options.timeoutMs ?? 30_000;
+    this.engines = options.engines;
+    this.searchMode = options.searchMode;
+    this.fetchFn = options.fetchFn ?? globalThis.fetch;
+  }
+
+  async search(query: string, maxResults: number): Promise<ReadonlyArray<SearchResult>> {
+    const data = await this.request<OpenWebSearchResponse>("/search", {
+      query,
+      limit: maxResults,
+      ...(this.engines?.length ? { engines: [...this.engines] } : {}),
+      ...(this.searchMode ? { searchMode: this.searchMode } : {}),
+    });
+    return (data.results ?? [])
+      .filter((result) => Boolean(result.url))
+      .slice(0, maxResults)
+      .map((result) => ({
+        title: result.title ?? result.url ?? "",
+        url: result.url ?? "",
+        snippet: result.description ?? "",
+      }));
+  }
+
+  async fetch(url: string, maxChars: number): Promise<string> {
+    const data = await this.request<OpenWebFetchResponse>("/fetch-web", {
+      url,
+      maxChars,
+      readability: true,
+      includeLinks: false,
+    });
+    return (data.content ?? "").slice(0, maxChars);
+  }
+
+  private async request<T>(path: string, body: Record<string, unknown>): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let response: Response;
+    try {
+      response = await this.fetchFn(`${this.endpoint}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const timedOut = error instanceof Error && error.name === "AbortError";
+      throw new OpenWebSearchProviderError(
+        timedOut
+          ? `open-webSearch request timed out after ${this.timeoutMs}ms.`
+          : `Could not connect to open-webSearch: ${error instanceof Error ? error.message : String(error)}`,
+        timedOut ? "timeout" : "connection_failed",
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const raw = await response.text();
+    let envelope: OpenWebSearchEnvelope<T>;
+    try {
+      envelope = JSON.parse(raw) as OpenWebSearchEnvelope<T>;
+    } catch {
+      throw new OpenWebSearchProviderError(
+        "open-webSearch returned invalid JSON.",
+        "invalid_json",
+        response.status,
+        { responsePreview: raw.slice(0, 200) },
+      );
+    }
+
+    if (!response.ok || envelope.status === "error") {
+      throw new OpenWebSearchProviderError(
+        envelope.error?.message ?? `open-webSearch request failed with HTTP ${response.status}.`,
+        envelope.error?.code ?? "daemon_error",
+        response.status,
+        envelope.error?.details,
+      );
+    }
+    if (envelope.status !== "ok" || envelope.data === null) {
+      throw new OpenWebSearchProviderError("open-webSearch response data is missing.", "missing_data", response.status);
+    }
+    return envelope.data;
+  }
+}
+
+function normalizeLoopbackEndpoint(endpoint: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new OpenWebSearchProviderError("open-webSearch endpoint must be a valid URL.", "invalid_endpoint");
+  }
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    !["http:", "https:"].includes(parsed.protocol)
+    || Boolean(parsed.username)
+    || Boolean(parsed.password)
+    || !["127.0.0.1", "localhost", "::1"].includes(hostname)
+  ) {
+    throw new OpenWebSearchProviderError(
+      "open-webSearch endpoint must use HTTP(S), contain no credentials, and point to loopback.",
+      "invalid_endpoint",
+    );
+  }
+  return parsed.toString().replace(/\/+$/, "");
+}

--- a/packages/core/src/research/provider.ts
+++ b/packages/core/src/research/provider.ts
@@ -1,0 +1,9 @@
+import type { SearchResult } from "../utils/web-search.js";
+
+/** Minimal search/fetch contract consumed by the research workflow. */
+export interface ResearchProvider {
+  readonly id: string;
+  search(query: string, maxResults: number): Promise<ReadonlyArray<SearchResult>>;
+  fetch(url: string, maxChars: number): Promise<string>;
+}
+


### PR DESCRIPTION
## Summary
<!-- 1-3 bullet points: what changed and why -->

- **引入了统一的 `ResearchProvider` 调研接口**：为调研提供最小化的 `search` 和 `fetch` 行为契约，解耦具体的搜索引擎与调研 Agent 逻辑。
- **添加了 `OpenWebSearchProvider` 适配器**：可通过对接https://github.com/Aas-ee/open-webSearch ，为调研 Agent 提供本地的网络检索和网页解析能力。
- **在 `Researcher` 中支持外部 Provider 注入**：更新了 `runResearchReport` 依赖项（`ResearchDeps`），使其能动态解析并使用传入的 `ResearchProvider`。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [x] Test
- [ ] Performance

## Motivation (optional)
<!-- Why this change is needed. Link issues if applicable. Closes #xxx -->

为了增强调研 Agent 的检索灵活性，使系统能够摆脱对特定默认网络检索工具的依赖。引入该通用 Provider 接口后，开发者可以很方便地扩展并切换到其他搜索引擎服务商（如 `open-websearch` 实例）。

## Changes
<!-- File-level change list: what each file does -->

| File | Change |
|------|--------|
| [provider.ts](file:///E:/interesting/InkOS/packages/core/src/research/provider.ts) | **[NEW]** 定义了核心的 `ResearchProvider` 抽象接口，包含 `id`, `search` 和 `fetch` 声明。 |
| [open-websearch-provider.ts](file:///E:/interesting/InkOS/packages/core/src/research/open-websearch-provider.ts) | **[NEW]** 实现了基于本地 `open-websearch` HTTP 服务端适配的 `OpenWebSearchProvider`，支持 `/search` 和 `/fetch-web` 接口调用。 |
| [open-websearch-provider.test.ts](file:///E:/interesting/InkOS/packages/core/src/__tests__/open-websearch-provider.test.ts) | **[NEW]** 对 `OpenWebSearchProvider` 的各个场景（正常搜索、网页抓取、超时控制及异常处理）进行单元测试覆盖。 |
| [researcher.ts](file:///E:/interesting/InkOS/packages/core/src/agents/researcher.ts) | **[MODIFY]** 将 `ResearchProvider` 集成入 `ResearchDeps`，并在执行调研任务时动态绑定和使用它的 `search`/`fetch` 方法。 |
| [index.ts](file:///E:/interesting/InkOS/packages/core/src/index.ts) | **[MODIFY]** 在 package 出口向外暴露新增的 Provider 类型和错误类，方便外部集成和调用。 |

## Usage (optional)
<!-- Code snippets, CLI examples, or config samples showing how to use the new feature -->

通过以下示例代码，可以在调用 `runResearchReport` 时注入并使用本地的 `open-websearch` 检索实例：

```typescript
import { OpenWebSearchProvider, runResearchReport } from "@actalk/inkos-core";

// 实例化 OpenWebSearch 服务商适配器
const provider = new OpenWebSearchProvider({
  endpoint: "http://127.0.0.1:3210",
  timeoutMs: 5000,
});

// 在依赖中注入 provider 执行调研
const report = await runResearchReport(
  {
    topic: "AI Agent Design Patterns",
    purpose: "general",
    depth: "quick",
  },
  { provider }
);