### PR TITLE
fix/feat: issue batch — OpenRouter fallback, MiniMax thinking, revision gate, per-book review, notify format, chat import, tool details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Chat 新增 `import_chapters` 工具：可把本地文件/目录（含对话上传的附件）里的已有小说导入为书籍真实章节，自动逆向生成设定并重放章节状态；与 `ingest_material`（只存参考资料）分工明确（#324）
+- OpenRouter 等动态模型清单服务（openrouter/newapi/kkaiapi/ppio/siliconcloud）不再用静态白名单拦截用户配置的模型；openrouter 连通性探测模型更换为长期存在的 `openrouter/auto`，修复回退到已下架模型导致的 404（#300）
+- MiniMax 接入默认请求 `reasoning_split`，思考内容不再以 `<think>` 标签混进章节/对话正文（M2.x 的 thinking 无法在服务端关闭）；响应起始处的完整 think 块统一剥离兜底（#329）
+- 修订判断标准可配置：`writing.revisionGate` 三档 strict（默认，现状）/ lenient（不变差即应用）/ always（手动修订一律应用），支持全局与书级覆盖（#326）
+- CLI 现在遵守书级 `writing.reviewMode`（此前 `inkos write next` 永远自动审查）；新增 `inkos auto [book-id] <目标章号>` 连续自动写作到指定章（#307）
+- 通知渠道支持 `format: text`（默认仍为 markdown）；`write next / write rewrite / auto / revise / audit` 新增 `--notify`，动作完成或失败后发送通知（#308）
+- Studio 新增"操作详情默认展开"浏览器偏好（项目设置 → 对话界面）；read/grep 等小工具行有结果时也可展开查看正文（#306）
+
 ## v1.6.3
 
 ### Hotfix

--- a/packages/cli/src/__tests__/auto-command.test.ts
+++ b/packages/cli/src/__tests__/auto-command.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeNextChapterMock = vi.fn();
+const buildPipelineConfigMock = vi.fn();
+const loadConfigMock = vi.fn();
+const loadBookConfigMock = vi.fn();
+const getNextChapterNumberMock = vi.fn();
+const logMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@actalk/inkos-core", () => ({
+  PipelineRunner: class {
+    writeNextChapter = writeNextChapterMock;
+  },
+  StateManager: class {
+    async loadBookConfig() {
+      return loadBookConfigMock();
+    }
+    async getNextChapterNumber() {
+      return getNextChapterNumberMock();
+    }
+  },
+}));
+
+vi.mock("../utils.js", () => ({
+  loadConfig: loadConfigMock,
+  buildPipelineConfig: buildPipelineConfigMock,
+  findProjectRoot: vi.fn(() => "/project"),
+  resolveBookId: vi.fn(async (bookId?: string) => bookId ?? "auto-book"),
+  getLegacyMigrationHint: vi.fn(async () => null),
+  log: logMock,
+  logError: logErrorMock,
+}));
+
+vi.mock("../localization.js", () => ({
+  formatWriteNextProgress: vi.fn(() => "progress"),
+  formatWriteNextResultLines: vi.fn(() => ["ok"]),
+  formatWriteNextComplete: vi.fn(() => "done"),
+  formatAutoWriteStart: vi.fn(() => "auto-start"),
+  formatAutoWriteAlreadyComplete: vi.fn(() => "nothing-to-do"),
+  resolveCliLanguage: vi.fn(() => "zh"),
+}));
+
+function chapterResult(chapterNumber: number, status = "ready-for-review") {
+  return {
+    chapterNumber,
+    title: `第${chapterNumber}章`,
+    wordCount: 3000,
+    auditResult: { passed: true, issues: [], summary: "ok" },
+    revised: false,
+    status,
+  };
+}
+
+const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+describe("inkos auto command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadBookConfigMock.mockResolvedValue({
+      language: "zh",
+      writing: { reviewMode: "manual" },
+    });
+    loadConfigMock.mockResolvedValue({
+      llm: {},
+      writing: { reviewRetries: 1, reviewMode: "manual" },
+    });
+    buildPipelineConfigMock.mockReturnValue({});
+  });
+
+  afterAll(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("writes from the current chapter up to the target chapter with forced auto review", async () => {
+    getNextChapterNumberMock.mockResolvedValue(3);
+    let chapter = 2;
+    writeNextChapterMock.mockImplementation(async () => chapterResult(++chapter));
+
+    const { autoCommand } = await import("../commands/auto.js");
+    await autoCommand.parseAsync(["node", "auto", "demo-book", "5"], { from: "node" });
+
+    expect(writeNextChapterMock).toHaveBeenCalledTimes(3);
+    // reviewMode is "manual" on both book and project, but auto-write must
+    // force the inline audit→revise loop.
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ chapterReviewMode: "auto" }),
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the book already reached the target chapter", async () => {
+    getNextChapterNumberMock.mockResolvedValue(6);
+
+    const { autoCommand } = await import("../commands/auto.js");
+    await autoCommand.parseAsync(["node", "auto", "demo-book", "5"], { from: "node" });
+
+    expect(writeNextChapterMock).not.toHaveBeenCalled();
+    expect(buildPipelineConfigMock).not.toHaveBeenCalled();
+    expect(logMock).toHaveBeenCalledWith("nothing-to-do");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("stops immediately when a chapter write fails", async () => {
+    getNextChapterNumberMock.mockResolvedValue(1);
+    writeNextChapterMock
+      .mockResolvedValueOnce(chapterResult(1))
+      .mockRejectedValueOnce(new Error("LLM exploded"));
+
+    const { autoCommand } = await import("../commands/auto.js");
+    await autoCommand.parseAsync(["node", "auto", "demo-book", "3"], { from: "node" });
+
+    expect(writeNextChapterMock).toHaveBeenCalledTimes(2);
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Chapter 2 failed"),
+    );
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("LLM exploded"),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("stops when a chapter ends in state-degraded status", async () => {
+    getNextChapterNumberMock.mockResolvedValue(1);
+    writeNextChapterMock
+      .mockResolvedValueOnce(chapterResult(1))
+      .mockResolvedValueOnce(chapterResult(2, "state-degraded"));
+
+    const { autoCommand } = await import("../commands/auto.js");
+    await autoCommand.parseAsync(["node", "auto", "demo-book", "3"], { from: "node" });
+
+    expect(writeNextChapterMock).toHaveBeenCalledTimes(2);
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("state-degraded"),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/__tests__/localization.test.ts
+++ b/packages/cli/src/__tests__/localization.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatAutoWriteAlreadyComplete,
+  formatAutoWriteStart,
   formatBookCreateCreating,
   formatBookCreateCreated,
   formatBookCreateNextStep,
@@ -65,6 +67,18 @@ describe("CLI localization", () => {
       "  Issues:",
       "    [critical] continuity: Mismatch",
     ]);
+  });
+
+  it("formats auto-write banners in both languages", () => {
+    expect(formatAutoWriteStart("zh", "shan-he", 3, 10))
+      .toBe("自动写作「shan-he」：从第3章连续写到第10章...");
+    expect(formatAutoWriteAlreadyComplete("zh", "shan-he", 12, 10))
+      .toBe("「shan-he」已写到第12章（目标第10章），无需继续。");
+
+    expect(formatAutoWriteStart("en", "harbor", 3, 10))
+      .toBe('Auto-writing "harbor": chapter 3 through chapter 10...');
+    expect(formatAutoWriteAlreadyComplete("en", "harbor", 12, 10))
+      .toBe('"harbor" already has 12 chapter(s) written (target: chapter 10). Nothing to do.');
   });
 
   it("formats import summaries with language-specific units and action hints", () => {

--- a/packages/cli/src/__tests__/notify-option.test.ts
+++ b/packages/cli/src/__tests__/notify-option.test.ts
@@ -1,0 +1,348 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeNextChapterMock = vi.fn();
+const auditDraftMock = vi.fn();
+const reviseDraftMock = vi.fn();
+const dispatchNotificationMock = vi.fn();
+const buildPipelineConfigMock = vi.fn();
+const loadConfigMock = vi.fn();
+const loadBookConfigMock = vi.fn();
+const getNextChapterNumberMock = vi.fn();
+const logMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@actalk/inkos-core", () => ({
+  PipelineRunner: class {
+    writeNextChapter = writeNextChapterMock;
+    auditDraft = auditDraftMock;
+    reviseDraft = reviseDraftMock;
+  },
+  StateManager: class {
+    async loadBookConfig() {
+      return loadBookConfigMock();
+    }
+    async getNextChapterNumber() {
+      return getNextChapterNumberMock();
+    }
+  },
+  dispatchNotification: dispatchNotificationMock,
+  resolveChapterReviewMode: vi.fn(() => "auto"),
+  resolveRevisionGate: vi.fn(() => undefined),
+  DEFAULT_REVISE_MODE: "spot-fix",
+  // Real localization.ts imports these from core; keep them deterministic.
+  formatLengthCount: (count: number) => `${count}字`,
+  resolveLengthCountingMode: () => "chars",
+}));
+
+vi.mock("../utils.js", () => ({
+  loadConfig: loadConfigMock,
+  buildPipelineConfig: buildPipelineConfigMock,
+  findProjectRoot: vi.fn(() => "/project"),
+  resolveBookId: vi.fn(async (bookId?: string) => bookId ?? "auto-book"),
+  getLegacyMigrationHint: vi.fn(async () => null),
+  resolveContext: vi.fn(async () => undefined),
+  log: logMock,
+  logError: logErrorMock,
+}));
+
+const notifyChannels = [
+  { type: "telegram", botToken: "123:ABC", chatId: "-100", format: "text" },
+];
+
+function chapterResult(chapterNumber: number, status = "ready-for-review") {
+  return {
+    chapterNumber,
+    title: `第${chapterNumber}章`,
+    wordCount: 3000,
+    auditResult: { passed: true, issues: [], summary: "ok" },
+    revised: false,
+    status,
+  };
+}
+
+const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+describe("--notify command option", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    loadBookConfigMock.mockResolvedValue({
+      title: "示例书",
+      language: "zh",
+      writing: {},
+    });
+    loadConfigMock.mockResolvedValue({
+      llm: {},
+      writing: { reviewRetries: 1 },
+      notify: notifyChannels,
+    });
+    buildPipelineConfigMock.mockReturnValue({});
+    dispatchNotificationMock.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    exitSpy.mockRestore();
+  });
+
+  describe("write next", () => {
+    it("skips the success notification for a single-chapter run (pipeline already notified per chapter)", async () => {
+      writeNextChapterMock.mockResolvedValueOnce(chapterResult(4));
+
+      const { writeCommand } = await import("../commands/write.js");
+      await writeCommand.parseAsync(["node", "write", "next", "demo-book", "--notify"], { from: "node" });
+
+      expect(writeNextChapterMock).toHaveBeenCalledTimes(1);
+      expect(dispatchNotificationMock).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("sends one batch summary for a multi-chapter run", async () => {
+      let chapter = 3;
+      writeNextChapterMock.mockImplementation(async () => chapterResult(++chapter));
+
+      const { writeCommand } = await import("../commands/write.js");
+      await writeCommand.parseAsync(
+        ["node", "write", "next", "demo-book", "--count", "2", "--notify"],
+        { from: "node" },
+      );
+
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [channels, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(channels).toBe(notifyChannels);
+      expect(message.title).toBe("✅ 写作完成《示例书》");
+      expect(message.body).toContain("本次完成 2 章（第4章到第5章）");
+      expect(message.body).toContain("第4章 第4章 | 3000字 | 审计通过");
+    });
+
+    it("does not send a batch summary without --notify", async () => {
+      let chapter = 3;
+      writeNextChapterMock.mockImplementation(async () => chapterResult(++chapter));
+
+      const { writeCommand } = await import("../commands/write.js");
+      await writeCommand.parseAsync(
+        ["node", "write", "next", "demo-book", "--count", "2"],
+        { from: "node" },
+      );
+
+      expect(dispatchNotificationMock).not.toHaveBeenCalled();
+    });
+
+    it("sends a failure notification with the error message before exiting", async () => {
+      writeNextChapterMock.mockRejectedValueOnce(new Error("LLM exploded"));
+
+      const { writeCommand } = await import("../commands/write.js");
+      await writeCommand.parseAsync(["node", "write", "next", "demo-book", "--notify"], { from: "node" });
+
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("❌ 写作失败《示例书》");
+      expect(message.body).toContain("LLM exploded");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("sends no failure notification without --notify", async () => {
+      writeNextChapterMock.mockRejectedValueOnce(new Error("LLM exploded"));
+
+      const { writeCommand } = await import("../commands/write.js");
+      await writeCommand.parseAsync(["node", "write", "next", "demo-book"], { from: "node" });
+
+      expect(dispatchNotificationMock).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("write rewrite", () => {
+    it("sends a failure notification when the command fails", async () => {
+      const { writeCommand } = await import("../commands/write.js");
+      await writeCommand.parseAsync(
+        ["node", "write", "rewrite", "a", "b", "c", "--notify"],
+        { from: "node" },
+      );
+
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [channels, message] = dispatchNotificationMock.mock.calls[0]!;
+      // Failure happened before the book config was loaded: helper loads the
+      // project config itself and falls back to zh with no book name.
+      expect(channels).toBe(notifyChannels);
+      expect(message.title).toBe("❌ 重写失败");
+      expect(message.body).toContain("Usage: inkos write rewrite");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("audit", () => {
+    it("sends a completion notification with the audit verdict", async () => {
+      auditDraftMock.mockResolvedValueOnce({
+        chapterNumber: 4,
+        passed: true,
+        issues: [],
+        summary: "整体一致",
+      });
+
+      const { auditCommand } = await import("../commands/audit.js");
+      await auditCommand.parseAsync(["node", "audit", "demo-book", "--notify"], { from: "node" });
+
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [channels, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(channels).toBe(notifyChannels);
+      expect(message.title).toBe("✅ 审计完成《示例书》");
+      expect(message.body).toBe("第4章审计通过（0 个问题）\n整体一致");
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("uses English copy when the book language is en", async () => {
+      loadBookConfigMock.mockResolvedValue({ title: "My Book", language: "en", writing: {} });
+      auditDraftMock.mockResolvedValueOnce({
+        chapterNumber: 2,
+        passed: false,
+        issues: [{ severity: "major", category: "timeline", description: "conflict" }],
+        summary: "timeline conflict",
+      });
+
+      const { auditCommand } = await import("../commands/audit.js");
+      await auditCommand.parseAsync(["node", "audit", "demo-book", "--notify"], { from: "node" });
+
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("✅ Audit complete: My Book");
+      expect(message.body).toBe("Chapter 2 audit failed (1 issue(s))\ntimeline conflict");
+    });
+
+    it("warns and skips when --notify is set but no channels are configured", async () => {
+      loadConfigMock.mockResolvedValue({ llm: {}, writing: { reviewRetries: 1 }, notify: [] });
+      auditDraftMock.mockResolvedValueOnce({
+        chapterNumber: 4,
+        passed: true,
+        issues: [],
+        summary: "ok",
+      });
+
+      const { auditCommand } = await import("../commands/audit.js");
+      await auditCommand.parseAsync(["node", "audit", "demo-book", "--notify"], { from: "node" });
+
+      expect(dispatchNotificationMock).not.toHaveBeenCalled();
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("--notify"));
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not let a notification failure change the command exit code", async () => {
+      dispatchNotificationMock.mockRejectedValueOnce(new Error("network down"));
+      auditDraftMock.mockResolvedValueOnce({
+        chapterNumber: 4,
+        passed: true,
+        issues: [],
+        summary: "ok",
+      });
+
+      const { auditCommand } = await import("../commands/audit.js");
+      await auditCommand.parseAsync(["node", "audit", "demo-book", "--notify"], { from: "node" });
+
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("network down"));
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("sends a failure notification when the audit fails", async () => {
+      auditDraftMock.mockRejectedValueOnce(new Error("no chapters"));
+
+      const { auditCommand } = await import("../commands/audit.js");
+      await auditCommand.parseAsync(["node", "audit", "demo-book", "--notify"], { from: "node" });
+
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("❌ 审计失败《示例书》");
+      expect(message.body).toContain("no chapters");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("revise", () => {
+    it("sends a completion notification when the revision is applied", async () => {
+      reviseDraftMock.mockResolvedValueOnce({
+        chapterNumber: 3,
+        wordCount: 3200,
+        fixedIssues: ["fix a", "fix b"],
+        applied: true,
+        status: "ready-for-review",
+      });
+
+      const { reviseCommand } = await import("../commands/revise.js");
+      await reviseCommand.parseAsync(["node", "revise", "demo-book", "3", "--notify"], { from: "node" });
+
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("✅ 修订完成《示例书》");
+      expect(message.body).toBe("第3章已修订 | 3200字 | 修复 2 个问题");
+    });
+
+    it("reports a kept original draft with the skip reason", async () => {
+      reviseDraftMock.mockResolvedValueOnce({
+        chapterNumber: 3,
+        wordCount: 3000,
+        fixedIssues: [],
+        applied: false,
+        status: "unchanged",
+        skippedReason: "无阻断问题",
+      });
+
+      const { reviseCommand } = await import("../commands/revise.js");
+      await reviseCommand.parseAsync(["node", "revise", "demo-book", "3", "--notify"], { from: "node" });
+
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("✅ 修订完成《示例书》");
+      expect(message.body).toBe("第3章保留原稿：无阻断问题");
+    });
+
+    it("sends a failure notification when the revision fails", async () => {
+      reviseDraftMock.mockRejectedValueOnce(new Error("revision blew up"));
+
+      const { reviseCommand } = await import("../commands/revise.js");
+      await reviseCommand.parseAsync(["node", "revise", "demo-book", "3", "--notify"], { from: "node" });
+
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("❌ 修订失败《示例书》");
+      expect(message.body).toContain("revision blew up");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("auto", () => {
+    it("sends one batch summary for a multi-chapter run", async () => {
+      getNextChapterNumberMock.mockResolvedValue(1);
+      let chapter = 0;
+      writeNextChapterMock.mockImplementation(async () => chapterResult(++chapter));
+
+      const { autoCommand } = await import("../commands/auto.js");
+      await autoCommand.parseAsync(["node", "auto", "demo-book", "3", "--notify"], { from: "node" });
+
+      expect(writeNextChapterMock).toHaveBeenCalledTimes(3);
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("✅ 自动连写完成《示例书》");
+      expect(message.body).toContain("本次完成 3 章（第1章到第3章）");
+    });
+
+    it("skips the success notification for a single-chapter run (pipeline already notified per chapter)", async () => {
+      getNextChapterNumberMock.mockResolvedValue(3);
+      writeNextChapterMock.mockResolvedValueOnce(chapterResult(3));
+
+      const { autoCommand } = await import("../commands/auto.js");
+      await autoCommand.parseAsync(["node", "auto", "demo-book", "3", "--notify"], { from: "node" });
+
+      expect(dispatchNotificationMock).not.toHaveBeenCalled();
+    });
+
+    it("sends a failure notification when a chapter write fails mid-run", async () => {
+      getNextChapterNumberMock.mockResolvedValue(1);
+      writeNextChapterMock
+        .mockResolvedValueOnce(chapterResult(1))
+        .mockRejectedValueOnce(new Error("LLM exploded"));
+
+      const { autoCommand } = await import("../commands/auto.js");
+      await autoCommand.parseAsync(["node", "auto", "demo-book", "3", "--notify"], { from: "node" });
+
+      expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
+      const [, message] = dispatchNotificationMock.mock.calls[0]!;
+      expect(message.title).toBe("❌ 自动连写失败《示例书》");
+      expect(message.body).toContain("Chapter 2 failed");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/revise-gate.test.ts
+++ b/packages/cli/src/__tests__/revise-gate.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const reviseDraftMock = vi.fn();
+const buildPipelineConfigMock = vi.fn();
+const loadConfigMock = vi.fn();
+const loadBookConfigMock = vi.fn();
+const logMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@actalk/inkos-core", () => ({
+  DEFAULT_REVISE_MODE: "spot-fix",
+  PipelineRunner: class {
+    reviseDraft = reviseDraftMock;
+  },
+  StateManager: class {
+    async loadBookConfig() {
+      return loadBookConfigMock();
+    }
+  },
+  // Mirrors the real core implementation: book-level overrides project-level,
+  // both unset falls back to "strict". The real function is unit-tested in
+  // packages/core/src/__tests__/revision-gate.test.ts.
+  resolveRevisionGate: (
+    book: { writing?: { revisionGate?: "strict" | "lenient" | "always" } },
+    projectWriting?: { revisionGate?: "strict" | "lenient" | "always" },
+  ) => book.writing?.revisionGate ?? projectWriting?.revisionGate ?? "strict",
+}));
+
+vi.mock("../utils.js", () => ({
+  loadConfig: loadConfigMock,
+  buildPipelineConfig: buildPipelineConfigMock,
+  findProjectRoot: vi.fn(() => "/project"),
+  resolveBookId: vi.fn(async (bookId?: string) => bookId ?? "auto-book"),
+  log: logMock,
+  logError: logErrorMock,
+}));
+
+describe("inkos revise revision gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reviseDraftMock.mockResolvedValue({
+      chapterNumber: 1,
+      wordCount: 3000,
+      fixedIssues: ["- fixed"],
+      applied: true,
+      status: "ready-for-review",
+    });
+    buildPipelineConfigMock.mockReturnValue({});
+  });
+
+  it("passes the book-level revisionGate into the pipeline config", async () => {
+    loadBookConfigMock.mockResolvedValue({
+      language: "zh",
+      writing: { revisionGate: "always" },
+    });
+    loadConfigMock.mockResolvedValue({
+      llm: {},
+      writing: { reviewRetries: 1, revisionGate: "strict" },
+    });
+
+    const { reviseCommand } = await import("../commands/revise.js");
+    await reviseCommand.parseAsync(["node", "revise", "demo-book", "1"], { from: "node" });
+
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ revisionGate: "always" }),
+    );
+    expect(reviseDraftMock).toHaveBeenCalledWith("demo-book", 1, "spot-fix");
+  });
+
+  it("falls back to the project-level revisionGate when the book does not set one", async () => {
+    loadBookConfigMock.mockResolvedValue({ language: "zh" });
+    loadConfigMock.mockResolvedValue({
+      llm: {},
+      writing: { reviewRetries: 1, revisionGate: "lenient" },
+    });
+
+    const { reviseCommand } = await import("../commands/revise.js");
+    await reviseCommand.parseAsync(["node", "revise", "demo-book", "1"], { from: "node" });
+
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ revisionGate: "lenient" }),
+    );
+  });
+
+  it("defaults to strict when neither book nor project sets a revisionGate", async () => {
+    loadBookConfigMock.mockResolvedValue({ language: "zh" });
+    loadConfigMock.mockResolvedValue({ llm: {}, writing: { reviewRetries: 1 } });
+
+    const { reviseCommand } = await import("../commands/revise.js");
+    await reviseCommand.parseAsync(["node", "revise", "demo-book", "1"], { from: "node" });
+
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ revisionGate: "strict" }),
+    );
+  });
+});

--- a/packages/cli/src/__tests__/revision-command.test.ts
+++ b/packages/cli/src/__tests__/revision-command.test.ts
@@ -18,6 +18,12 @@ vi.mock("@actalk/inkos-core", () => ({
       return loadBookConfigMock();
     }
   },
+  // Mirrors the real core implementation; unit-tested in
+  // packages/core/src/__tests__/revision-gate.test.ts.
+  resolveRevisionGate: (
+    book: { writing?: { revisionGate?: "strict" | "lenient" | "always" } },
+    projectWriting?: { revisionGate?: "strict" | "lenient" | "always" },
+  ) => book.writing?.revisionGate ?? projectWriting?.revisionGate ?? "strict",
 }));
 
 vi.mock("../utils.js", () => ({
@@ -65,6 +71,7 @@ describe("revision-related CLI commands", () => {
 
     expect(buildPipelineConfigMock).toHaveBeenCalledWith(expect.anything(), "/project", {
       externalContext: "把注意力拉回师债主线。",
+      revisionGate: "strict",
     });
     expect(reviseDraftMock).toHaveBeenCalledWith("demo-book", 3, "rewrite");
   });

--- a/packages/cli/src/__tests__/write-review-mode.test.ts
+++ b/packages/cli/src/__tests__/write-review-mode.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeNextChapterMock = vi.fn();
+const buildPipelineConfigMock = vi.fn();
+const loadConfigMock = vi.fn();
+const loadBookConfigMock = vi.fn();
+const logMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@actalk/inkos-core", () => ({
+  PipelineRunner: class {
+    writeNextChapter = writeNextChapterMock;
+  },
+  StateManager: class {
+    async loadBookConfig() {
+      return loadBookConfigMock();
+    }
+  },
+  // Mirrors the real core implementation: book-level overrides project-level,
+  // both unset falls back to "auto". The real function is unit-tested in
+  // packages/core/src/__tests__/chapter-review-mode.test.ts.
+  resolveChapterReviewMode: (
+    book: { writing?: { reviewMode?: "auto" | "manual" } },
+    projectWriting?: { reviewMode?: "auto" | "manual" },
+  ) => book.writing?.reviewMode ?? projectWriting?.reviewMode ?? "auto",
+}));
+
+vi.mock("../utils.js", () => ({
+  loadConfig: loadConfigMock,
+  buildPipelineConfig: buildPipelineConfigMock,
+  findProjectRoot: vi.fn(() => "/project"),
+  resolveBookId: vi.fn(async (bookId?: string) => bookId ?? "auto-book"),
+  getLegacyMigrationHint: vi.fn(async () => null),
+  resolveContext: vi.fn(async () => undefined),
+  log: logMock,
+  logError: logErrorMock,
+}));
+
+vi.mock("../localization.js", () => ({
+  formatWriteNextProgress: vi.fn(() => "progress"),
+  formatWriteNextResultLines: vi.fn(() => ["ok"]),
+  formatWriteNextComplete: vi.fn(() => "done"),
+  resolveCliLanguage: vi.fn(() => "zh"),
+}));
+
+describe("inkos write next review mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeNextChapterMock.mockResolvedValue({
+      chapterNumber: 4,
+      title: "第四章",
+      wordCount: 3000,
+      auditResult: { passed: true, issues: [], summary: "ok" },
+      revised: false,
+      status: "ready-for-review",
+    });
+    buildPipelineConfigMock.mockReturnValue({});
+  });
+
+  it("passes book-level reviewMode into the pipeline config", async () => {
+    loadBookConfigMock.mockResolvedValue({
+      language: "zh",
+      writing: { reviewMode: "manual" },
+    });
+    loadConfigMock.mockResolvedValue({
+      llm: {},
+      writing: { reviewRetries: 1, reviewMode: "auto" },
+    });
+
+    const { writeCommand } = await import("../commands/write.js");
+    await writeCommand.parseAsync(["node", "write", "next", "demo-book"], { from: "node" });
+
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ chapterReviewMode: "manual" }),
+    );
+    expect(writeNextChapterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the project-level reviewMode when the book does not set one", async () => {
+    loadBookConfigMock.mockResolvedValue({ language: "zh" });
+    loadConfigMock.mockResolvedValue({
+      llm: {},
+      writing: { reviewRetries: 1, reviewMode: "manual" },
+    });
+
+    const { writeCommand } = await import("../commands/write.js");
+    await writeCommand.parseAsync(["node", "write", "next", "demo-book"], { from: "node" });
+
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ chapterReviewMode: "manual" }),
+    );
+  });
+
+  it("defaults to auto when neither book nor project sets a reviewMode", async () => {
+    loadBookConfigMock.mockResolvedValue({ language: "zh" });
+    loadConfigMock.mockResolvedValue({ llm: {}, writing: { reviewRetries: 1 } });
+
+    const { writeCommand } = await import("../commands/write.js");
+    await writeCommand.parseAsync(["node", "write", "next", "demo-book"], { from: "node" });
+
+    expect(buildPipelineConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/project",
+      expect.objectContaining({ chapterReviewMode: "auto" }),
+    );
+  });
+});

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,13 +1,24 @@
 import { Command } from "commander";
-import { PipelineRunner } from "@actalk/inkos-core";
+import { PipelineRunner, StateManager } from "@actalk/inkos-core";
 import { loadConfig, buildPipelineConfig, findProjectRoot, resolveBookId, log, logError } from "../utils.js";
+import {
+  formatNotifyAuditBody,
+  formatNotifyCommandTitle,
+  formatNotifyFailureBody,
+  resolveCliLanguage,
+  type CliLanguage,
+} from "../localization.js";
+import { sendCommandNotification } from "../notify-helper.js";
 
 export const auditCommand = new Command("audit")
   .description("Audit a chapter for continuity issues")
   .argument("[book-id]", "Book ID (auto-detected if only one book)")
   .argument("[chapter]", "Chapter number (defaults to latest)")
   .option("--json", "Output JSON")
+  .option("--notify", "Send a notification to configured notify channels when the command finishes")
   .action(async (bookIdArg: string | undefined, chapterStr: string | undefined, opts) => {
+    let notifyLanguage: CliLanguage = "zh";
+    let notifyBookName: string | undefined;
     try {
       const config = await loadConfig();
       const root = findProjectRoot();
@@ -22,6 +33,12 @@ export const auditCommand = new Command("audit")
         bookId = await resolveBookId(bookIdArg, root);
         chapterNumber = chapterStr ? parseInt(chapterStr, 10) : undefined;
       }
+
+      const state = new StateManager(root);
+      const book = await state.loadBookConfig(bookId);
+      const language = resolveCliLanguage(book.language);
+      notifyLanguage = language;
+      notifyBookName = book.title ?? bookId;
 
       const pipeline = new PipelineRunner(buildPipelineConfig(config, root));
 
@@ -41,7 +58,27 @@ export const auditCommand = new Command("audit")
           }
         }
       }
+
+      // Unlike write commands, the pipeline sends no notification for
+      // auditDraft, so --notify always sends the completion notification here.
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(language, "audit", notifyBookName, true),
+          body: formatNotifyAuditBody(language, {
+            chapterNumber: result.chapterNumber,
+            passed: result.passed,
+            issueCount: result.issues.length,
+            summary: result.summary,
+          }),
+        }, config);
+      }
     } catch (e) {
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(notifyLanguage, "audit", notifyBookName, false),
+          body: formatNotifyFailureBody(notifyLanguage, e),
+        });
+      }
       if (opts.json) {
         log(JSON.stringify({ error: String(e) }));
       } else {

--- a/packages/cli/src/commands/auto.ts
+++ b/packages/cli/src/commands/auto.ts
@@ -1,0 +1,120 @@
+import { Command } from "commander";
+import { PipelineRunner, StateManager } from "@actalk/inkos-core";
+import { loadConfig, buildPipelineConfig, findProjectRoot, getLegacyMigrationHint, resolveBookId, log, logError } from "../utils.js";
+import {
+  formatAutoWriteAlreadyComplete,
+  formatAutoWriteStart,
+  formatWriteNextComplete,
+  formatWriteNextProgress,
+  formatWriteNextResultLines,
+  resolveCliLanguage,
+} from "../localization.js";
+
+export const autoCommand = new Command("auto")
+  .description("Auto-write chapters until the book reaches a target chapter number: auto [book-id] <target-chapter>")
+  .argument("<args...>", "Book ID (optional, auto-detected if only one book) and target chapter number")
+  .option("--words <n>", "Words per chapter (overrides book config)")
+  .option("--json", "Output JSON")
+  .option("-q, --quiet", "Suppress console output")
+  .action(async (args: ReadonlyArray<string>, opts) => {
+    try {
+      const root = findProjectRoot();
+
+      let bookId: string;
+      let targetChapter: number;
+      if (args.length === 1) {
+        targetChapter = parseInt(args[0]!, 10);
+        if (isNaN(targetChapter)) throw new Error(`Expected target chapter number, got "${args[0]}"`);
+        bookId = await resolveBookId(undefined, root);
+      } else if (args.length === 2) {
+        targetChapter = parseInt(args[1]!, 10);
+        if (isNaN(targetChapter)) throw new Error(`Expected target chapter number, got "${args[1]}"`);
+        bookId = await resolveBookId(args[0], root);
+      } else {
+        throw new Error("Usage: inkos auto [book-id] <target-chapter>");
+      }
+      if (targetChapter < 1) {
+        throw new Error(`Target chapter must be >= 1, got ${targetChapter}`);
+      }
+
+      const state = new StateManager(root);
+      const book = await state.loadBookConfig(bookId);
+      const language = resolveCliLanguage(book.language);
+      const migrationHint = await getLegacyMigrationHint(root, bookId);
+      if (migrationHint && !opts.json) {
+        log(`[migration] ${migrationHint}`);
+      }
+
+      const startChapter = await state.getNextChapterNumber(bookId);
+      if (startChapter > targetChapter) {
+        if (opts.json) {
+          log(JSON.stringify([], null, 2));
+        } else {
+          log(formatAutoWriteAlreadyComplete(language, bookId, startChapter - 1, targetChapter));
+        }
+        return;
+      }
+
+      const config = await loadConfig();
+      // `inkos auto` is unattended batch writing, so the audit→revise loop must
+      // run inline: force "auto" regardless of book/project reviewMode settings.
+      const pipeline = new PipelineRunner(buildPipelineConfig(config, root, {
+        quiet: opts.quiet,
+        chapterReviewMode: "auto",
+      }));
+
+      if (!opts.json) log(formatAutoWriteStart(language, bookId, startChapter, targetChapter));
+
+      const wordCount = opts.words ? parseInt(opts.words, 10) : undefined;
+
+      const results = [];
+      for (let chapter = startChapter; chapter <= targetChapter; chapter++) {
+        if (!opts.json) log(formatWriteNextProgress(language, chapter, targetChapter, bookId));
+
+        let result;
+        try {
+          result = await pipeline.writeNextChapter(bookId, wordCount);
+        } catch (e) {
+          throw new Error(
+            `Chapter ${chapter} failed, stopping auto-write (${results.length} chapter(s) completed this run): ${e instanceof Error ? e.message : String(e)}`,
+            { cause: e },
+          );
+        }
+        results.push(result);
+
+        if (!opts.json) {
+          for (const line of formatWriteNextResultLines(language, {
+            chapterNumber: result.chapterNumber,
+            title: result.title,
+            wordCount: result.wordCount,
+            auditPassed: result.auditResult.passed,
+            revised: result.revised,
+            status: result.status,
+            issues: result.auditResult.issues,
+          })) {
+            log(line);
+          }
+          log("");
+        }
+
+        if (result.status === "state-degraded") {
+          throw new Error(
+            `Chapter ${result.chapterNumber} finished in state-degraded status, stopping auto-write. Run "inkos write repair-state ${bookId} ${result.chapterNumber}" first, then re-run inkos auto.`,
+          );
+        }
+      }
+
+      if (opts.json) {
+        log(JSON.stringify(results, null, 2));
+      } else {
+        log(formatWriteNextComplete(language));
+      }
+    } catch (e) {
+      if (opts.json) {
+        log(JSON.stringify({ error: String(e) }));
+      } else {
+        logError(`Auto-write failed: ${e}`);
+      }
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/commands/auto.ts
+++ b/packages/cli/src/commands/auto.ts
@@ -4,11 +4,16 @@ import { loadConfig, buildPipelineConfig, findProjectRoot, getLegacyMigrationHin
 import {
   formatAutoWriteAlreadyComplete,
   formatAutoWriteStart,
+  formatNotifyBatchWriteBody,
+  formatNotifyCommandTitle,
+  formatNotifyFailureBody,
   formatWriteNextComplete,
   formatWriteNextProgress,
   formatWriteNextResultLines,
   resolveCliLanguage,
+  type CliLanguage,
 } from "../localization.js";
+import { sendCommandNotification } from "../notify-helper.js";
 
 export const autoCommand = new Command("auto")
   .description("Auto-write chapters until the book reaches a target chapter number: auto [book-id] <target-chapter>")
@@ -16,7 +21,10 @@ export const autoCommand = new Command("auto")
   .option("--words <n>", "Words per chapter (overrides book config)")
   .option("--json", "Output JSON")
   .option("-q, --quiet", "Suppress console output")
+  .option("--notify", "Send a notification to configured notify channels when the command finishes")
   .action(async (args: ReadonlyArray<string>, opts) => {
+    let notifyLanguage: CliLanguage = "zh";
+    let notifyBookName: string | undefined;
     try {
       const root = findProjectRoot();
 
@@ -40,6 +48,8 @@ export const autoCommand = new Command("auto")
       const state = new StateManager(root);
       const book = await state.loadBookConfig(bookId);
       const language = resolveCliLanguage(book.language);
+      notifyLanguage = language;
+      notifyBookName = book.title ?? bookId;
       const migrationHint = await getLegacyMigrationHint(root, bookId);
       if (migrationHint && !opts.json) {
         log(`[migration] ${migrationHint}`);
@@ -109,7 +119,30 @@ export const autoCommand = new Command("auto")
       } else {
         log(formatWriteNextComplete(language));
       }
+
+      // The pipeline itself already sends one notification per completed
+      // chapter whenever notify channels are configured (runner.ts, end of
+      // writeNextChapter). A single-chapter run would therefore duplicate that
+      // exact notification — only send a command-level batch summary when this
+      // run wrote more than one chapter.
+      if (opts.notify && results.length > 1) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(language, "auto", notifyBookName, true),
+          body: formatNotifyBatchWriteBody(language, results.map((r) => ({
+            chapterNumber: r.chapterNumber,
+            title: r.title,
+            wordCount: r.wordCount,
+            auditPassed: r.auditResult.passed,
+          }))),
+        }, config);
+      }
     } catch (e) {
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(notifyLanguage, "auto", notifyBookName, false),
+          body: formatNotifyFailureBody(notifyLanguage, e),
+        });
+      }
       if (opts.json) {
         log(JSON.stringify({ error: String(e) }));
       } else {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -28,6 +28,7 @@ configCommand
         "inputGovernanceMode",
         "foundation.reviewRetries",
         "writing.reviewRetries",
+        "writing.revisionGate",
         "daemon.schedule.radarCron", "daemon.schedule.writeCron",
         "daemon.maxConcurrentBooks", "daemon.chaptersPerCycle",
         "daemon.retryDelayMs", "daemon.cooldownAfterChapterMs",

--- a/packages/cli/src/commands/revise.ts
+++ b/packages/cli/src/commands/revise.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { DEFAULT_REVISE_MODE, PipelineRunner, type ReviseMode } from "@actalk/inkos-core";
+import { DEFAULT_REVISE_MODE, PipelineRunner, StateManager, resolveRevisionGate, type ReviseMode } from "@actalk/inkos-core";
 import { loadConfig, buildPipelineConfig, findProjectRoot, resolveBookId, log, logError } from "../utils.js";
 
 export const reviseCommand = new Command("revise")
@@ -24,8 +24,11 @@ export const reviseCommand = new Command("revise")
         chapterNumber = chapterStr ? parseInt(chapterStr, 10) : undefined;
       }
 
+      const state = new StateManager(root);
+      const book = await state.loadBookConfig(bookId);
       const pipeline = new PipelineRunner(buildPipelineConfig(config, root, {
         externalContext: opts.brief,
+        revisionGate: resolveRevisionGate(book, config.writing),
       }));
 
       const mode = opts.mode as ReviseMode;

--- a/packages/cli/src/commands/revise.ts
+++ b/packages/cli/src/commands/revise.ts
@@ -1,6 +1,14 @@
 import { Command } from "commander";
 import { DEFAULT_REVISE_MODE, PipelineRunner, StateManager, resolveRevisionGate, type ReviseMode } from "@actalk/inkos-core";
 import { loadConfig, buildPipelineConfig, findProjectRoot, resolveBookId, log, logError } from "../utils.js";
+import {
+  formatNotifyCommandTitle,
+  formatNotifyFailureBody,
+  formatNotifyReviseBody,
+  resolveCliLanguage,
+  type CliLanguage,
+} from "../localization.js";
+import { sendCommandNotification } from "../notify-helper.js";
 
 export const reviseCommand = new Command("revise")
   .description("Revise a chapter based on audit issues")
@@ -9,7 +17,10 @@ export const reviseCommand = new Command("revise")
   .option("--mode <mode>", "Revise mode: spot-fix, polish, rewrite, rework, anti-detect", DEFAULT_REVISE_MODE)
   .option("--brief <text>", "One-off creative guidance for this revise/rewrite only")
   .option("--json", "Output JSON")
+  .option("--notify", "Send a notification to configured notify channels when the command finishes")
   .action(async (bookIdArg: string | undefined, chapterStr: string | undefined, opts) => {
+    let notifyLanguage: CliLanguage = "zh";
+    let notifyBookName: string | undefined;
     try {
       const config = await loadConfig();
       const root = findProjectRoot();
@@ -26,6 +37,9 @@ export const reviseCommand = new Command("revise")
 
       const state = new StateManager(root);
       const book = await state.loadBookConfig(bookId);
+      const language = resolveCliLanguage(book.language);
+      notifyLanguage = language;
+      notifyBookName = book.title ?? bookId;
       const pipeline = new PipelineRunner(buildPipelineConfig(config, root, {
         externalContext: opts.brief,
         revisionGate: resolveRevisionGate(book, config.writing),
@@ -50,7 +64,28 @@ export const reviseCommand = new Command("revise")
           log(`    - ${fix}`);
         }
       }
+
+      // Unlike write commands, the pipeline sends no notification for
+      // reviseDraft, so --notify always sends the completion notification here.
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(language, "revise", notifyBookName, true),
+          body: formatNotifyReviseBody(language, {
+            chapterNumber: result.chapterNumber,
+            applied: result.applied,
+            wordCount: result.wordCount,
+            fixedCount: result.fixedIssues.length,
+            skippedReason: result.skippedReason,
+          }),
+        }, config);
+      }
     } catch (e) {
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(notifyLanguage, "revise", notifyBookName, false),
+          body: formatNotifyFailureBody(notifyLanguage, e),
+        });
+      }
       if (opts.json) {
         log(JSON.stringify({ error: String(e) }));
       } else {

--- a/packages/cli/src/commands/write.ts
+++ b/packages/cli/src/commands/write.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { PipelineRunner, StateManager } from "@actalk/inkos-core";
+import { PipelineRunner, StateManager, resolveChapterReviewMode } from "@actalk/inkos-core";
 import { readdir, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -33,7 +33,11 @@ writeCommand
       }
       const config = await loadConfig();
 
-      const pipeline = new PipelineRunner(buildPipelineConfig(config, root, { externalContext: context, quiet: opts.quiet }));
+      const pipeline = new PipelineRunner(buildPipelineConfig(config, root, {
+        externalContext: context,
+        quiet: opts.quiet,
+        chapterReviewMode: resolveChapterReviewMode(book, config.writing),
+      }));
 
       const count = parseInt(opts.count, 10);
       const wordCount = opts.words ? parseInt(opts.words, 10) : undefined;
@@ -124,6 +128,7 @@ writeCommand
       }
 
       const state = new StateManager(root);
+      const book = await state.loadBookConfig(bookId);
       const bookDir = state.bookDir(bookId);
       const chaptersDir = join(bookDir, "chapters");
       const restoreFrom = chapter - 1;
@@ -179,10 +184,10 @@ writeCommand
       const config = await loadConfig();
       const pipeline = new PipelineRunner(buildPipelineConfig(config, root, {
         externalContext: opts.brief,
+        chapterReviewMode: resolveChapterReviewMode(book, config.writing),
       }));
 
       const result = await pipeline.writeNextChapter(bookId, wordCount);
-      const book = await state.loadBookConfig(bookId);
       const language = resolveCliLanguage(book.language);
 
       if (opts.json) {

--- a/packages/cli/src/commands/write.ts
+++ b/packages/cli/src/commands/write.ts
@@ -4,7 +4,17 @@ import { readdir, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { loadConfig, buildPipelineConfig, findProjectRoot, getLegacyMigrationHint, resolveContext, resolveBookId, log, logError } from "../utils.js";
-import { formatWriteNextComplete, formatWriteNextProgress, formatWriteNextResultLines, resolveCliLanguage } from "../localization.js";
+import {
+  formatNotifyBatchWriteBody,
+  formatNotifyCommandTitle,
+  formatNotifyFailureBody,
+  formatWriteNextComplete,
+  formatWriteNextProgress,
+  formatWriteNextResultLines,
+  resolveCliLanguage,
+  type CliLanguage,
+} from "../localization.js";
+import { sendCommandNotification } from "../notify-helper.js";
 
 export const writeCommand = new Command("write")
   .description("Write chapters");
@@ -19,7 +29,10 @@ writeCommand
   .option("--context-file <path>", "Read guidance from file")
   .option("--json", "Output JSON")
   .option("-q, --quiet", "Suppress console output")
+  .option("--notify", "Send a notification to configured notify channels when the command finishes")
   .action(async (bookIdArg: string | undefined, opts) => {
+    let notifyLanguage: CliLanguage = "zh";
+    let notifyBookName: string | undefined;
     try {
       const root = findProjectRoot();
       const bookId = await resolveBookId(bookIdArg, root);
@@ -27,6 +40,8 @@ writeCommand
       const state = new StateManager(root);
       const book = await state.loadBookConfig(bookId);
       const language = resolveCliLanguage(book.language);
+      notifyLanguage = language;
+      notifyBookName = book.title ?? bookId;
       const migrationHint = await getLegacyMigrationHint(root, bookId);
       if (migrationHint && !opts.json) {
         log(`[migration] ${migrationHint}`);
@@ -79,7 +94,30 @@ writeCommand
       } else {
         log(formatWriteNextComplete(language));
       }
+
+      // The pipeline itself already sends one notification per completed
+      // chapter whenever notify channels are configured (runner.ts, end of
+      // writeNextChapter). A single-chapter run would therefore duplicate that
+      // exact notification — only send a command-level batch summary when this
+      // run wrote more than one chapter.
+      if (opts.notify && results.length > 1) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(language, "write-next", notifyBookName, true),
+          body: formatNotifyBatchWriteBody(language, results.map((r) => ({
+            chapterNumber: r.chapterNumber,
+            title: r.title,
+            wordCount: r.wordCount,
+            auditPassed: r.auditResult.passed,
+          }))),
+        }, config);
+      }
     } catch (e) {
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(notifyLanguage, "write-next", notifyBookName, false),
+          body: formatNotifyFailureBody(notifyLanguage, e),
+        });
+      }
       if (opts.json) {
         log(JSON.stringify({ error: String(e) }));
       } else {
@@ -97,7 +135,10 @@ writeCommand
   .option("--words <n>", "Words per chapter (overrides book config)")
   .option("--brief <text>", "One-off creative guidance for this rewrite only")
   .option("--json", "Output JSON")
+  .option("--notify", "Send a notification to configured notify channels when the command finishes")
   .action(async (args: ReadonlyArray<string>, opts) => {
+    let notifyLanguage: CliLanguage = "zh";
+    let notifyBookName: string | undefined;
     try {
       const root = findProjectRoot();
 
@@ -129,6 +170,8 @@ writeCommand
 
       const state = new StateManager(root);
       const book = await state.loadBookConfig(bookId);
+      notifyLanguage = resolveCliLanguage(book.language);
+      notifyBookName = book.title ?? bookId;
       const bookDir = state.bookDir(bookId);
       const chaptersDir = join(bookDir, "chapters");
       const restoreFrom = chapter - 1;
@@ -205,7 +248,18 @@ writeCommand
           log(line);
         }
       }
+
+      // Success notification intentionally skipped: the pipeline already sent
+      // the per-chapter notification for this exact chapter (runner.ts, end of
+      // writeNextChapter) — a command-level one would be a duplicate. --notify
+      // only adds the failure notification for this command.
     } catch (e) {
+      if (opts.notify) {
+        await sendCommandNotification({
+          title: formatNotifyCommandTitle(notifyLanguage, "write-rewrite", notifyBookName, false),
+          body: formatNotifyFailureBody(notifyLanguage, e),
+        });
+      }
       if (opts.json) {
         log(JSON.stringify({ error: String(e) }));
       } else {

--- a/packages/cli/src/localization.ts
+++ b/packages/cli/src/localization.ts
@@ -139,6 +139,30 @@ export function formatWriteNextComplete(language: CliLanguage): string {
   });
 }
 
+export function formatAutoWriteStart(
+  language: CliLanguage,
+  bookId: string,
+  startChapter: number,
+  targetChapter: number,
+): string {
+  return localize(language, {
+    zh: `自动写作「${bookId}」：从第${startChapter}章连续写到第${targetChapter}章...`,
+    en: `Auto-writing "${bookId}": chapter ${startChapter} through chapter ${targetChapter}...`,
+  });
+}
+
+export function formatAutoWriteAlreadyComplete(
+  language: CliLanguage,
+  bookId: string,
+  writtenChapters: number,
+  targetChapter: number,
+): string {
+  return localize(language, {
+    zh: `「${bookId}」已写到第${writtenChapters}章（目标第${targetChapter}章），无需继续。`,
+    en: `"${bookId}" already has ${writtenChapters} chapter(s) written (target: chapter ${targetChapter}). Nothing to do.`,
+  });
+}
+
 export function formatImportChaptersDiscovery(
   language: CliLanguage,
   chapterCount: number,

--- a/packages/cli/src/localization.ts
+++ b/packages/cli/src/localization.ts
@@ -163,6 +163,105 @@ export function formatAutoWriteAlreadyComplete(
   });
 }
 
+export type NotifyCommandAction = "write-next" | "write-rewrite" | "revise" | "audit" | "auto";
+
+const NOTIFY_ACTION_LABELS: Record<NotifyCommandAction, { zh: string; en: string }> = {
+  "write-next": { zh: "写作", en: "Write" },
+  "write-rewrite": { zh: "重写", en: "Rewrite" },
+  revise: { zh: "修订", en: "Revise" },
+  audit: { zh: "审计", en: "Audit" },
+  auto: { zh: "自动连写", en: "Auto-write" },
+};
+
+export function formatNotifyCommandTitle(
+  language: CliLanguage,
+  action: NotifyCommandAction,
+  bookName: string | undefined,
+  succeeded: boolean,
+): string {
+  const label = localize(language, NOTIFY_ACTION_LABELS[action]);
+  const book = bookName === undefined
+    ? ""
+    : localize(language, { zh: `《${bookName}》`, en: `: ${bookName}` });
+  return succeeded
+    ? localize(language, { zh: `✅ ${label}完成${book}`, en: `✅ ${label} complete${book}` })
+    : localize(language, { zh: `❌ ${label}失败${book}`, en: `❌ ${label} failed${book}` });
+}
+
+export function formatNotifyBatchWriteBody(
+  language: CliLanguage,
+  chapters: ReadonlyArray<{
+    readonly chapterNumber: number;
+    readonly title: string;
+    readonly wordCount: number;
+    readonly auditPassed: boolean;
+  }>,
+): string {
+  const first = chapters[0]!;
+  const last = chapters[chapters.length - 1]!;
+  const lines = [
+    localize(language, {
+      zh: `本次完成 ${chapters.length} 章（第${first.chapterNumber}章到第${last.chapterNumber}章）`,
+      en: `${chapters.length} chapter(s) written (chapter ${first.chapterNumber} to ${last.chapterNumber})`,
+    }),
+    ...chapters.map((ch) => {
+      const lengthLabel = formatLengthCount(ch.wordCount, resolveLengthCountingMode(language));
+      return localize(language, {
+        zh: `第${ch.chapterNumber}章 ${ch.title} | ${lengthLabel} | ${ch.auditPassed ? "审计通过" : "需复核"}`,
+        en: `Chapter ${ch.chapterNumber} ${ch.title} | ${lengthLabel} | ${ch.auditPassed ? "audit passed" : "needs review"}`,
+      });
+    }),
+  ];
+  return lines.join("\n");
+}
+
+export function formatNotifyAuditBody(
+  language: CliLanguage,
+  result: {
+    readonly chapterNumber: number;
+    readonly passed: boolean;
+    readonly issueCount: number;
+    readonly summary: string;
+  },
+): string {
+  const head = localize(language, {
+    zh: `第${result.chapterNumber}章审计${result.passed ? "通过" : "未通过"}（${result.issueCount} 个问题）`,
+    en: `Chapter ${result.chapterNumber} audit ${result.passed ? "passed" : "failed"} (${result.issueCount} issue(s))`,
+  });
+  return result.summary ? `${head}\n${result.summary}` : head;
+}
+
+export function formatNotifyReviseBody(
+  language: CliLanguage,
+  result: {
+    readonly chapterNumber: number;
+    readonly applied: boolean;
+    readonly wordCount: number;
+    readonly fixedCount: number;
+    readonly skippedReason?: string;
+  },
+): string {
+  if (!result.applied) {
+    return localize(language, {
+      zh: `第${result.chapterNumber}章保留原稿${result.skippedReason ? `：${result.skippedReason}` : ""}`,
+      en: `Chapter ${result.chapterNumber} kept original draft${result.skippedReason ? `: ${result.skippedReason}` : ""}`,
+    });
+  }
+  const lengthLabel = formatLengthCount(result.wordCount, resolveLengthCountingMode(language));
+  return localize(language, {
+    zh: `第${result.chapterNumber}章已修订 | ${lengthLabel} | 修复 ${result.fixedCount} 个问题`,
+    en: `Chapter ${result.chapterNumber} revised | ${lengthLabel} | ${result.fixedCount} issue(s) fixed`,
+  });
+}
+
+export function formatNotifyFailureBody(language: CliLanguage, error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return localize(language, {
+    zh: `错误：${detail}`,
+    en: `Error: ${detail}`,
+  });
+}
+
 export function formatImportChaptersDiscovery(
   language: CliLanguage,
   chapterCount: number,

--- a/packages/cli/src/notify-helper.ts
+++ b/packages/cli/src/notify-helper.ts
@@ -1,0 +1,34 @@
+import { dispatchNotification, type ProjectConfig } from "@actalk/inkos-core";
+import { loadConfig, logError } from "./utils.js";
+
+export interface CliNotifyMessage {
+  readonly title: string;
+  readonly body: string;
+}
+
+/**
+ * Send a command-level notification (--notify) to the project's configured
+ * notify channels. Callers guard with the --notify flag before invoking so
+ * message strings are only assembled when a notification will be attempted.
+ *
+ * - Uses the caller's already-loaded project config when provided; otherwise
+ *   loads it here (failure paths may fail before the command loaded it).
+ * - Never throws: notification delivery must not change the command's exit
+ *   code, so every failure is written to stderr as a warning instead.
+ */
+export async function sendCommandNotification(
+  message: CliNotifyMessage,
+  config?: ProjectConfig,
+): Promise<void> {
+  try {
+    const resolved = config ?? (await loadConfig());
+    const channels = resolved.notify ?? [];
+    if (channels.length === 0) {
+      logError("--notify: no notify channels configured in project config (notify: []), skipping notification");
+      return;
+    }
+    await dispatchNotification(channels, message);
+  } catch (e) {
+    logError(`--notify: failed to send notification: ${e}`);
+  }
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -4,6 +4,7 @@ import { initCommand } from "./commands/init.js";
 import { configCommand } from "./commands/config.js";
 import { bookCommand } from "./commands/book.js";
 import { writeCommand } from "./commands/write.js";
+import { autoCommand } from "./commands/auto.js";
 import { reviewCommand } from "./commands/review.js";
 import { statusCommand } from "./commands/status.js";
 import { radarCommand } from "./commands/radar.js";
@@ -63,6 +64,7 @@ export function createProgram(hooks: ProgramHooks = {}): Command {
   program.addCommand(configCommand);
   program.addCommand(bookCommand);
   program.addCommand(writeCommand);
+  program.addCommand(autoCommand);
   program.addCommand(reviewCommand);
   program.addCommand(statusCommand);
   program.addCommand(radarCommand);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -108,7 +108,7 @@ export function parseLLMOverridesFromArgv(argv: readonly string[]): LLMConfigCli
 export function buildPipelineConfig(
   config: ProjectConfig,
   root: string,
-  extra?: Partial<Pick<PipelineConfig, "notifyChannels" | "radarSources" | "externalContext" | "inputGovernanceMode">> & {
+  extra?: Partial<Pick<PipelineConfig, "notifyChannels" | "radarSources" | "externalContext" | "inputGovernanceMode" | "chapterReviewMode">> & {
     readonly quiet?: boolean;
     readonly logFile?: NodeJS.WritableStream;
   },
@@ -149,6 +149,7 @@ export function buildPipelineConfig(
     defaultLLMConfig: config.llm,
     foundationReviewRetries: config.foundation.reviewRetries,
     writingReviewRetries: config.writing?.reviewRetries ?? 1,
+    chapterReviewMode: extra?.chapterReviewMode,
     modelOverrides: config.modelOverrides,
     inputGovernanceMode: extra?.inputGovernanceMode ?? config.inputGovernanceMode,
     notifyChannels: extra?.notifyChannels ?? config.notify,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -108,7 +108,7 @@ export function parseLLMOverridesFromArgv(argv: readonly string[]): LLMConfigCli
 export function buildPipelineConfig(
   config: ProjectConfig,
   root: string,
-  extra?: Partial<Pick<PipelineConfig, "notifyChannels" | "radarSources" | "externalContext" | "inputGovernanceMode" | "chapterReviewMode">> & {
+  extra?: Partial<Pick<PipelineConfig, "notifyChannels" | "radarSources" | "externalContext" | "inputGovernanceMode" | "chapterReviewMode" | "revisionGate">> & {
     readonly quiet?: boolean;
     readonly logFile?: NodeJS.WritableStream;
   },
@@ -150,6 +150,7 @@ export function buildPipelineConfig(
     foundationReviewRetries: config.foundation.reviewRetries,
     writingReviewRetries: config.writing?.reviewRetries ?? 1,
     chapterReviewMode: extra?.chapterReviewMode,
+    revisionGate: extra?.revisionGate,
     modelOverrides: config.modelOverrides,
     inputGovernanceMode: extra?.inputGovernanceMode ?? config.inputGovernanceMode,
     notifyChannels: extra?.notifyChannels ?? config.notify,

--- a/packages/core/src/__tests__/agent-import-chapters-tool.test.ts
+++ b/packages/core/src/__tests__/agent-import-chapters-tool.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StateManager } from "../state/manager.js";
+import { createImportChaptersTool } from "../agent/agent-tools.js";
+
+function mockPipeline() {
+  return {
+    importChapters: vi.fn(async (input: { bookId: string; chapters: ReadonlyArray<{ title: string; content: string }> }) => ({
+      bookId: input.bookId,
+      importedCount: input.chapters.length,
+      totalWords: 4200,
+      nextChapter: input.chapters.length + 1,
+    })),
+  };
+}
+
+describe("import_chapters agent tool", () => {
+  let root: string;
+  let state: StateManager;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "inkos-import-chapters-tool-"));
+    state = new StateManager(root);
+
+    await state.saveBookConfig("harbor", {
+      id: "harbor",
+      title: "Harbor",
+      platform: "tomato",
+      genre: "other",
+      status: "active",
+      targetChapters: 20,
+      chapterWordCount: 3000,
+      createdAt: "2026-07-07T00:00:00.000Z",
+      updatedAt: "2026-07-07T00:00:00.000Z",
+    });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("imports a directory of .md/.txt files in filename order with prefix-stripped titles", async () => {
+    const sourceDir = join(root, "source-dir");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "02_风暴.txt"), "码头的雨下了一夜。", "utf-8");
+    await writeFile(join(sourceDir, "01_序章.md"), "林月守着玉印。", "utf-8");
+    await writeFile(join(sourceDir, "notes.pdf"), "ignored", "utf-8");
+
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    const result = await tool.execute("tool-import-dir", { sourcePath: sourceDir });
+
+    expect(pipeline.importChapters).toHaveBeenCalledTimes(1);
+    expect(pipeline.importChapters).toHaveBeenCalledWith({
+      bookId: "harbor",
+      chapters: [
+        { title: "序章", content: "林月守着玉印。" },
+        { title: "风暴", content: "码头的雨下了一夜。" },
+      ],
+      resumeFrom: undefined,
+      importMode: undefined,
+    });
+    expect(result.content[0]?.type).toBe("text");
+    if (result.content[0]?.type === "text") {
+      expect(result.content[0].text).toContain('Imported 2 chapter(s) into book "harbor"');
+      expect(result.content[0].text).toContain("Next chapter to write: 3");
+    }
+    expect(result.details).toMatchObject({
+      kind: "chapters_imported",
+      bookId: "harbor",
+      importedCount: 2,
+      totalWords: 4200,
+      nextChapter: 3,
+      importMode: "continuation",
+    });
+  });
+
+  it("auto-splits a single file by chapter headings and resolves project-relative stored_path", async () => {
+    await mkdir(join(root, ".inkos", "uploads", "s1"), { recursive: true });
+    await writeFile(
+      join(root, ".inkos", "uploads", "s1", "novel.txt"),
+      "第一章 开局\n\n他在码头醒来。\n\n第二章 反转\n\n账本不见了。\n",
+      "utf-8",
+    );
+
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    await tool.execute("tool-import-file", { sourcePath: ".inkos/uploads/s1/novel.txt" });
+
+    expect(pipeline.importChapters).toHaveBeenCalledWith({
+      bookId: "harbor",
+      chapters: [
+        { title: "开局", content: "他在码头醒来。" },
+        { title: "反转", content: "账本不见了。" },
+      ],
+      resumeFrom: undefined,
+      importMode: undefined,
+    });
+  });
+
+  it("splits a single file with a custom splitPattern", async () => {
+    const sourceFile = join(root, "novel-custom.txt");
+    await writeFile(sourceFile, "Part 序幕\n雨夜。\nPart 终局\n天亮。\n", "utf-8");
+
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    await tool.execute("tool-import-custom-split", {
+      sourcePath: sourceFile,
+      splitPattern: "^Part\\s+(.*)$",
+    });
+
+    expect(pipeline.importChapters).toHaveBeenCalledWith({
+      bookId: "harbor",
+      chapters: [
+        { title: "序幕", content: "雨夜。" },
+        { title: "终局", content: "天亮。" },
+      ],
+      resumeFrom: undefined,
+      importMode: undefined,
+    });
+  });
+
+  it("throws when the single file yields no chapters", async () => {
+    const sourceFile = join(root, "no-headings.txt");
+    await writeFile(sourceFile, "只有正文，没有任何章节标题。", "utf-8");
+
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    await expect(tool.execute("tool-import-no-split", { sourcePath: sourceFile }))
+      .rejects.toThrow(/No chapters found/);
+    expect(pipeline.importChapters).not.toHaveBeenCalled();
+  });
+
+  it("throws when the book already has chapters and resumeFrom is missing", async () => {
+    await mkdir(join(state.bookDir("harbor"), "chapters"), { recursive: true });
+    await writeFile(
+      join(state.bookDir("harbor"), "chapters", "0001_旧章.md"),
+      "# 第1章 旧章\n\n已有正文。\n",
+      "utf-8",
+    );
+    await state.saveChapterIndex("harbor", [{
+      number: 1,
+      title: "旧章",
+      status: "imported",
+      wordCount: 10,
+      createdAt: "2026-07-07T00:00:00.000Z",
+      updatedAt: "2026-07-07T00:00:00.000Z",
+      auditIssues: [],
+      lengthWarnings: [],
+    }]);
+
+    const sourceDir = join(root, "source-dir");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "01_新章.md"), "新的正文。", "utf-8");
+
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    await expect(tool.execute("tool-import-conflict", { sourcePath: sourceDir }))
+      .rejects.toThrow(/already has 1 chapter\(s\).*resumeFrom/);
+    expect(pipeline.importChapters).not.toHaveBeenCalled();
+  });
+
+  it("passes resumeFrom and importMode through to pipeline.importChapters", async () => {
+    await mkdir(join(state.bookDir("harbor"), "chapters"), { recursive: true });
+    await writeFile(
+      join(state.bookDir("harbor"), "chapters", "0001_旧章.md"),
+      "# 第1章 旧章\n\n已有正文。\n",
+      "utf-8",
+    );
+    await state.saveChapterIndex("harbor", [{
+      number: 1,
+      title: "旧章",
+      status: "imported",
+      wordCount: 10,
+      createdAt: "2026-07-07T00:00:00.000Z",
+      updatedAt: "2026-07-07T00:00:00.000Z",
+      auditIssues: [],
+      lengthWarnings: [],
+    }]);
+
+    const sourceDir = join(root, "source-dir");
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, "01_旧章.md"), "已有正文。", "utf-8");
+    await writeFile(join(sourceDir, "02_新章.md"), "新的正文。", "utf-8");
+
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    const result = await tool.execute("tool-import-resume", {
+      sourcePath: sourceDir,
+      resumeFrom: 2,
+      importMode: "series",
+    });
+
+    expect(pipeline.importChapters).toHaveBeenCalledWith({
+      bookId: "harbor",
+      chapters: [
+        { title: "旧章", content: "已有正文。" },
+        { title: "新章", content: "新的正文。" },
+      ],
+      resumeFrom: 2,
+      importMode: "series",
+    });
+    expect(result.content[0]?.type).toBe("text");
+    if (result.content[0]?.type === "text") {
+      expect(result.content[0].text).toContain("Resumed replay from chapter 2");
+    }
+    expect(result.details).toMatchObject({ importMode: "series" });
+  });
+
+  it("rejects a bookId that does not match the active book", async () => {
+    const pipeline = mockPipeline();
+    const tool = createImportChaptersTool(pipeline as never, "harbor", root);
+
+    await expect(tool.execute("tool-import-wrong-book", {
+      bookId: "other-book",
+      sourcePath: join(root, "whatever.txt"),
+    })).rejects.toThrow(/must match the active book/);
+    expect(pipeline.importChapters).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/__tests__/agent-session.test.ts
+++ b/packages/core/src/__tests__/agent-session.test.ts
@@ -571,6 +571,7 @@ describe("runAgentSession cache — bookId switch", () => {
       "research_web",
       "ingest_material",
       "retrieve_material",
+      "import_chapters",
     ]);
   });
 
@@ -894,6 +895,7 @@ describe("runAgentSession cache — bookId switch", () => {
       "research_web",
       "ingest_material",
       "retrieve_material",
+      "import_chapters",
       "grep",
       "ls",
     ]);

--- a/packages/core/src/__tests__/chapter-review-mode.test.ts
+++ b/packages/core/src/__tests__/chapter-review-mode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveChapterReviewMode } from "../models/book.js";
+
+describe("resolveChapterReviewMode", () => {
+  it("book-level reviewMode overrides project-level reviewMode", () => {
+    expect(resolveChapterReviewMode(
+      { writing: { reviewMode: "manual" } },
+      { reviewMode: "auto" },
+    )).toBe("manual");
+
+    expect(resolveChapterReviewMode(
+      { writing: { reviewMode: "auto" } },
+      { reviewMode: "manual" },
+    )).toBe("auto");
+  });
+
+  it("falls back to project-level reviewMode when book does not set one", () => {
+    expect(resolveChapterReviewMode({}, { reviewMode: "manual" })).toBe("manual");
+    expect(resolveChapterReviewMode(
+      { writing: {} },
+      { reviewMode: "manual" },
+    )).toBe("manual");
+  });
+
+  it("defaults to auto when neither book nor project sets a reviewMode", () => {
+    expect(resolveChapterReviewMode({})).toBe("auto");
+    expect(resolveChapterReviewMode({ writing: {} }, {})).toBe("auto");
+  });
+});

--- a/packages/core/src/__tests__/effective-llm-config.test.ts
+++ b/packages/core/src/__tests__/effective-llm-config.test.ts
@@ -374,6 +374,70 @@ describe("resolveEffectiveLLMConfig", () => {
     })).rejects.toThrow(/模型.*kimi-k2\.5.*不属于.*google/);
   });
 
+  it("openrouter 配置了不在静态 bank 的模型时保留用户模型，不回退 checkModel（issue #300）", async () => {
+    await writeProject({
+      configSource: "studio",
+      service: "openrouter",
+      services: [{ service: "openrouter" }],
+      defaultModel: "moonshotai/kimi-k2-thinking",
+    });
+    await writeSecrets({ openrouter: { apiKey: "sk-or" } });
+
+    const result = await resolveEffectiveLLMConfig({
+      consumer: "studio",
+      projectRoot: root,
+      envLayers: { global: {}, project: {}, process: {} },
+      requireApiKey: true,
+    });
+
+    expect(result.llm.service).toBe("openrouter");
+    expect(result.llm.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(result.llm.model).toBe("moonshotai/kimi-k2-thinking");
+  });
+
+  it("CLI env 显式指定 openrouter 未列出模型时也直接透传", async () => {
+    await writeProject({
+      configSource: "studio",
+      service: "openrouter",
+      services: [{ service: "openrouter" }],
+      defaultModel: "openrouter/auto",
+    });
+    await writeSecrets({ openrouter: { apiKey: "sk-or" } });
+
+    const result = await resolveEffectiveLLMConfig({
+      consumer: "cli",
+      projectRoot: root,
+      envLayers: {
+        global: {},
+        project: { INKOS_LLM_MODEL: "z-ai/glm-4.7" },
+        process: {},
+      },
+    });
+
+    expect(result.llm.service).toBe("openrouter");
+    expect(result.llm.model).toBe("z-ai/glm-4.7");
+    expect(result.diagnostics.modelSource).toBe("env");
+  });
+
+  it("openrouter 完全没配模型时才回退到 checkModel", async () => {
+    await writeProject({
+      configSource: "studio",
+      service: "openrouter",
+      services: [{ service: "openrouter" }],
+    });
+    await writeSecrets({ openrouter: { apiKey: "sk-or" } });
+
+    const result = await resolveEffectiveLLMConfig({
+      consumer: "studio",
+      projectRoot: root,
+      envLayers: { global: {}, project: {}, process: {} },
+      requireApiKey: true,
+    });
+
+    expect(result.llm.service).toBe("openrouter");
+    expect(result.llm.model).toBe("openrouter/auto");
+  });
+
   it("CLI env 指向 Ollama 时允许用户本地安装的动态模型", async () => {
     await writeProject({
       configSource: "studio",

--- a/packages/core/src/__tests__/notify-format.test.ts
+++ b/packages/core/src/__tests__/notify-format.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { dispatchNotification } from "../notify/dispatcher.js";
+import { stripMarkdownMarks } from "../notify/format.js";
+import { NotifyChannelSchema } from "../models/project.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue({ ok: true });
+});
+
+function lastRequestBody(): Record<string, unknown> {
+  const [, opts] = mockFetch.mock.calls[0]!;
+  return JSON.parse(opts.body);
+}
+
+const message = {
+  title: "示例书 第4章",
+  body: "**第四章** | 3000字\n- [major] 时间线冲突",
+};
+
+describe("NotifyChannelSchema format field", () => {
+  it("defaults format to markdown for backward compatibility", () => {
+    const telegram = NotifyChannelSchema.parse({
+      type: "telegram",
+      botToken: "123:ABC",
+      chatId: "-100123",
+    });
+    expect(telegram.format).toBe("markdown");
+
+    const webhook = NotifyChannelSchema.parse({
+      type: "webhook",
+      url: "https://example.com/hook",
+    });
+    expect(webhook.format).toBe("markdown");
+  });
+
+  it("accepts text format on every channel type", () => {
+    const feishu = NotifyChannelSchema.parse({
+      type: "feishu",
+      webhookUrl: "https://open.feishu.cn/webhook/xxx",
+      format: "text",
+    });
+    expect(feishu.format).toBe("text");
+
+    const wechatWork = NotifyChannelSchema.parse({
+      type: "wechat-work",
+      webhookUrl: "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx",
+      format: "text",
+    });
+    expect(wechatWork.format).toBe("text");
+  });
+
+  it("rejects unknown format values", () => {
+    expect(() =>
+      NotifyChannelSchema.parse({
+        type: "telegram",
+        botToken: "123:ABC",
+        chatId: "-100123",
+        format: "html",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("stripMarkdownMarks", () => {
+  it("strips bold, inline code and code fences", () => {
+    expect(stripMarkdownMarks("**bold** and `code`")).toBe("bold and code");
+    expect(stripMarkdownMarks("```ts\nconst a = 1;\n```")).toBe("const a = 1;\n");
+  });
+});
+
+describe("dispatchNotification telegram formats", () => {
+  it("markdown format keeps parse_mode and bold title", async () => {
+    await dispatchNotification(
+      [{ type: "telegram", botToken: "123:ABC", chatId: "-100", format: "markdown" }],
+      message,
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const body = lastRequestBody();
+    expect(body.parse_mode).toBe("Markdown");
+    expect(body.text).toBe("**示例书 第4章**\n\n**第四章** | 3000字\n- [major] 时间线冲突");
+  });
+
+  it("text format omits parse_mode and strips markdown marks", async () => {
+    await dispatchNotification(
+      [{ type: "telegram", botToken: "123:ABC", chatId: "-100", format: "text" }],
+      message,
+    );
+
+    const body = lastRequestBody();
+    expect(body).not.toHaveProperty("parse_mode");
+    expect(body.text).toBe("示例书 第4章\n\n第四章 | 3000字\n- [major] 时间线冲突");
+  });
+});
+
+describe("dispatchNotification wechat-work formats", () => {
+  it("markdown format keeps msgtype markdown", async () => {
+    await dispatchNotification(
+      [{ type: "wechat-work", webhookUrl: "https://qyapi.weixin.qq.com/hook", format: "markdown" }],
+      message,
+    );
+
+    const body = lastRequestBody();
+    expect(body.msgtype).toBe("markdown");
+    expect(body.markdown).toEqual({
+      content: "**示例书 第4章**\n\n**第四章** | 3000字\n- [major] 时间线冲突",
+    });
+  });
+
+  it("text format sends msgtype text with plain content", async () => {
+    await dispatchNotification(
+      [{ type: "wechat-work", webhookUrl: "https://qyapi.weixin.qq.com/hook", format: "text" }],
+      message,
+    );
+
+    const body = lastRequestBody();
+    expect(body.msgtype).toBe("text");
+    expect(body.text).toEqual({
+      content: "示例书 第4章\n\n第四章 | 3000字\n- [major] 时间线冲突",
+    });
+    expect(body).not.toHaveProperty("markdown");
+  });
+});
+
+describe("dispatchNotification feishu formats", () => {
+  it("markdown format keeps the interactive card", async () => {
+    await dispatchNotification(
+      [{ type: "feishu", webhookUrl: "https://open.feishu.cn/hook", format: "markdown" }],
+      message,
+    );
+
+    const body = lastRequestBody();
+    expect(body.msg_type).toBe("interactive");
+    const card = body.card as {
+      header: { title: { content: string } };
+      elements: Array<{ tag: string; content: string }>;
+    };
+    expect(card.header.title.content).toBe("示例书 第4章");
+    expect(card.elements[0]).toEqual({ tag: "markdown", content: message.body });
+  });
+
+  it("text format sends msg_type text with title and plain body combined", async () => {
+    await dispatchNotification(
+      [{ type: "feishu", webhookUrl: "https://open.feishu.cn/hook", format: "text" }],
+      message,
+    );
+
+    const body = lastRequestBody();
+    expect(body.msg_type).toBe("text");
+    expect(body.content).toEqual({
+      text: "示例书 第4章\n\n第四章 | 3000字\n- [major] 时间线冲突",
+    });
+    expect(body).not.toHaveProperty("card");
+  });
+});
+
+describe("dispatchNotification webhook format", () => {
+  it("includes the channel format in the JSON payload data", async () => {
+    await dispatchNotification(
+      [{ type: "webhook", url: "https://example.com/hook", events: [], format: "text" }],
+      message,
+    );
+
+    const body = lastRequestBody();
+    expect(body.event).toBe("pipeline-complete");
+    expect(body.data).toEqual({
+      title: message.title,
+      body: message.body,
+      format: "text",
+    });
+  });
+});

--- a/packages/core/src/__tests__/pipeline-runner.test.ts
+++ b/packages/core/src/__tests__/pipeline-runner.test.ts
@@ -4955,6 +4955,136 @@ describe("PipelineRunner", () => {
     }
   }, SLOW_PIPELINE_TEST_TIMEOUT_MS);
 
+  async function createRevisionGateFixture(revisionGate?: "strict" | "lenient" | "always") {
+    const fixture = await createRunnerFixture(revisionGate ? { revisionGate } : {});
+    const storyDir = join(fixture.state.bookDir(fixture.bookId), "story");
+    const chaptersDir = join(fixture.state.bookDir(fixture.bookId), "chapters");
+    // Single paragraph, varied sentence openings, no hedge/transition words →
+    // zero structural AI tells, so audit counts come only from the LLM audit mocks.
+    const originalBody = "林越推门进去，先看见柜台后那盏没关的灯，他放轻脚步绕过货架。";
+    const revisedBody = "门被风顶开，林越先停在门槛前，听见柜台后那盏灯轻轻晃动。";
+
+    await Promise.all([
+      writeFile(join(chaptersDir, "0001_Test_Chapter.md"), `# 第1章 Test Chapter\n\n${originalBody}`, "utf-8"),
+      writeFile(join(storyDir, "current_state.md"), createStateCard({
+        chapter: 1,
+        location: "Ashen ferry crossing",
+        protagonistState: "Lin Yue still hides the oath token.",
+        goal: "Find the vanished mentor.",
+        conflict: "The mentor debt is still personal.",
+      }), "utf-8"),
+      writeFile(join(storyDir, "pending_hooks.md"), "# Pending Hooks\n", "utf-8"),
+    ]);
+    await fixture.state.saveChapterIndex(fixture.bookId, [{
+      number: 1,
+      title: "Test Chapter",
+      status: "audit-failed",
+      wordCount: originalBody.length,
+      createdAt: "2026-03-19T00:00:00.000Z",
+      updatedAt: "2026-03-19T00:00:00.000Z",
+      auditIssues: [],
+      lengthWarnings: [],
+    }]);
+
+    vi.spyOn(ReviserAgent.prototype, "reviseChapter").mockResolvedValue(
+      createReviseOutput({
+        revisedContent: revisedBody,
+        wordCount: revisedBody.length,
+        fixedIssues: ["- 调整了开场镜头。"],
+        updatedState: createStateCard({
+          chapter: 1,
+          location: "Ashen ferry crossing",
+          protagonistState: "Lin Yue still hides the oath token.",
+          goal: "Find the vanished mentor.",
+          conflict: "The mentor debt sharpens into a direct threat.",
+        }),
+        updatedHooks: "# Pending Hooks\n",
+      }),
+    );
+
+    return { ...fixture, chaptersDir, revisedBody };
+  }
+
+  const GATE_WARNING_ISSUE: AuditIssue = {
+    severity: "warning",
+    category: "节奏",
+    description: "结尾解释略多。",
+    suggestion: "压缩一行解释。",
+  };
+
+  it("applies a no-improvement manual revision when revisionGate is lenient", async () => {
+    const { root, runner, bookId, chaptersDir, revisedBody } = await createRevisionGateFixture("lenient");
+
+    // Same warning before and after: strict would reject (no improvement),
+    // lenient applies because nothing worsened.
+    vi.spyOn(ContinuityAuditor.prototype, "auditChapter")
+      .mockResolvedValueOnce(createAuditResult({ passed: false, issues: [GATE_WARNING_ISSUE], summary: "needs revision" }))
+      .mockResolvedValueOnce(createAuditResult({ passed: false, issues: [GATE_WARNING_ISSUE], summary: "still weak" }));
+
+    try {
+      const result = await runner.reviseDraft(bookId, 1);
+      const savedChapter = await readFile(join(chaptersDir, "0001_Test_Chapter.md"), "utf-8");
+
+      expect(result.applied).toBe(true);
+      expect(result.skippedReason).toBeUndefined();
+      expect(savedChapter).toContain(revisedBody);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, SLOW_PIPELINE_TEST_TIMEOUT_MS);
+
+  it("rejects a worsening manual revision under the lenient gate and reports the lenient standard", async () => {
+    const { root, runner, bookId, chaptersDir, revisedBody } = await createRevisionGateFixture("lenient");
+
+    vi.spyOn(ContinuityAuditor.prototype, "auditChapter")
+      .mockResolvedValueOnce(createAuditResult({ passed: false, issues: [GATE_WARNING_ISSUE], summary: "needs revision" }))
+      .mockResolvedValueOnce(createAuditResult({
+        passed: false,
+        issues: [GATE_WARNING_ISSUE, CRITICAL_ISSUE],
+        summary: "worse",
+      }));
+
+    try {
+      const result = await runner.reviseDraft(bookId, 1);
+      const savedChapter = await readFile(join(chaptersDir, "0001_Test_Chapter.md"), "utf-8");
+
+      expect(result.applied).toBe(false);
+      expect(result.skippedReason).toContain("Manual revision kept original chapter");
+      expect(result.revisionDiagnostics?.standard).toContain("lenient gate");
+      expect(result.revisionDiagnostics?.after.criticalCount).toBe(1);
+      expect(savedChapter).not.toContain(revisedBody);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, SLOW_PIPELINE_TEST_TIMEOUT_MS);
+
+  it("always applies manual revisions when revisionGate is always, even when the audit worsens", async () => {
+    const { root, runner, state, bookId, chaptersDir, revisedBody } = await createRevisionGateFixture("always");
+
+    vi.spyOn(ContinuityAuditor.prototype, "auditChapter")
+      .mockResolvedValueOnce(createAuditResult({ passed: false, issues: [GATE_WARNING_ISSUE], summary: "needs revision" }))
+      .mockResolvedValueOnce(createAuditResult({
+        passed: false,
+        issues: [GATE_WARNING_ISSUE, CRITICAL_ISSUE],
+        summary: "worse",
+      }));
+
+    try {
+      const result = await runner.reviseDraft(bookId, 1);
+      const savedChapter = await readFile(join(chaptersDir, "0001_Test_Chapter.md"), "utf-8");
+      const savedIndex = await state.loadChapterIndex(bookId);
+
+      expect(result.applied).toBe(true);
+      expect(savedChapter).toContain(revisedBody);
+      // Audit metrics are still recorded — the failing audit lands in the index
+      // instead of blocking the user's explicit revision.
+      expect(savedIndex[0]?.status).toBe("audit-failed");
+      expect(savedIndex[0]?.auditIssues).toContain("[critical] Fix the chapter state");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, SLOW_PIPELINE_TEST_TIMEOUT_MS);
+
   it("re-audits revisions against updated state overrides instead of stale on-disk truth files", async () => {
     const { root, runner, state, bookId } = await createRunnerFixture();
     const storyDir = join(state.bookDir(bookId), "story");

--- a/packages/core/src/__tests__/provider-minimax-thinking.test.ts
+++ b/packages/core/src/__tests__/provider-minimax-thinking.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { chatCompletion, createLLMClient } from "../llm/provider.js";
 
-const { fetchCalls } = vi.hoisted(() => ({
+const { fetchCalls, responseQueue } = vi.hoisted(() => ({
   fetchCalls: [] as Array<{ url: string; init: RequestInit; body: Record<string, unknown> }>,
+  responseQueue: [] as Response[],
 }));
 
 vi.mock("../utils/proxy-fetch.js", () => ({
@@ -12,6 +13,8 @@ vi.mock("../utils/proxy-fetch.js", () => ({
       init,
       body: JSON.parse(String(init.body ?? "{}")),
     });
+    const queued = responseQueue.shift();
+    if (queued) return queued;
     return {
       ok: true,
       json: async () => ({
@@ -31,22 +34,44 @@ vi.mock("@mariozechner/pi-ai", () => ({
   }),
 }));
 
-function minimaxClient(model: string) {
+function minimaxClient(model: string, stream = false) {
   return createLLMClient({
     provider: "openai",
     service: "minimax",
     model,
     apiKey: "sk-test",
     apiFormat: "chat",
-    stream: false,
+    stream,
     temperature: 0.9,
     thinkingBudget: 0,
     extra: {},
   } as never);
 }
 
+function jsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    json: async () => payload,
+  } as Response;
+}
+
+function sseResponse(events: string[]): Response {
+  const chunks = events.map((event) => `data: ${event}\n\n`);
+  let index = 0;
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: async () => index < chunks.length
+          ? { value: new TextEncoder().encode(chunks[index++]), done: false }
+          : { value: undefined, done: true },
+      }),
+    },
+  } as unknown as Response;
+}
+
 describe("MiniMax thinking defaults", () => {
-  it("disables MiniMax-M3 thinking by default on the OpenAI-compatible endpoint", async () => {
+  it("disables MiniMax-M3 thinking and requests reasoning_split by default", async () => {
     fetchCalls.length = 0;
     const client = minimaxClient("MiniMax-M3");
 
@@ -60,10 +85,11 @@ describe("MiniMax thinking defaults", () => {
     expect(fetchCalls[0]!.body).toMatchObject({
       model: "MiniMax-M3",
       thinking: { type: "disabled" },
+      reasoning_split: true,
     });
   });
 
-  it("does not send unsupported thinking controls to MiniMax-M2.x models", async () => {
+  it("sends reasoning_split but no thinking control to MiniMax-M2.x models", async () => {
     fetchCalls.length = 0;
     const client = minimaxClient("MiniMax-M2.7");
 
@@ -73,5 +99,93 @@ describe("MiniMax thinking defaults", () => {
 
     expect(fetchCalls).toHaveLength(1);
     expect(fetchCalls[0]!.body).not.toHaveProperty("thinking");
+    expect(fetchCalls[0]!.body).toMatchObject({ reasoning_split: true });
+  });
+});
+
+describe("MiniMax thinking leak prevention (issue #329)", () => {
+  it("does not merge reasoning_content into the returned content (non-stream)", async () => {
+    fetchCalls.length = 0;
+    responseQueue.push(jsonResponse({
+      choices: [{
+        message: {
+          content: "第一章正文开始。",
+          reasoning_content: "让我先推演一下剧情走向……",
+        },
+      }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }));
+    const client = minimaxClient("MiniMax-M2.7");
+
+    const result = await chatCompletion(client, "MiniMax-M2.7", [
+      { role: "user", content: "写第一章" },
+    ], { retry: false });
+
+    expect(result.content).toBe("第一章正文开始。");
+    expect(result.content).not.toContain("推演");
+  });
+
+  it("strips a leading inline <think> block from non-stream content", async () => {
+    fetchCalls.length = 0;
+    responseQueue.push(jsonResponse({
+      choices: [{
+        message: {
+          content: "<think>这里是模型的内心推理，不该出现在章节里</think>\n\n第一章正文开始。",
+        },
+      }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }));
+    const client = minimaxClient("MiniMax-M2.7");
+
+    const result = await chatCompletion(client, "MiniMax-M2.7", [
+      { role: "user", content: "写第一章" },
+    ], { retry: false });
+
+    expect(result.content).toBe("第一章正文开始。");
+    expect(result.content).not.toContain("内心推理");
+  });
+
+  it("keeps reasoning_content and reasoning_details deltas out of streamed content", async () => {
+    fetchCalls.length = 0;
+    responseQueue.push(sseResponse([
+      JSON.stringify({ choices: [{ delta: { reasoning_content: "思考片段A" } }] }),
+      JSON.stringify({ choices: [{ delta: { reasoning_details: [{ text: "思考片段B" }] } }] }),
+      JSON.stringify({ choices: [{ delta: { content: "第一章" } }] }),
+      JSON.stringify({ choices: [{ delta: { content: "正文。" } }] }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 } }),
+      "[DONE]",
+    ]));
+    const client = minimaxClient("MiniMax-M2.7", true);
+    const deltas: string[] = [];
+
+    const result = await chatCompletion(client, "MiniMax-M2.7", [
+      { role: "user", content: "写第一章" },
+    ], { retry: false, onTextDelta: (text) => deltas.push(text) });
+
+    expect(result.content).toBe("第一章正文。");
+    expect(result.content).not.toContain("思考片段");
+    expect(deltas.join("")).toBe("第一章正文。");
+  });
+
+  it("strips a leading inline <think> block split across stream chunks", async () => {
+    fetchCalls.length = 0;
+    responseQueue.push(sseResponse([
+      JSON.stringify({ choices: [{ delta: { content: "<th" } }] }),
+      JSON.stringify({ choices: [{ delta: { content: "ink>模型内心推理" } }] }),
+      JSON.stringify({ choices: [{ delta: { content: "</think>\n第一" } }] }),
+      JSON.stringify({ choices: [{ delta: { content: "章正文。" } }] }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] }),
+      "[DONE]",
+    ]));
+    const client = minimaxClient("MiniMax-M2.7", true);
+    const deltas: string[] = [];
+
+    const result = await chatCompletion(client, "MiniMax-M2.7", [
+      { role: "user", content: "写第一章" },
+    ], { retry: false, onTextDelta: (text) => deltas.push(text) });
+
+    expect(result.content).toBe("第一章正文。");
+    expect(deltas.join("")).toBe("第一章正文。");
+    expect(deltas.join("")).not.toContain("内心推理");
   });
 });

--- a/packages/core/src/__tests__/providers-lookup.test.ts
+++ b/packages/core/src/__tests__/providers-lookup.test.ts
@@ -56,7 +56,7 @@ describe("Layer 2 优先级（聚合入口精简后）", () => {
   });
 
   it("OpenRouter 专属带后缀 id（:free）命中 openrouter provider", () => {
-    const hit = lookupModel("custom", "google/gemma-2-9b-it:free");
+    const hit = lookupModel("custom", "meta-llama/llama-3.1-8b-instruct:free");
     expect(hit).toBeDefined();
     expect(hit?.maxOutput).toBe(4096);
   });

--- a/packages/core/src/__tests__/revision-gate.test.ts
+++ b/packages/core/src/__tests__/revision-gate.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveRevisionGate } from "../models/book.js";
+
+describe("resolveRevisionGate", () => {
+  it("book-level revisionGate overrides project-level revisionGate", () => {
+    expect(resolveRevisionGate(
+      { writing: { revisionGate: "always" } },
+      { revisionGate: "lenient" },
+    )).toBe("always");
+
+    expect(resolveRevisionGate(
+      { writing: { revisionGate: "strict" } },
+      { revisionGate: "always" },
+    )).toBe("strict");
+  });
+
+  it("falls back to project-level revisionGate when book does not set one", () => {
+    expect(resolveRevisionGate({}, { revisionGate: "lenient" })).toBe("lenient");
+    expect(resolveRevisionGate(
+      { writing: {} },
+      { revisionGate: "always" },
+    )).toBe("always");
+  });
+
+  it("defaults to strict when neither book nor project sets a revisionGate", () => {
+    expect(resolveRevisionGate({})).toBe("strict");
+    expect(resolveRevisionGate({ writing: {} }, {})).toBe("strict");
+  });
+});

--- a/packages/core/src/__tests__/think-tag-stripper.test.ts
+++ b/packages/core/src/__tests__/think-tag-stripper.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createLeadingThinkTagStripper, stripLeadingThinkBlock } from "../llm/think-tag-stripper.js";
+
+describe("stripLeadingThinkBlock", () => {
+  it("strips a complete leading <think> block and following whitespace", () => {
+    expect(stripLeadingThinkBlock("<think>推理</think>\n\n正文开始。")).toBe("正文开始。");
+  });
+
+  it("strips a leading block preceded by whitespace", () => {
+    expect(stripLeadingThinkBlock("\n  <think>推理</think>正文")).toBe("正文");
+  });
+
+  it("leaves mid-text <think> occurrences untouched", () => {
+    const text = "正文里介绍 <think> 标签的用法。";
+    expect(stripLeadingThinkBlock(text)).toBe(text);
+  });
+
+  it("leaves an unterminated leading block untouched (no data loss)", () => {
+    const text = "<think>推理到一半被截断";
+    expect(stripLeadingThinkBlock(text)).toBe(text);
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripLeadingThinkBlock("普通正文。")).toBe("普通正文。");
+  });
+});
+
+describe("createLeadingThinkTagStripper", () => {
+  function pushAll(chunks: string[]): { emitted: string[]; flushed: string } {
+    const stripper = createLeadingThinkTagStripper();
+    const emitted = chunks.map((chunk) => stripper.push(chunk)).filter((piece) => piece.length > 0);
+    return { emitted, flushed: stripper.flush() };
+  }
+
+  it("suppresses a leading block split across chunk boundaries", () => {
+    const { emitted, flushed } = pushAll(["<th", "ink>推理A", "推理B</th", "ink>\n正文", "继续"]);
+    expect(emitted.join("")).toBe("正文继续");
+    expect(flushed).toBe("");
+  });
+
+  it("emits buffered text once the prefix diverges from <think>", () => {
+    const { emitted, flushed } = pushAll(["<th", "ree>不是 think 标签", "，正文"]);
+    expect(emitted.join("")).toBe("<three>不是 think 标签，正文");
+    expect(flushed).toBe("");
+  });
+
+  it("passes plain text through immediately", () => {
+    const stripper = createLeadingThinkTagStripper();
+    expect(stripper.push("正文第一段")).toBe("正文第一段");
+    expect(stripper.push("<think>正文中间的字样不受影响")).toBe("<think>正文中间的字样不受影响");
+    expect(stripper.flush()).toBe("");
+  });
+
+  it("returns an unterminated leading block via flush", () => {
+    const { emitted, flushed } = pushAll(["<think>推理没有闭合"]);
+    expect(emitted).toEqual([]);
+    expect(flushed).toBe("<think>推理没有闭合");
+  });
+});

--- a/packages/core/src/agent/agent-session.ts
+++ b/packages/core/src/agent/agent-session.ts
@@ -39,6 +39,7 @@ import {
   createResearchWebTool,
   createIngestMaterialTool,
   createRetrieveMaterialTool,
+  createImportChaptersTool,
 } from "./agent-tools.js";
 import { createFilmAuthoringTools, filmLLMDepsFromClient } from "./film-authoring-tools.js";
 import { createBookContextTransform } from "./context-transform.js";
@@ -757,6 +758,7 @@ function createAgentToolsForMode(params: {
   const researchTool = createResearchWebTool(params.projectRoot);
   const materialTool = createIngestMaterialTool(params.projectRoot);
   const materialRetrievalTool = createRetrieveMaterialTool(params.projectRoot);
+  const importChaptersTool = createImportChaptersTool(params.pipeline, params.bookId, params.projectRoot);
   const isConfirmed = (
     intent: NonNullable<AgentSessionConfig["requestedIntent"]>,
   ): boolean => {
@@ -765,7 +767,7 @@ function createAgentToolsForMode(params: {
   };
 
   if (params.sessionKind === "chat") {
-    return [proposalTool, researchTool, materialTool, materialRetrievalTool];
+    return [proposalTool, researchTool, materialTool, materialRetrievalTool, importChaptersTool];
   }
 
   if (params.sessionKind === "short") {
@@ -857,12 +859,13 @@ function createAgentToolsForMode(params: {
     researchTool,
     materialTool,
     materialRetrievalTool,
+    importChaptersTool,
     createGrepTool(params.projectRoot),
     createLsTool(params.projectRoot),
   ];
 
   if (params.sessionKind === "edit") {
-    return bookTools.filter((tool) => !["sub_agent", "generate_cover", "research_web"].includes(tool.name));
+    return bookTools.filter((tool) => !["sub_agent", "generate_cover", "research_web", "import_chapters"].includes(tool.name));
   }
 
   return bookTools;

--- a/packages/core/src/agent/agent-system-prompt.ts
+++ b/packages/core/src/agent/agent-system-prompt.ts
@@ -37,28 +37,30 @@ function buildChatPrompt(isZh: boolean): string {
 
 这里不是自动生产入口。用户讨论、提问、比较方案时，直接回答。
 
-可用工具：propose_action、research_web、ingest_material、retrieve_material。用户明确要创建长篇、生成短篇、启动互动世界、生成封面、创建剧本、创建分镜，或打开同人/续写/番外/仿写辅助入口时调用 propose_action。用户明确要求联网研究、事实核查、年代/职业/世界观资料时调用 research_web。用户给出 URL、上传 PDF/Markdown/文本资料，或要求“把这个资料纳入参考库/先读这份资料”时调用 ingest_material。用户要求基于已归档资料回答、整理、对照或继续创作时，先用 retrieve_material 按当前任务召回相关片段；资料卡只是参考材料，不会自动改设定或正文。
+可用工具：propose_action、research_web、ingest_material、retrieve_material、import_chapters。用户明确要创建长篇、生成短篇、启动互动世界、生成封面、创建剧本、创建分镜，或打开同人/续写/番外/仿写辅助入口时调用 propose_action。用户明确要求联网研究、事实核查、年代/职业/世界观资料时调用 research_web。用户给出 URL、上传 PDF/Markdown/文本资料，或要求“把这个资料纳入参考库/先读这份资料”时调用 ingest_material。用户要求基于已归档资料回答、整理、对照或继续创作时，先用 retrieve_material 按当前任务召回相关片段；资料卡只是参考材料，不会自动改设定或正文。
+用户要把已有小说的章节文件或整本文稿导入成某本书的正式章节（InkOS 会逆向生成设定文件）时调用 import_chapters；只是想把资料存成参考材料时用 ingest_material，两者不要混用。import_chapters 需要明确的目标 bookId（必须是已存在的书；没有书就先走建书流程）和本地文件/目录路径，路径可以直接用“用户上传文件”区块里的 stored_path，也可以是用户说明的本机绝对路径。
 
 生产型动作：create_book、short_run、play_start、generate_cover、script_create、storyboard_create、interactive_film_create。确认后会切换到对应 session 执行。
 辅助入口动作：fanfic_init、continuation_import、spinoff_create、style_imitation。确认后只打开现有 Studio 工具，不能声称已经生成成品。
 辅助入口是“打开工具并准备材料”，不是立即生成成品。用户明确提到“同人 / 续写 / 番外 / 仿写 / 文风分析 / 参考文风 / 模仿笔法 / 先分析再仿写”时，必须调用 propose_action，不要用普通文字追问书名、原文、父书路径或解释流程。材料缺失时从用户方向临时概括一个短标题，instruction 里写清“待用户在入口补充材料”。映射：同人=fanfic_init，续写=continuation_import，番外/正典资料/不进入主线=spinoff_create，仿写/文风分析/参考文风/模仿笔法=style_imitation。确认卡标题/摘要必须说“打开入口 / 准备材料”，不要说“直接生成成品”。
 
 调用 propose_action 时，instruction 必须自包含：写清目标入口、标题/书名/路径、故事或视觉方向、用户提到的关键上下文；不要让下一条 session 依赖上一轮聊天上下文猜。能确定的执行参数必须同时填进结构化字段：createBook / shortRun / playStart / generateCover / scriptCreate / storyboardCreate / interactiveFilmCreate，不要只写在 instruction 文本里。互动世界如果用户说“开放世界/自由玩/自己行动”，playStart.mode 填 open；如果用户说“分支互动/点着玩/给选项”，playStart.mode 填 guided。互动影游/互动剧/影游交付/盛世天下式多结局剧本，使用 interactive_film_create，不要路由到 play_start。
-信息不足时只问一个关键问题。不要在 chat 里创建、写入、编辑或生成故事/图片产物；research_web、ingest_material 和 retrieve_material 只处理参考材料除外。
+信息不足时只问一个关键问题。不要在 chat 里创建、写入、编辑或生成故事/图片产物；research_web、ingest_material 和 retrieve_material 只处理参考材料除外，import_chapters 是唯一会写入书籍章节的例外，只在用户明确要求导入已有章节时调用。
 
 ${commonOutputRules(true)}`
     : `You are the InkOS general chat assistant.
 
 This is not an automatic production surface. Answer questions, discussion, comparisons, and issue reports directly.
 
-Available tools: propose_action, research_web, ingest_material, and retrieve_material. Use propose_action when the user clearly wants to create a book, run short fiction, start a play world, generate a cover, create a script, create a storyboard, or open assisted fanfiction / continuation / side-story / style-imitation workflows. Use research_web when the user explicitly asks for web research, fact checking, era/profession/worldbuilding references, or market research. Use ingest_material when the user provides a URL, uploaded PDF/Markdown/text file, or asks to archive/read provided materials. Use retrieve_material before answering, comparing, or continuing from archived materials. Research reports and material cards are reference material only and do not automatically change canon or prose.
+Available tools: propose_action, research_web, ingest_material, retrieve_material, and import_chapters. Use propose_action when the user clearly wants to create a book, run short fiction, start a play world, generate a cover, create a script, create a storyboard, or open assisted fanfiction / continuation / side-story / style-imitation workflows. Use research_web when the user explicitly asks for web research, fact checking, era/profession/worldbuilding references, or market research. Use ingest_material when the user provides a URL, uploaded PDF/Markdown/text file, or asks to archive/read provided materials. Use retrieve_material before answering, comparing, or continuing from archived materials. Research reports and material cards are reference material only and do not automatically change canon or prose.
+Use import_chapters when the user wants existing novel chapters or a full manuscript imported into a book as real chapters (InkOS reverse-engineers the truth files from the text); use ingest_material when they only want reference material archived — do not confuse the two. import_chapters requires an explicit target bookId (an existing book; if none exists, create the book first) and a local file/directory path: the stored_path from the Uploaded Files block works, and so does an absolute path the user names on this machine.
 
 Production actions: create_book, short_run, play_start, generate_cover, script_create, storyboard_create, interactive_film_create. After confirmation, InkOS switches to the matching session and runs them.
 Assisted workflow actions: fanfic_init, continuation_import, spinoff_create, style_imitation. After confirmation, InkOS only opens the existing Studio tool; do not claim finished content was generated.
 Assisted workflows open a tool and prepare materials; they do not immediately generate finished content. When the user explicitly asks for fanfiction, continuation, side-story/spinoff, style imitation, style analysis, reference-style analysis, prose mimicry, or "analyze first then imitate", you must call propose_action. Do not answer by asking for a title/source text/parent-book path or by explaining the workflow in plain text. If materials are missing, infer a short temporary title from the user's direction, and say in the instruction that the user will fill missing materials in the opened tool. Mapping: fanfiction=fanfic_init, continuation=continuation_import, side-story/spinoff/canon-materials=spinoff_create, style imitation/style analysis/reference-style/prose mimicry=style_imitation. The confirmation card title/summary must say "open workflow / prepare materials"; do not say finished content will be generated.
 
 When calling propose_action, instruction must be self-contained: include target surface, title/book/path, story or visual direction, and concrete context behind references like "that book" or "this cover". Do not make the next session infer missing context from this chat. Put known execution arguments into the structured createBook / shortRun / playStart / generateCover / scriptCreate / storyboardCreate / interactiveFilmCreate fields as well; do not leave them only in instruction text. For interactive worlds, set playStart.mode=open when the user asks for open/free-form play, and playStart.mode=guided when the user asks for branching/choice-led play. For interactive film/drama/game-script deliverables with branch logic, flags, endings, scripts, and storyboards, use interactive_film_create instead of play_start.
-If information is missing, ask one key question. Do not create, write, edit, or generate story/image artifacts in chat; research_web, ingest_material, and retrieve_material are reference-material-only exceptions.
+If information is missing, ask one key question. Do not create, write, edit, or generate story/image artifacts in chat; research_web, ingest_material, and retrieve_material are reference-material-only exceptions, and import_chapters is the only exception that writes book chapters — call it only when the user explicitly asks to import existing chapters.
 
 ${commonOutputRules(false)}`;
 }
@@ -485,6 +487,7 @@ function buildBookPrompt(bookId: string, isZh: boolean): string {
 - research_web：用户明确要求联网研究、事实核查、年代/职业/地域/制度资料时使用；报告保存为参考材料，不会自动改当前书设定或正文。
 - ingest_material：用户给 URL、上传 PDF/Markdown/文本资料，或要求“先读/归档这份资料”时使用；资料卡保存在 .inkos/materials，不会自动改当前书设定或正文。
 - retrieve_material：基于当前任务从 .inkos/materials 召回相关片段；返回带路径和字符范围的证据指针。它只读取参考资料，不改设定或正文。
+- import_chapters：把用户提供的已有小说章节（本地文件或目录，路径可用“用户上传文件”区块里的 stored_path，也可以是用户给出的绝对路径）导入当前书成为正式章节，并逆向生成设定文件。目录模式按文件名排序、每个 .md/.txt 文件一章；单文件模式默认按“第X章/Chapter N”标题自动分章，可用 splitPattern 自定义正则。当前书已有章节时必须传 resumeFrom 续导，否则会报错。它和 ingest_material 的区别：ingest_material 只存参考资料，import_chapters 会写入章节和设定。
 - grep：搜索内容。
 - ls：列出文件或章节。
 
@@ -507,6 +510,7 @@ function buildBookPrompt(bookId: string, isZh: boolean): string {
 - 用户粘贴/提供某章完整新正文并要求替换 → replace_chapter_text。
 - 用户要求生成或重做封面 → generate_cover。
 - 用户要求查外部事实、年代职业细节、真实地域制度资料 → research_web；用户提供 URL/PDF/文本资料 → ingest_material；用户要求基于已归档资料回答、对照、续写或整理 → retrieve_material；如需把研究结果或资料内容写入设定，必须再由用户明确确认后用 write_truth_file。
+- 用户要求把已有小说/章节/整本文稿导入当前书（成为正式章节并生成设定）→ import_chapters；只是提供参考资料、不要求进正文 → ingest_material。
 - 其他普通讨论 → 直接回答。
 
 ## 章节索引
@@ -543,6 +547,7 @@ ${commonOutputRules(true)}`
 - research_web: collect web research or fact checks for era/profession/region/institution details. Reports are saved as reference material and do not automatically change canon or prose.
 - ingest_material: archive a user-provided URL, uploaded PDF, Markdown, or text file into .inkos/materials. Material cards are references only and do not automatically change canon or prose.
 - retrieve_material: retrieve task-relevant snippets from .inkos/materials with path and character-range evidence pointers. It reads reference materials only and does not change canon or prose.
+- import_chapters: import the user's existing novel chapters (a local file or directory; the path can be the stored_path from the Uploaded Files block or an absolute path the user names) into the active book as real chapters, reverse-engineering the truth files. Directory mode imports each .md/.txt file as one chapter in filename order; single-file mode auto-splits on "第X章"/"Chapter N" headings, with splitPattern for a custom regex. When the book already has chapters, resumeFrom is required, otherwise it errors. Difference from ingest_material: ingest_material archives reference material only, import_chapters writes chapters and settings.
 - grep: search content.
 - ls: list files or chapters.
 
@@ -565,6 +570,7 @@ ${commonOutputRules(true)}`
 - User-provided full replacement for an existing chapter → replace_chapter_text.
 - Cover generation/regeneration → generate_cover.
 - External facts, era/profession details, or real-world regional/institutional references → research_web. User-provided URLs/PDF/text files → ingest_material. Archived-material questions, comparisons, continuations, or summaries → retrieve_material. If research or material content should affect canon, wait for explicit confirmation and then use write_truth_file.
+- The user wants existing novel chapters or a full manuscript imported into the active book (as real chapters with reverse-engineered settings) → import_chapters. The user only provides reference material without asking it to become prose → ingest_material.
 - Ordinary discussion → answer directly.
 
 ## Chapter Index

--- a/packages/core/src/agent/agent-tools.ts
+++ b/packages/core/src/agent/agent-tools.ts
@@ -18,6 +18,7 @@ import { runInteractiveFilmCreation, runScriptCreation, runStoryboardCreation } 
 import { runResearchReport } from "../agents/researcher.js";
 import { ingestMaterial } from "../materials/ingest.js";
 import { retrieveMaterials } from "../materials/retrieve.js";
+import { loadChaptersFromPath } from "./chapter-import-source.js";
 import type { ScriptTargetFormat } from "../agents/script-storyboard.js";
 import { createPlayDB, type PlayGraphDB } from "../play/play-db-factory.js";
 import { PlayRunner, type PlayOpeningSeedResult, type PlayReplayResult, type PlayStepResult, type PlayVariantRestoreResult } from "../play/play-runner.js";
@@ -1057,6 +1058,100 @@ export function createRetrieveMaterialTool(projectRoot: string): AgentTool<typeo
           query: params.query,
           purpose: params.purpose,
           results,
+        },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 5. Chapter Import Tool (import_chapters)
+// ---------------------------------------------------------------------------
+
+const ImportChaptersParams = Type.Object({
+  bookId: Type.Optional(Type.String({
+    description: "Target book ID to import into. In active-book sessions, omit it to use the current active book; if provided, it must match the active book. In general chat there is no active book, so it is required and must be an existing book.",
+  })),
+  sourcePath: Type.String({
+    description: "Local path of the chapter source: either the stored_path from the Uploaded Files block (project-relative, e.g. .inkos/uploads/<session>/novel.txt) or an absolute path on this machine that the user provided. A directory imports each .md/.txt file as one chapter in filename order; a single file is split into chapters automatically by heading lines.",
+  }),
+  splitPattern: Type.Optional(Type.String({
+    description: "Single-file mode only: custom JavaScript regex source matching chapter heading lines. Omit to use the default pattern, which matches \"第X章/第X回\" and \"Chapter N\" headings.",
+  })),
+  resumeFrom: Type.Optional(Type.Number({
+    description: "Resume an interrupted import from chapter N (1-based). Required when the book already has chapters: replay starts at chapter N and earlier chapters are kept. Omit for a fresh import into an empty book.",
+  })),
+  importMode: Type.Optional(Type.Union([
+    Type.Literal("continuation"),
+    Type.Literal("series"),
+  ], {
+    description: "continuation (default): the book picks up exactly where the imported text left off, no new spacetime. series: shared universe but an independent new story, so a new spacetime is generated.",
+  })),
+});
+
+type ImportChaptersParamsType = Static<typeof ImportChaptersParams>;
+
+export function createImportChaptersTool(
+  pipeline: PipelineRunner,
+  activeBookId: string | null,
+  projectRoot: string,
+): AgentTool<typeof ImportChaptersParams> {
+  return {
+    name: "import_chapters",
+    description:
+      "Import an existing novel's chapters from a local file or directory into an InkOS book as real chapters (not reference material). " +
+      "InkOS reverse-engineers foundation/truth files from the imported text and replays every chapter to rebuild story state, so the book can be continued afterwards. " +
+      "Use ingest_material instead when the user only wants to archive reference material without touching book chapters.",
+    label: "Import Chapters",
+    parameters: ImportChaptersParams,
+    async execute(
+      _toolCallId: string,
+      params: ImportChaptersParamsType,
+      _signal?: AbortSignal,
+      onUpdate?: AgentToolUpdateCallback,
+    ): Promise<AgentToolResult<unknown>> {
+      const targetBookId = resolveToolBookId("import_chapters", params.bookId, activeBookId);
+
+      const state = new StateManager(projectRoot);
+      const existingChapterCount = (await state.getNextChapterNumber(targetBookId)) - 1;
+      if (existingChapterCount > 0 && params.resumeFrom === undefined) {
+        throw new Error(
+          `Book "${targetBookId}" already has ${existingChapterCount} chapter(s). ` +
+          `Pass resumeFrom=<n> to resume/append from chapter n, or ask the user to clear the existing chapters first.`,
+        );
+      }
+
+      const resolvedSourcePath = isAbsolute(params.sourcePath)
+        ? params.sourcePath
+        : resolve(projectRoot, params.sourcePath);
+      onUpdate?.(textResult(`Reading chapters from ${resolvedSourcePath}...`));
+      const chapters = await loadChaptersFromPath(resolvedSourcePath, params.splitPattern);
+
+      onUpdate?.(textResult(`Found ${chapters.length} chapter(s); importing into "${targetBookId}"...`));
+      const result = await pipeline.importChapters({
+        bookId: targetBookId,
+        chapters,
+        resumeFrom: params.resumeFrom,
+        importMode: params.importMode,
+      });
+
+      const regeneratedFoundation = (params.resumeFrom ?? 1) === 1;
+      return textResult(
+        [
+          `Imported ${result.importedCount} chapter(s) into book "${result.bookId}".`,
+          `Total imported length: ${result.totalWords}. Next chapter to write: ${result.nextChapter}.`,
+          regeneratedFoundation
+            ? "Foundation and truth files were reverse-engineered from the imported text; chapter files and the chapter index were rebuilt by sequential replay."
+            : `Resumed replay from chapter ${params.resumeFrom}; earlier chapters and the existing foundation were kept.`,
+          `The book can now be continued with sub_agent(agent="writer") in the book session.`,
+        ].join("\n"),
+        {
+          kind: "chapters_imported",
+          bookId: result.bookId,
+          importedCount: result.importedCount,
+          totalWords: result.totalWords,
+          nextChapter: result.nextChapter,
+          importMode: params.importMode ?? "continuation",
         },
       );
     },

--- a/packages/core/src/agent/chapter-import-source.ts
+++ b/packages/core/src/agent/chapter-import-source.ts
@@ -1,0 +1,54 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { splitChapters, type SplitChapter } from "../utils/chapter-splitter.js";
+
+/**
+ * Load chapters from a local source path for `import_chapters`.
+ *
+ * - Directory mode: each `.md`/`.txt` file becomes one chapter, in filename
+ *   sort order. The chapter title is the filename without its extension and
+ *   without a leading numeric prefix (e.g. `03_风暴.md` → `风暴`).
+ * - Single-file mode: the file is split into chapters with `splitChapters`,
+ *   using `splitPattern` as a custom heading regex when provided.
+ *
+ * This mirrors the pure loading logic of `inkos import chapters` in the CLI
+ * so the agent tool does not depend on the CLI package.
+ */
+export async function loadChaptersFromPath(
+  sourcePath: string,
+  splitPattern?: string,
+): Promise<ReadonlyArray<SplitChapter>> {
+  const sourceStat = await stat(sourcePath);
+
+  if (sourceStat.isDirectory()) {
+    const entries = await readdir(sourcePath);
+    const textFiles = entries
+      .filter((f) => f.endsWith(".md") || f.endsWith(".txt"))
+      .sort();
+
+    if (textFiles.length === 0) {
+      throw new Error(`No .md or .txt files found in ${sourcePath}.`);
+    }
+
+    return Promise.all(
+      textFiles.map(async (f) => {
+        const content = await readFile(join(sourcePath, f), "utf-8");
+        const title = f.replace(/\.(md|txt)$/, "").replace(/^\d+[_\-\s]*/, "");
+        return { title, content };
+      }),
+    );
+  }
+
+  const text = await readFile(sourcePath, "utf-8");
+  const chapters = splitChapters(text, splitPattern);
+
+  if (chapters.length === 0) {
+    throw new Error(
+      `No chapters found in ${sourcePath}. ` +
+      `The default pattern matches "第X章/第X回" and "Chapter N" heading lines. ` +
+      `Pass splitPattern with a custom regex if the source uses a different heading style.`,
+    );
+  }
+
+  return chapters;
+}

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -13,6 +13,7 @@ export {
   createInteractiveFilmCreationTool,
   createResearchWebTool,
   createIngestMaterialTool,
+  createImportChaptersTool,
   createGenerateCoverTool,
   createPlayStartTool,
   createPlayReviseTool,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -510,6 +510,7 @@ export { validateRuntimeState, type RuntimeStateValidationIssue } from "./state/
 
 // Notify
 export { dispatchNotification, dispatchWebhookEvent, type NotifyMessage } from "./notify/dispatcher.js";
+export type { NotifyFormat } from "./notify/format.js";
 export type { TelegramConfig } from "./notify/telegram.js";
 export type { FeishuConfig } from "./notify/feishu.js";
 export type { WechatWorkConfig } from "./notify/wechat-work.js";
@@ -518,26 +519,29 @@ export type { WebhookConfig, WebhookEvent, WebhookPayload } from "./notify/webho
 export async function sendTelegram(
   config: import("./notify/telegram.js").TelegramConfig,
   message: string,
+  format?: import("./notify/format.js").NotifyFormat,
 ): Promise<void> {
   const transport = await import("./notify/telegram.js");
-  await transport.sendTelegram(config, message);
+  await transport.sendTelegram(config, message, format);
 }
 
 export async function sendFeishu(
   config: import("./notify/feishu.js").FeishuConfig,
   title: string,
   text: string,
+  format?: import("./notify/format.js").NotifyFormat,
 ): Promise<void> {
   const transport = await import("./notify/feishu.js");
-  await transport.sendFeishu(config, title, text);
+  await transport.sendFeishu(config, title, text, format);
 }
 
 export async function sendWechatWork(
   config: import("./notify/wechat-work.js").WechatWorkConfig,
   text: string,
+  format?: import("./notify/format.js").NotifyFormat,
 ): Promise<void> {
   const transport = await import("./notify/wechat-work.js");
-  await transport.sendWechatWork(config, text);
+  await transport.sendWechatWork(config, text, format);
 }
 
 export async function sendWebhook(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // Models
-export { type BookConfig, type Platform, type Genre, type BookStatus, type FanficMode, type ChapterReviewMode, BookConfigSchema, PlatformSchema, GenreSchema, BookStatusSchema, FanficModeSchema, normalizePlatformId, normalizePlatformOrOther, resolveChapterReviewMode } from "./models/book.js";
+export { type BookConfig, type Platform, type Genre, type BookStatus, type FanficMode, type ChapterReviewMode, type RevisionGate, BookConfigSchema, PlatformSchema, GenreSchema, BookStatusSchema, FanficModeSchema, normalizePlatformId, normalizePlatformOrOther, resolveChapterReviewMode, resolveRevisionGate } from "./models/book.js";
 export { type ChapterMeta, type ChapterStatus, ChapterMetaSchema, ChapterStatusSchema } from "./models/chapter.js";
 export { type ProjectConfig, type LLMConfig, type NotifyChannel, type DetectionConfig, type QualityGates, type FoundationConfig, type WritingConfig, type AgentLLMOverride, type InputGovernanceMode, type ResearchSearchConfig, ProjectConfigSchema, LLMConfigSchema, AgentLLMOverrideSchema, DetectionConfigSchema, QualityGatesSchema, FoundationConfigSchema, WritingConfigSchema, InputGovernanceModeSchema, ResearchSearchConfigSchema } from "./models/project.js";
 export { type CurrentState, type ParticleLedger, type PendingHooks, type PendingHook, type LedgerEntry } from "./models/state.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // Models
-export { type BookConfig, type Platform, type Genre, type BookStatus, type FanficMode, BookConfigSchema, PlatformSchema, GenreSchema, BookStatusSchema, FanficModeSchema, normalizePlatformId, normalizePlatformOrOther } from "./models/book.js";
+export { type BookConfig, type Platform, type Genre, type BookStatus, type FanficMode, type ChapterReviewMode, BookConfigSchema, PlatformSchema, GenreSchema, BookStatusSchema, FanficModeSchema, normalizePlatformId, normalizePlatformOrOther, resolveChapterReviewMode } from "./models/book.js";
 export { type ChapterMeta, type ChapterStatus, ChapterMetaSchema, ChapterStatusSchema } from "./models/chapter.js";
 export { type ProjectConfig, type LLMConfig, type NotifyChannel, type DetectionConfig, type QualityGates, type FoundationConfig, type WritingConfig, type AgentLLMOverride, type InputGovernanceMode, type ResearchSearchConfig, ProjectConfigSchema, LLMConfigSchema, AgentLLMOverrideSchema, DetectionConfigSchema, QualityGatesSchema, FoundationConfigSchema, WritingConfigSchema, InputGovernanceModeSchema, ResearchSearchConfigSchema } from "./models/project.js";
 export { type CurrentState, type ParticleLedger, type PendingHooks, type PendingHook, type LedgerEntry } from "./models/state.js";

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -15,6 +15,7 @@ import { lookupModel } from "./providers/lookup.js";
 import { fetchWithProxy } from "../utils/proxy-fetch.js";
 import { isApiKeyOptionalForEndpoint } from "../utils/llm-endpoint-auth.js";
 import { isLlmStubEnabled, stubChatCompletion } from "../agent/llm-stub.js";
+import { createLeadingThinkTagStripper, stripLeadingThinkBlock } from "./think-tag-stripper.js";
 
 
 // === Streaming Monitor Types ===
@@ -654,13 +655,16 @@ function buildCustomHeaders(client: LLMClient): Record<string, string> {
 }
 
 function defaultOpenAIChatExtra(client: LLMClient, model: string): Record<string, unknown> {
-  if (
-    client.service === "minimax"
-    && /^minimax-m3(?:$|[-_.])/i.test(model)
-  ) {
-    return { thinking: { type: "disabled" } };
-  }
-  return {};
+  if (client.service !== "minimax") return {};
+  // MiniMax OpenAI 兼容端点（issue #329）：
+  // - reasoning_split: true 让 thinking 拆分到 reasoning_content / reasoning_details，
+  //   不再以 <think>...</think> 内联在 content 里。M2.x 系列的 thinking 无法关闭，
+  //   不拆分的话思考内容会混进章节/对话正文。
+  // - M3 系列额外默认关闭 thinking（M2.x 不支持 thinking 参数，不能发送）。
+  return {
+    reasoning_split: true,
+    ...(/^minimax-m3(?:$|[-_.])/i.test(model) ? { thinking: { type: "disabled" } } : {}),
+  };
 }
 
 function sanitizeHeaderApiKey(apiKey: string | undefined): string {
@@ -805,7 +809,11 @@ function extractChatDeltaContent(json: any): string {
 }
 
 function extractChatDeltaReasoningContent(json: any): string {
-  return extractOpenAITextPart(json?.choices?.[0]?.delta?.reasoning_content);
+  const delta = json?.choices?.[0]?.delta;
+  // MiniMax reasoning_split 模式下流式 thinking 走 delta.reasoning_details
+  //（[{ text: "..." }] 数组）；其它服务走 delta.reasoning_content。
+  return extractOpenAITextPart(delta?.reasoning_content)
+    || extractOpenAITextPart(delta?.reasoning_details);
 }
 
 function extractResponsesContent(json: any): string {
@@ -1084,7 +1092,9 @@ async function chatCompletionViaCustomOpenAICompatible(
 
   if (!client.stream) {
     const json = await response.json() as any;
-    const content = extractChatContent(json);
+    // MiniMax M2.x 等模型可能把思考内容以 <think>...</think> 内联在 content 开头，
+    // 剥掉起始处的完整 think 块，防止思考内容混进章节/对话正文（issue #329）。
+    const content = stripLeadingThinkBlock(extractChatContent(json));
     if (!content) {
       throw wrapLLMError(new Error("LLM returned empty response"), errorCtx);
     }
@@ -1109,6 +1119,9 @@ async function chatCompletionViaCustomOpenAICompatible(
   // 网关掐断长连接时流会"干净地"关闭但没有任何终止信号——那是截断，不是完成。
   let sawTerminal = false;
   const monitor = createStreamMonitor(onStreamProgress);
+  // 内联 <think>...</think> 的模型（如 MiniMax M2.x）：剥掉响应起始处的完整
+  // think 块，思考内容既不并入正文也不通过 onTextDelta 发给 UI（issue #329）。
+  const thinkStripper = createLeadingThinkTagStripper();
 
   try {
     while (true) {
@@ -1129,9 +1142,12 @@ async function chatCompletionViaCustomOpenAICompatible(
         }
         const delta = extractChatDeltaContent(json);
         if (delta) {
-          content += delta;
           monitor.onChunk(delta);
-          onTextDelta?.(delta);
+          const emittable = thinkStripper.push(delta);
+          if (emittable) {
+            content += emittable;
+            onTextDelta?.(emittable);
+          }
         } else {
           const reasoningDelta = extractChatDeltaReasoningContent(json);
           if (reasoningDelta) {
@@ -1152,6 +1168,8 @@ async function chatCompletionViaCustomOpenAICompatible(
     monitor.stop();
   }
 
+  // 流结束仍缓冲在剥离器里的文本（未闭合的 think 块等）原样并回，避免数据丢失。
+  content += thinkStripper.flush();
   const finalContent = content || reasoningContent;
   if (!finalContent) {
     throw wrapLLMError(new Error("LLM returned empty response from stream"), errorCtx);

--- a/packages/core/src/llm/providers/endpoints/openrouter.ts
+++ b/packages/core/src/llm/providers/endpoints/openrouter.ts
@@ -18,7 +18,9 @@ export const OPENROUTER: InkosEndpoint = {
   group: "aggregator",
   api: "openai-responses",
   baseUrl: "https://openrouter.ai/api/v1",
-  checkModel: "google/gemma-2-9b-it:free",
+  // openrouter/auto 是 OpenRouter 官方的自动路由入口，长期存在；
+  // 具体模型 id（如 google/gemma-2-9b-it:free）会随上游下架失效（issue #300）。
+  checkModel: "openrouter/auto",
   temperatureRange: [0, 2],
   defaultTemperature: 0.7,
   writingTemperature: 1,
@@ -82,6 +84,5 @@ export const OPENROUTER: InkosEndpoint = {
     { id: "meta-llama/llama-3.3-70b-instruct:free", maxOutput: 4096, contextWindowTokens: 65536 },
     { id: "qwen/qwen-2-7b-instruct:free", maxOutput: 4096, contextWindowTokens: 32768 },
     { id: "meta-llama/llama-3.1-8b-instruct:free", maxOutput: 4096, contextWindowTokens: 131072 },
-    { id: "google/gemma-2-9b-it:free", maxOutput: 4096, contextWindowTokens: 8192 },
   ],
 };

--- a/packages/core/src/llm/think-tag-stripper.ts
+++ b/packages/core/src/llm/think-tag-stripper.ts
@@ -1,0 +1,73 @@
+// 部分 OpenAI 兼容服务（如 MiniMax M2.x、经网关代理的 DeepSeek-R1 类模型）会把
+// 思考内容以 <think>...</think> 标签内联在 content 字段的开头返回（issue #329）。
+// 这里只剥离"响应起始处的完整 think 块"：正文中间出现的 "<think>" 字样不动，
+// 起始处未闭合的 think 块也原样保留（说明正文根本没生成，剥掉会造成数据丢失）。
+
+const OPEN_TAG = "<think>";
+const CLOSE_TAG = "</think>";
+
+type StripperState = "detecting" | "insideThink" | "passthrough";
+
+export interface LeadingThinkTagStripper {
+  /** 送入一段增量文本，返回可以安全并入正文的部分（可能为空串，表示还在缓冲判断）。 */
+  readonly push: (chunk: string) => string;
+  /** 流结束时调用：把仍在缓冲的文本原样返回（未闭合的 think 块不剥离）。 */
+  readonly flush: () => string;
+}
+
+/**
+ * 流式剥离器：只处理响应起始处的完整 <think>...</think> 块。
+ * 在能确定"开头不是 think 块"之前先缓冲，不向外发出任何文本，
+ * 保证思考内容不会先展示再消失以外——根本不会被发出。
+ */
+export function createLeadingThinkTagStripper(): LeadingThinkTagStripper {
+  let state: StripperState = "detecting";
+  let pending = "";
+
+  const push = (chunk: string): string => {
+    if (state === "passthrough") return chunk;
+    pending += chunk;
+
+    if (state === "detecting") {
+      const leadingWhitespace = /^\s*/.exec(pending)![0];
+      const rest = pending.slice(leadingWhitespace.length);
+      if (rest.length < OPEN_TAG.length) {
+        if (OPEN_TAG.startsWith(rest)) return ""; // 还无法判断，继续缓冲
+        state = "passthrough";
+        const out = pending;
+        pending = "";
+        return out;
+      }
+      if (!rest.startsWith(OPEN_TAG)) {
+        state = "passthrough";
+        const out = pending;
+        pending = "";
+        return out;
+      }
+      state = "insideThink";
+    }
+
+    // state === "insideThink"：等待闭合标签
+    const closeIndex = pending.indexOf(CLOSE_TAG);
+    if (closeIndex < 0) return "";
+    state = "passthrough";
+    const afterClose = pending.slice(closeIndex + CLOSE_TAG.length).replace(/^\s+/, "");
+    pending = "";
+    return afterClose;
+  };
+
+  const flush = (): string => {
+    const out = pending;
+    pending = "";
+    state = "passthrough";
+    return out;
+  };
+
+  return { push, flush };
+}
+
+/** 非流式版本：剥离字符串起始处的完整 <think>...</think> 块（语义与流式剥离器一致）。 */
+export function stripLeadingThinkBlock(text: string): string {
+  const stripper = createLeadingThinkTagStripper();
+  return stripper.push(text) + stripper.flush();
+}

--- a/packages/core/src/models/book.ts
+++ b/packages/core/src/models/book.ts
@@ -67,6 +67,7 @@ export const BookConfigSchema = z.object({
   fanficMode: FanficModeSchema.optional(),
   writing: z.object({
     reviewMode: z.enum(["auto", "manual"]).optional(),
+    revisionGate: z.enum(["strict", "lenient", "always"]).optional(),
   }).optional(),
 });
 
@@ -84,4 +85,23 @@ export function resolveChapterReviewMode(
   projectWriting?: { readonly reviewMode?: ChapterReviewMode },
 ): ChapterReviewMode {
   return book.writing?.reviewMode ?? projectWriting?.reviewMode ?? "auto";
+}
+
+export type RevisionGate = "strict" | "lenient" | "always";
+
+/**
+ * Resolve the effective manual-revision gate for a book:
+ * book-level `writing.revisionGate` (book.json) overrides the project-level
+ * `writing.revisionGate` (inkos.json); both unset falls back to "strict".
+ *
+ * - "strict": apply only when audit counts do not worsen AND at least one of
+ *   blocking/AI-tell improves (historical default behavior).
+ * - "lenient": apply whenever audit counts do not worsen (no improvement required).
+ * - "always": always apply manual revisions; audit counts are recorded only.
+ */
+export function resolveRevisionGate(
+  book: Pick<BookConfig, "writing">,
+  projectWriting?: { readonly revisionGate?: RevisionGate },
+): RevisionGate {
+  return book.writing?.revisionGate ?? projectWriting?.revisionGate ?? "strict";
 }

--- a/packages/core/src/models/book.ts
+++ b/packages/core/src/models/book.ts
@@ -71,3 +71,17 @@ export const BookConfigSchema = z.object({
 });
 
 export type BookConfig = z.infer<typeof BookConfigSchema>;
+
+export type ChapterReviewMode = "auto" | "manual";
+
+/**
+ * Resolve the effective chapter review mode for a book:
+ * book-level `writing.reviewMode` (book.json) overrides the project-level
+ * `writing.reviewMode` (inkos.json); both unset falls back to "auto".
+ */
+export function resolveChapterReviewMode(
+  book: Pick<BookConfig, "writing">,
+  projectWriting?: { readonly reviewMode?: ChapterReviewMode },
+): ChapterReviewMode {
+  return book.writing?.reviewMode ?? projectWriting?.reviewMode ?? "auto";
+}

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -44,20 +44,24 @@ export const NotifyChannelSchema = z.discriminatedUnion("type", [
     type: z.literal("telegram"),
     botToken: z.string().min(1),
     chatId: z.string().min(1),
+    format: z.enum(["markdown", "text"]).default("markdown"),
   }),
   z.object({
     type: z.literal("wechat-work"),
     webhookUrl: z.string().url(),
+    format: z.enum(["markdown", "text"]).default("markdown"),
   }),
   z.object({
     type: z.literal("feishu"),
     webhookUrl: z.string().url(),
+    format: z.enum(["markdown", "text"]).default("markdown"),
   }),
   z.object({
     type: z.literal("webhook"),
     url: z.string().url(),
     secret: z.string().optional(),
     events: z.array(z.string()).default([]),
+    format: z.enum(["markdown", "text"]).default("markdown"),
   }),
 ]);
 

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -92,6 +92,7 @@ export type FoundationConfig = z.infer<typeof FoundationConfigSchema>;
 export const WritingConfigSchema = z.object({
   reviewRetries: z.number().int().min(0).max(10).default(1),
   reviewMode: z.enum(["auto", "manual"]).default("auto"),
+  revisionGate: z.enum(["strict", "lenient", "always"]).default("strict"),
 });
 
 export type WritingConfig = z.infer<typeof WritingConfigSchema>;

--- a/packages/core/src/notify/dispatcher.ts
+++ b/packages/core/src/notify/dispatcher.ts
@@ -1,4 +1,5 @@
 import type { NotifyChannel } from "../models/project.js";
+import { stripMarkdownMarks } from "./format.js";
 import type { WebhookPayload } from "./webhook.js";
 
 export interface NotifyMessage {
@@ -10,7 +11,9 @@ export async function dispatchNotification(
   channels: ReadonlyArray<NotifyChannel>,
   message: NotifyMessage,
 ): Promise<void> {
-  const fullText = `**${message.title}**\n\n${message.body}`;
+  const markdownText = `**${message.title}**\n\n${message.body}`;
+  const plainBody = stripMarkdownMarks(message.body);
+  const plainText = `${message.title}\n\n${plainBody}`;
 
   const tasks = channels.map(async (channel) => {
     try {
@@ -20,7 +23,8 @@ export async function dispatchNotification(
             const { sendTelegram } = await import("./telegram.js");
             await sendTelegram(
               { botToken: channel.botToken, chatId: channel.chatId },
-              fullText,
+              channel.format === "text" ? plainText : markdownText,
+              channel.format,
             );
           }
           break;
@@ -30,7 +34,8 @@ export async function dispatchNotification(
             await sendFeishu(
               { webhookUrl: channel.webhookUrl },
               message.title,
-              message.body,
+              channel.format === "text" ? plainBody : message.body,
+              channel.format,
             );
           }
           break;
@@ -39,7 +44,8 @@ export async function dispatchNotification(
             const { sendWechatWork } = await import("./wechat-work.js");
             await sendWechatWork(
               { webhookUrl: channel.webhookUrl },
-              fullText,
+              channel.format === "text" ? plainText : markdownText,
+              channel.format,
             );
           }
           break;
@@ -54,7 +60,7 @@ export async function dispatchNotification(
                 event: "pipeline-complete",
                 bookId: "",
                 timestamp: new Date().toISOString(),
-                data: { title: message.title, body: message.body },
+                data: { title: message.title, body: message.body, format: channel.format },
               },
             );
           }

--- a/packages/core/src/notify/feishu.ts
+++ b/packages/core/src/notify/feishu.ts
@@ -1,3 +1,5 @@
+import type { NotifyFormat } from "./format.js";
+
 export interface FeishuConfig {
   readonly webhookUrl: string;
 }
@@ -6,25 +8,32 @@ export async function sendFeishu(
   config: FeishuConfig,
   title: string,
   content: string,
+  format: NotifyFormat = "markdown",
 ): Promise<void> {
+  const payload = format === "text"
+    ? {
+        msg_type: "text",
+        content: { text: `${title}\n\n${content}` },
+      }
+    : {
+        msg_type: "interactive",
+        card: {
+          header: {
+            title: { tag: "plain_text", content: title },
+            template: "blue",
+          },
+          elements: [
+            {
+              tag: "markdown",
+              content,
+            },
+          ],
+        },
+      };
   const response = await fetch(config.webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      msg_type: "interactive",
-      card: {
-        header: {
-          title: { tag: "plain_text", content: title },
-          template: "blue",
-        },
-        elements: [
-          {
-            tag: "markdown",
-            content,
-          },
-        ],
-      },
-    }),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {

--- a/packages/core/src/notify/format.ts
+++ b/packages/core/src/notify/format.ts
@@ -1,0 +1,17 @@
+/**
+ * Output format for text notifications.
+ * "markdown" keeps the historical behavior; "text" is for receivers that render
+ * raw markdown poorly (phone notification bars, simple webhook consumers).
+ */
+export type NotifyFormat = "markdown" | "text";
+
+/**
+ * Strip common markdown marks (code fences, bold, inline code) so a message
+ * assembled for markdown channels reads cleanly on plain-text channels.
+ */
+export function stripMarkdownMarks(text: string): string {
+  return text
+    .replace(/```[^\n]*\n?/g, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1");
+}

--- a/packages/core/src/notify/telegram.ts
+++ b/packages/core/src/notify/telegram.ts
@@ -1,3 +1,5 @@
+import type { NotifyFormat } from "./format.js";
+
 export interface TelegramConfig {
   readonly botToken: string;
   readonly chatId: string;
@@ -6,6 +8,7 @@ export interface TelegramConfig {
 export async function sendTelegram(
   config: TelegramConfig,
   message: string,
+  format: NotifyFormat = "markdown",
 ): Promise<void> {
   const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
   const response = await fetch(url, {
@@ -14,7 +17,8 @@ export async function sendTelegram(
     body: JSON.stringify({
       chat_id: config.chatId,
       text: message,
-      parse_mode: "Markdown",
+      // Plain-text mode: omit parse_mode so Telegram renders the message as-is.
+      ...(format === "markdown" ? { parse_mode: "Markdown" } : {}),
     }),
   });
 

--- a/packages/core/src/notify/wechat-work.ts
+++ b/packages/core/src/notify/wechat-work.ts
@@ -1,3 +1,5 @@
+import type { NotifyFormat } from "./format.js";
+
 export interface WechatWorkConfig {
   readonly webhookUrl: string;
 }
@@ -5,14 +7,15 @@ export interface WechatWorkConfig {
 export async function sendWechatWork(
   config: WechatWorkConfig,
   content: string,
+  format: NotifyFormat = "markdown",
 ): Promise<void> {
+  const payload = format === "text"
+    ? { msgtype: "text", text: { content } }
+    : { msgtype: "markdown", markdown: { content } };
   const response = await fetch(config.webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      msgtype: "markdown",
-      markdown: { content },
-    }),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {

--- a/packages/core/src/pipeline/runner.ts
+++ b/packages/core/src/pipeline/runner.ts
@@ -1,7 +1,7 @@
 import type { LLMClient, OnStreamProgress } from "../llm/provider.js";
 import { chatCompletion, createLLMClient } from "../llm/provider.js";
 import type { Logger } from "../utils/logger.js";
-import type { BookConfig, FanficMode } from "../models/book.js";
+import type { BookConfig, FanficMode, RevisionGate } from "../models/book.js";
 import type { ChapterMeta } from "../models/chapter.js";
 import type { NotifyChannel, LLMConfig, AgentLLMOverride, InputGovernanceMode } from "../models/project.js";
 import type { GenreProfile } from "../models/genre-profile.js";
@@ -246,6 +246,13 @@ export function buildImportFoundationSource(
   ].join("\n");
 }
 
+/** Human-readable description of each manual-revision gate, surfaced in revisionDiagnostics. */
+const REVISION_GATE_STANDARDS: Record<RevisionGate, string> = {
+  strict: "A revision is applied only when blocking, critical, and AI-tell counts do not worsen, and at least blocking or AI-tell issues improve.",
+  lenient: "A revision is applied whenever blocking, critical, and AI-tell counts do not worsen; no improvement is required (lenient gate).",
+  always: "Manual revisions are always applied; audit counts are recorded for reference only (always gate).",
+};
+
 export interface PipelineConfig {
   readonly client: LLMClient;
   readonly model: string;
@@ -259,6 +266,14 @@ export interface PipelineConfig {
    * become explicit, user-driven checkpoint actions — chapter write stays fast.
    */
   readonly chapterReviewMode?: "auto" | "manual";
+  /**
+   * Gate for applying manual revisions (default "strict"):
+   * - "strict": apply only when blocking/critical/AI-tell counts do not worsen
+   *   AND at least one of blocking or AI-tell improves.
+   * - "lenient": apply whenever the counts do not worsen (no improvement required).
+   * - "always": always apply; audit counts are recorded but never block.
+   */
+  readonly revisionGate?: RevisionGate;
   readonly notifyChannels?: ReadonlyArray<NotifyChannel>;
   readonly radarSources?: ReadonlyArray<RadarSource>;
   readonly externalContext?: string;
@@ -1436,10 +1451,13 @@ export class PipelineRunner {
       const blockingDidNotWorsen = effectivePostRevision.blockingCount <= preRevision.blockingCount;
       const criticalDidNotWorsen = effectivePostRevision.criticalCount <= preRevision.criticalCount;
       const aiDidNotWorsen = effectivePostRevision.aiTellCount <= preRevision.aiTellCount;
-      const shouldApplyRevision = blockingDidNotWorsen
-        && criticalDidNotWorsen
-        && aiDidNotWorsen
-        && (improvedBlocking || improvedAITells);
+      const didNotWorsen = blockingDidNotWorsen && criticalDidNotWorsen && aiDidNotWorsen;
+      const revisionGate = this.config.revisionGate ?? "strict";
+      const shouldApplyRevision = revisionGate === "always"
+        ? true
+        : revisionGate === "lenient"
+          ? didNotWorsen
+          : didNotWorsen && (improvedBlocking || improvedAITells);
 
       if (!shouldApplyRevision) {
         const remainingIssues = effectivePostRevision.revisionBlockingIssues
@@ -1459,7 +1477,7 @@ export class PipelineRunner {
           status: "unchanged",
           skippedReason: `Manual revision kept original chapter: before blocking=${preRevision.blockingCount}, critical=${preRevision.criticalCount}, aiTell=${preRevision.aiTellCount}; after blocking=${effectivePostRevision.blockingCount}, critical=${effectivePostRevision.criticalCount}, aiTell=${effectivePostRevision.aiTellCount}.`,
           revisionDiagnostics: {
-            standard: "A revision is applied only when blocking, critical, and AI-tell counts do not worsen, and at least blocking or AI-tell issues improve.",
+            standard: REVISION_GATE_STANDARDS[revisionGate],
             before: {
               blockingCount: preRevision.blockingCount,
               criticalCount: preRevision.criticalCount,

--- a/packages/core/src/utils/effective-llm-config.ts
+++ b/packages/core/src/utils/effective-llm-config.ts
@@ -464,8 +464,27 @@ function modelBelongsToService(service: string, model: string): boolean {
   return endpoint.models.some((knownModel) => knownModel.id.toLowerCase() === model.toLowerCase());
 }
 
+/**
+ * 这些服务的可用模型清单是动态的，静态 bank 必然滞后，
+ * 所以用户显式配置的模型 id 直接透传，不做 bank 白名单校验（issue #300）：
+ * - ollama：本地装了什么模型就有什么模型
+ * - openrouter：聚合 350+ 上游模型，上游随时增删，bank 只列常用子集
+ * - newapi：自建中转网关，模型清单由部署方自定义，bank 为空
+ * - kkaiapi：多家大模型的 OpenAI 兼容中转站，上游清单随时变化
+ * - ppio：聚合平台，每周都有新模型 id，bank 只维护主流子集
+ * - siliconcloud：聚合平台，新模型上架频繁，bank 只维护主流子集
+ */
+const SERVICES_WITH_DYNAMIC_MODELS: ReadonlySet<string> = new Set([
+  "ollama",
+  "openrouter",
+  "newapi",
+  "kkaiapi",
+  "ppio",
+  "siliconcloud",
+]);
+
 function serviceAllowsUnlistedModels(service: string): boolean {
-  return service === "ollama";
+  return SERVICES_WITH_DYNAMIC_MODELS.has(service);
 }
 
 function serviceEntryKey(entry: ServiceConfigEntry): string {

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -4253,6 +4253,42 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(pipelineConfigs.at(-1)).toMatchObject({ chapterReviewMode: "manual" });
   });
 
+  it("uses a book-level revisionGate override when revising a chapter", async () => {
+    await writeCompleteBookFixture(root, "demo-book", "Demo Book");
+    const rawBookPath = join(root, "books", "demo-book", "book.json");
+    const rawBook = JSON.parse(await readFile(rawBookPath, "utf-8"));
+    await writeFile(rawBookPath, JSON.stringify({
+      ...rawBook,
+      writing: { revisionGate: "always" },
+    }, null, 2), "utf-8");
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+
+    const response = await app.request("http://localhost/api/v1/books/demo-book/revise/3", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode: "spot-fix" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(pipelineConfigs.at(-1)).toMatchObject({ revisionGate: "always" });
+  });
+
+  it("defaults the revisionGate to strict when neither book nor project sets one", async () => {
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+
+    const response = await app.request("http://localhost/api/v1/books/demo-book/revise/3", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode: "spot-fix" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(pipelineConfigs.at(-1)).toMatchObject({ revisionGate: "strict" });
+  });
+
   it("exposes a global default model endpoint backed by llm.defaultModel", async () => {
     const { createStudioServer } = await import("./server.js");
     const app = createStudioServer(cloneProjectConfig() as never, root);

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -1686,6 +1686,37 @@ async function resolveBookChapterReviewMode(root: string, bookId: string | undef
   }
 }
 
+type RevisionGateSetting = "strict" | "lenient" | "always";
+
+function normalizeRevisionGate(gate: unknown): RevisionGateSetting {
+  return gate === "lenient" || gate === "always" ? gate : "strict";
+}
+
+function readProjectRevisionGate(config: Record<string, unknown>): RevisionGateSetting {
+  const writing = config.writing && typeof config.writing === "object" && !Array.isArray(config.writing)
+    ? config.writing as Record<string, unknown>
+    : {};
+  return normalizeRevisionGate(writing.revisionGate);
+}
+
+function readBookRevisionGate(rawBook: Record<string, unknown>): RevisionGateSetting | undefined {
+  const writing = rawBook.writing && typeof rawBook.writing === "object" && !Array.isArray(rawBook.writing)
+    ? rawBook.writing as Record<string, unknown>
+    : undefined;
+  if (!writing || writing.revisionGate !== "strict" && writing.revisionGate !== "lenient" && writing.revisionGate !== "always") return undefined;
+  return writing.revisionGate;
+}
+
+async function resolveBookRevisionGate(root: string, bookId: string | undefined, projectGate: RevisionGateSetting): Promise<RevisionGateSetting> {
+  if (!bookId || !isSafeBookId(bookId)) return projectGate;
+  try {
+    const rawBook = await loadRawBookConfig(root, bookId);
+    return readBookRevisionGate(rawBook) ?? projectGate;
+  } catch {
+    return projectGate;
+  }
+}
+
 function unquoteEnvValue(value: string): string {
   const trimmed = value.trim();
   if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
@@ -2293,6 +2324,8 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const currentConfig = overrides?.currentConfig ?? await loadCurrentProjectConfig();
     const projectReviewMode = readProjectChapterReviewMode(currentConfig as unknown as Record<string, unknown>);
     const chapterReviewMode = await resolveBookChapterReviewMode(root, overrides?.bookIdForSettings, projectReviewMode);
+    const projectRevisionGate = readProjectRevisionGate(currentConfig as unknown as Record<string, unknown>);
+    const revisionGate = await resolveBookRevisionGate(root, overrides?.bookIdForSettings, projectRevisionGate);
     const scopedSseSink: LogSink = overrides?.sessionIdForSSE
       ? {
           write(entry) {
@@ -2314,6 +2347,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
       foundationReviewRetries: currentConfig.foundation?.reviewRetries ?? 2,
       writingReviewRetries: currentConfig.writing?.reviewRetries ?? 1,
       chapterReviewMode,
+      revisionGate,
       modelOverrides: currentConfig.modelOverrides,
       notifyChannels: currentConfig.notify,
       logger,
@@ -4695,6 +4729,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
 
       const pipeline = new PipelineRunner(await buildPipelineConfig({
         externalContext: body.brief,
+        bookIdForSettings: id,
       }));
       const normalizedMode = body.mode ?? "spot-fix";
       const result = await pipeline.reviseDraft(

--- a/packages/studio/src/components/chat/ToolExecutionSteps.tsx
+++ b/packages/studio/src/components/chat/ToolExecutionSteps.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { buildApiUrl } from "../../hooks/use-api";
 import { chatSelectors, useChatStore } from "../../store/chat";
+import { usePreferencesStore } from "../../store/preferences";
 
 // -- Status rendering helpers --
 
@@ -626,6 +627,29 @@ function useElapsedTimer(startedAt: number, active: boolean): number {
 
 // -- Pipeline operation (sub_agent) --
 
+/**
+ * Uncontrolled <details>: `open` only sets the initial state, so manual
+ * toggling keeps working (React leaves the DOM alone while the prop value is
+ * unchanged). The key remounts the element when the global preference flips,
+ * re-applying the new default.
+ */
+export function PipelineResultDetails({ result, defaultOpen }: { result: string; defaultOpen: boolean }) {
+  return (
+    <details
+      key={defaultOpen ? "result-default-open" : "result-default-collapsed"}
+      open={defaultOpen}
+      className="mx-3 mb-3 mt-1 rounded-lg border border-border/40 bg-background/60 px-2.5 py-2 text-xs"
+    >
+      <summary className="cursor-pointer select-none font-medium text-muted-foreground hover:text-foreground">
+        查看操作结果
+      </summary>
+      <div className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words leading-5 text-foreground">
+        {result}
+      </div>
+    </details>
+  );
+}
+
 function PipelineExecution({
   exec,
   onProposedAction,
@@ -640,6 +664,7 @@ function PipelineExecution({
   const isActive = exec.status === "running" || exec.status === "processing";
   const [open, setOpen] = useState(isActive);
   const elapsedMs = useElapsedTimer(exec.startedAt, isActive);
+  const toolDetailsDefaultOpen = usePreferencesStore((s) => s.toolDetailsDefaultOpen);
 
   useEffect(() => {
     if (exec.status === "running") setOpen(true);
@@ -680,14 +705,7 @@ function PipelineExecution({
       <PlayResultPreview exec={exec} />
       <PlayEditPreview exec={exec} />
       {typeof exec.result === "string" && exec.result.trim() && (
-        <details open className="mx-3 mb-3 mt-1 rounded-lg border border-border/40 bg-background/60 px-2.5 py-2 text-xs">
-          <summary className="cursor-pointer select-none font-medium text-muted-foreground hover:text-foreground">
-            查看操作结果
-          </summary>
-          <div className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words leading-5 text-foreground">
-            {exec.result}
-          </div>
-        </details>
+        <PipelineResultDetails result={exec.result} defaultOpen={toolDetailsDefaultOpen} />
       )}
       <CollapsibleContent>
         <div className="px-3 pb-3 pt-1">
@@ -741,6 +759,47 @@ function PipelineExecution({
 
 // -- Utility tools (read/edit/grep/ls) grouped --
 
+function UtilityExecStatusIcon({ status }: { status: ToolExecution["status"] }) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 size={10} className="text-green-600 dark:text-green-400 shrink-0" />;
+    case "error":
+      return <XCircle size={10} className="text-destructive shrink-0" />;
+    case "running":
+    case "processing":
+      return <Loader2 size={10} className="animate-spin text-primary shrink-0" />;
+  }
+}
+
+export function UtilityExecutionRow({ exec }: { exec: ToolExecution }) {
+  const title = `${exec.tool} ${String(exec.args?.path ?? exec.args?.pattern ?? "")}`;
+  const hasResult = typeof exec.result === "string" && exec.result.trim().length > 0;
+
+  if (!hasResult) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="font-mono truncate">{title}</span>
+        <UtilityExecStatusIcon status={exec.status} />
+      </div>
+    );
+  }
+
+  // Uncontrolled <details>, always collapsed by default: utility results are
+  // reference material, expanding them all would flood the transcript.
+  return (
+    <details className="group">
+      <summary className="flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden hover:text-foreground transition-colors">
+        <span className="font-mono truncate">{title}</span>
+        <UtilityExecStatusIcon status={exec.status} />
+        <ChevronDown size={10} className="shrink-0 transition-transform group-open:rotate-180" />
+      </summary>
+      <div className="mt-1 mb-1 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/40 bg-background/60 px-2 py-1.5 leading-5">
+        {exec.result}
+      </div>
+    </details>
+  );
+}
+
 function UtilityToolsGroup({ execs }: { execs: ToolExecution[] }) {
   const [open, setOpen] = useState(false);
   const allDone = execs.every(e => e.status === "completed" || e.status === "error");
@@ -759,11 +818,8 @@ function UtilityToolsGroup({ execs }: { execs: ToolExecution[] }) {
       <CollapsibleContent>
         <ul className="pl-6 space-y-0.5 py-1">
           {execs.map((exec) => (
-            <li key={exec.id} className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="font-mono truncate">{exec.tool} {String(exec.args?.path ?? exec.args?.pattern ?? "")}</span>
-              {exec.status === "completed" && <CheckCircle2 size={10} className="text-green-600 dark:text-green-400 shrink-0" />}
-              {exec.status === "error" && <XCircle size={10} className="text-destructive shrink-0" />}
-              {(exec.status === "running" || exec.status === "processing") && <Loader2 size={10} className="animate-spin text-primary shrink-0" />}
+            <li key={exec.id} className="text-xs text-muted-foreground">
+              <UtilityExecutionRow exec={exec} />
             </li>
           ))}
         </ul>

--- a/packages/studio/src/components/chat/__tests__/ToolExecutionSteps.test.ts
+++ b/packages/studio/src/components/chat/__tests__/ToolExecutionSteps.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { ToolExecution } from "../../../store/chat/types";
-import { ToolExecutionSteps, buildPlayRunStatusUrl, buildPlaySceneImageUrl, getGeneratedArtifactDetails, getPlayEditDetails, getPlayToolDetails, getProposedActionContractRows, getProposedActionDetails, groupToolExecutionsChronologically } from "../ToolExecutionSteps";
+import { PipelineResultDetails, ToolExecutionSteps, UtilityExecutionRow, buildPlayRunStatusUrl, buildPlaySceneImageUrl, getGeneratedArtifactDetails, getPlayEditDetails, getPlayToolDetails, getProposedActionContractRows, getProposedActionDetails, groupToolExecutionsChronologically } from "../ToolExecutionSteps";
+import { usePreferencesStore } from "../../../store/preferences";
 
 const makeExec = (overrides: Partial<ToolExecution> & { id: string; tool: string }): ToolExecution => ({
   label: "test",
@@ -463,5 +464,99 @@ describe("groupChronologically", () => {
       action: "fanfic_init",
       targetRoute: undefined,
     });
+  });
+});
+
+describe("tool details default-open preference", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({ toolDetailsDefaultOpen: true });
+  });
+
+  it("the preferences store defaults to expanded, keeping today's behavior", () => {
+    expect(usePreferencesStore.getState().toolDetailsDefaultOpen).toBe(true);
+  });
+
+  it("renders the pipeline result details expanded when the preference is on (default)", () => {
+    const exec = makeExec({
+      id: "writer-1",
+      tool: "sub_agent",
+      agent: "writer",
+      label: "写下一章",
+      result: "已完成第 1 章：雨棚。这里是更详细的操作结果。",
+    });
+
+    const html = renderToStaticMarkup(React.createElement(ToolExecutionSteps, { executions: [exec] }));
+
+    expect(html).toContain("查看操作结果");
+    expect(html).toContain("<details open");
+  });
+
+  it("renders the pipeline result details collapsed when the preference is off", () => {
+    const html = renderToStaticMarkup(React.createElement(PipelineResultDetails, {
+      result: "已完成第 1 章：雨棚。这里是更详细的操作结果。",
+      defaultOpen: false,
+    }));
+
+    // The block is still there (manually expandable), just not open by default.
+    expect(html).toContain("查看操作结果");
+    expect(html).toContain("已完成第 1 章：雨棚");
+    expect(html).not.toContain("<details open");
+  });
+
+  it("renders the pipeline result details expanded when defaultOpen is true", () => {
+    const html = renderToStaticMarkup(React.createElement(PipelineResultDetails, {
+      result: "已完成第 1 章：雨棚。",
+      defaultOpen: true,
+    }));
+
+    expect(html).toContain("<details open");
+  });
+});
+
+describe("UtilityExecutionRow", () => {
+  it("renders an expandable, default-collapsed result body when the execution has a result", () => {
+    const exec = makeExec({
+      id: "read-1",
+      tool: "read",
+      label: "读取文件",
+      args: { path: "books/demo/chapter-1.md" },
+      result: "第一章正文：雨停了，巷口的灯还亮着。",
+    });
+
+    const html = renderToStaticMarkup(React.createElement(UtilityExecutionRow, { exec }));
+
+    expect(html).toContain("read books/demo/chapter-1.md");
+    expect(html).toContain("第一章正文：雨停了，巷口的灯还亮着。");
+    expect(html).toContain("<details");
+    expect(html).not.toContain("<details open");
+  });
+
+  it("renders a plain row without details when the execution has no result", () => {
+    const exec = makeExec({
+      id: "ls-1",
+      tool: "ls",
+      label: "列目录",
+      args: { path: "books/demo" },
+    });
+
+    const html = renderToStaticMarkup(React.createElement(UtilityExecutionRow, { exec }));
+
+    expect(html).toContain("ls books/demo");
+    expect(html).not.toContain("<details");
+  });
+
+  it("treats a whitespace-only result as no result", () => {
+    const exec = makeExec({
+      id: "grep-1",
+      tool: "grep",
+      label: "搜索",
+      args: { pattern: "灯" },
+      result: "   \n  ",
+    });
+
+    const html = renderToStaticMarkup(React.createElement(UtilityExecutionRow, { exec }));
+
+    expect(html).toContain("grep 灯");
+    expect(html).not.toContain("<details");
   });
 });

--- a/packages/studio/src/hooks/use-i18n.ts
+++ b/packages/studio/src/hooks/use-i18n.ts
@@ -271,6 +271,10 @@ const strings = {
   "settings.detectionThreshold": { zh: "阈值", en: "Threshold" },
   "settings.detectionMaxRetries": { zh: "最大重试", en: "Max retries" },
   "settings.detectionAutoRewrite": { zh: "命中后自动反检测改写", en: "Auto anti-detect rewrite on hit" },
+  "settings.chatUi": { zh: "对话界面", en: "Chat Interface" },
+  "settings.chatUiHint": { zh: "控制对话页里操作详情的展示方式。该偏好保存在当前浏览器，不写入项目配置。", en: "Controls how operation details render on the chat page. Stored in this browser, not in project config." },
+  "settings.toolDetailsDefaultOpen": { zh: "操作详情默认展开", en: "Expand operation details by default" },
+  "settings.toolDetailsDefaultOpenHint": { zh: "关闭后，对话中的「查看操作结果」默认收起，仍可手动展开。", en: "When off, \"view result\" blocks in chat start collapsed; you can still expand them manually." },
 
   // Truth Files extras
   "truth.title": { zh: "真相文件", en: "Truth Files" },

--- a/packages/studio/src/pages/ProjectSettings.tsx
+++ b/packages/studio/src/pages/ProjectSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { Bell, Bot, FileText, Radar, RotateCcw, Search, Settings2, Plus, Trash2 } from "lucide-react";
+import { Bell, Bot, FileText, MessageSquare, Radar, RotateCcw, Search, Settings2, Plus, Trash2 } from "lucide-react";
 import { fetchJson, postApi, putApi, useApi } from "../hooks/use-api";
+import { usePreferencesStore } from "../store/preferences";
 import type { Theme } from "../hooks/use-theme";
 import type { TFunction } from "../hooks/use-i18n";
 import { useColors } from "../hooks/use-colors";
@@ -116,6 +117,8 @@ export function ProjectSettings({ nav, theme, t }: { nav: Nav; theme: Theme; t: 
   const [promptDraft, setPromptDraft] = useState("");
   const [notice, setNotice] = useState<{ tone: NoticeTone; message: string } | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
+  const toolDetailsDefaultOpen = usePreferencesStore((s) => s.toolDetailsDefaultOpen);
+  const setToolDetailsDefaultOpen = usePreferencesStore((s) => s.setToolDetailsDefaultOpen);
   const skills = skillsData?.skills ?? [];
   const promptGroups = groupPromptPacksForDisplay(promptPacksData ?? { packs: [], prompts: [] });
   const promptList = promptPacksData?.prompts ?? [];
@@ -244,6 +247,19 @@ export function ProjectSettings({ nav, theme, t }: { nav: Nav; theme: Theme; t: 
             {saving === "mode" ? t("config.saving") : t("config.save")}
           </button>
         </div>
+      </SettingsCard>
+
+      {/* Chat UI preferences — applied immediately, persisted in this browser's localStorage */}
+      <SettingsCard title={t("settings.chatUi")} description={t("settings.chatUiHint")} icon={<MessageSquare size={18} />}>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={toolDetailsDefaultOpen}
+            onChange={(e) => setToolDetailsDefaultOpen(e.target.checked)}
+          />
+          {t("settings.toolDetailsDefaultOpen")}
+        </label>
+        <p className="text-xs text-muted-foreground">{t("settings.toolDetailsDefaultOpenHint")}</p>
       </SettingsCard>
 
       <SettingsCard

--- a/packages/studio/src/store/preferences/index.ts
+++ b/packages/studio/src/store/preferences/index.ts
@@ -1,0 +1,2 @@
+export { usePreferencesStore, readStoredToolDetailsDefaultOpen, TOOL_DETAILS_STORAGE_KEY } from "./store";
+export type { PreferencesStore } from "./types";

--- a/packages/studio/src/store/preferences/store.test.ts
+++ b/packages/studio/src/store/preferences/store.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readStoredToolDetailsDefaultOpen, usePreferencesStore, TOOL_DETAILS_STORAGE_KEY } from "./store";
+
+function fakeStorage(entries: Record<string, string>) {
+  return {
+    getItem: (key: string) => (key in entries ? entries[key] : null),
+  };
+}
+
+describe("readStoredToolDetailsDefaultOpen", () => {
+  it("defaults to true when no storage is available", () => {
+    expect(readStoredToolDetailsDefaultOpen(null)).toBe(true);
+    expect(readStoredToolDetailsDefaultOpen(undefined)).toBe(true);
+  });
+
+  it("defaults to true when nothing is stored", () => {
+    expect(readStoredToolDetailsDefaultOpen(fakeStorage({}))).toBe(true);
+  });
+
+  it("returns false only for an explicitly stored \"false\"", () => {
+    expect(readStoredToolDetailsDefaultOpen(fakeStorage({ [TOOL_DETAILS_STORAGE_KEY]: "false" }))).toBe(false);
+    expect(readStoredToolDetailsDefaultOpen(fakeStorage({ [TOOL_DETAILS_STORAGE_KEY]: "true" }))).toBe(true);
+    expect(readStoredToolDetailsDefaultOpen(fakeStorage({ [TOOL_DETAILS_STORAGE_KEY]: "garbage" }))).toBe(true);
+  });
+});
+
+describe("usePreferencesStore", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({ toolDetailsDefaultOpen: true });
+  });
+
+  it("starts with details expanded by default", () => {
+    expect(usePreferencesStore.getState().toolDetailsDefaultOpen).toBe(true);
+  });
+
+  it("setToolDetailsDefaultOpen updates the state", () => {
+    usePreferencesStore.getState().setToolDetailsDefaultOpen(false);
+    expect(usePreferencesStore.getState().toolDetailsDefaultOpen).toBe(false);
+
+    usePreferencesStore.getState().setToolDetailsDefaultOpen(true);
+    expect(usePreferencesStore.getState().toolDetailsDefaultOpen).toBe(true);
+  });
+});

--- a/packages/studio/src/store/preferences/store.ts
+++ b/packages/studio/src/store/preferences/store.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import type { PreferencesStore } from "./types";
+
+// Same storage convention as the theme preference (`inkos:studio:theme`).
+export const TOOL_DETAILS_STORAGE_KEY = "inkos:studio:tool-details-default-open";
+
+interface PreferenceStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function getPreferenceStorage(): PreferenceStorageLike | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default is `true` (keep today's behavior: result details start expanded).
+ * Only an explicitly stored "false" turns the preference off.
+ */
+export function readStoredToolDetailsDefaultOpen(
+  storage: Pick<PreferenceStorageLike, "getItem"> | null | undefined,
+): boolean {
+  return storage?.getItem(TOOL_DETAILS_STORAGE_KEY) !== "false";
+}
+
+export const usePreferencesStore = create<PreferencesStore>()((set) => ({
+  toolDetailsDefaultOpen: readStoredToolDetailsDefaultOpen(getPreferenceStorage()),
+
+  setToolDetailsDefaultOpen: (open: boolean) => {
+    try {
+      getPreferenceStorage()?.setItem(TOOL_DETAILS_STORAGE_KEY, String(open));
+    } catch {
+      // Ignore storage failures (e.g. private mode) and keep the in-memory
+      // preference for this session — same policy as the theme preference.
+    }
+    set({ toolDetailsDefaultOpen: open });
+  },
+}));

--- a/packages/studio/src/store/preferences/types.ts
+++ b/packages/studio/src/store/preferences/types.ts
@@ -1,0 +1,9 @@
+export interface PreferencesStore {
+  /**
+   * Whether pipeline tool result blocks ("查看操作结果") in chat render
+   * expanded by default. Persisted per browser via localStorage.
+   */
+  toolDetailsDefaultOpen: boolean;
+
+  setToolDetailsDefaultOpen: (open: boolean) => void;
+}


### PR DESCRIPTION
## Summary

一批 GitHub issue 的集中修复/实现（#300 #306 #307 #308 #324 #326 #329 残留项）：

- **#300** OpenRouter 等动态模型清单服务（openrouter/newapi/kkaiapi/ppio/siliconcloud）不再用静态白名单拦截用户配置的模型；openrouter 连通性探测模型从已下架的 `google/gemma-2-9b-it:free` 换成 `openrouter/auto`（已向 OpenRouter /models 接口验证：gemma 已下架、auto 存在）
- **#329** MiniMax 请求默认带 `reasoning_split: true`，M2.x 无法关闭的 thinking 不再以 `<think>` 标签混进正文；响应起始 think 块剥离兜底（流式 + 非流式）
- **#326** 修订判断标准三档可配置 `writing.revisionGate`：strict（默认，现状）/ lenient（不变差即应用）/ always（一律应用），全局 + 书级覆盖，CLI 与 Studio 都接线
- **#307** CLI 遵守书级 `writing.reviewMode`（此前 `inkos write next` 永远自动审查）；新增 `inkos auto [book-id] <目标章号>` 连续自动写作
- **#308** 通知渠道支持 `format: markdown|text`；`write next/rewrite、auto、revise、audit` 新增 `--notify`（与 runner 既有单章通知做了去重）
- **#324** 新增 `import_chapters` agent 工具：对话里把本地文件/目录（含上传附件的 stored_path）导入为书籍真实章节，复用 `PipelineRunner.importChapters`
- **#306** Studio"操作详情默认展开"浏览器偏好 + read/grep 等小工具行可展开查看结果正文

每个 issue 独立原子提交，可单独回退。

## Test plan

- [x] core 全量 vitest：1614 passed
- [x] cli 全量 vitest：195 passed
- [x] studio 全量 vitest：465 passed
- [x] 三包 build + typecheck 退出码 0
- [x] OpenRouter /models 在线验证 checkModel 可用性
- [ ] 真实 MiniMax M2.x key 冒烟验证 reasoning_split 生效（无凭据，待维护者验证）
- [ ] Studio 操作详情开关人工过一遍交互
