### PR TITLE
fix(core): normalize project-relative paths to posix separators (Windows CI)

### DIFF
--- a/packages/core/src/__tests__/external-skill-loader.test.ts
+++ b/packages/core/src/__tests__/external-skill-loader.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join, relative } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createSkillRegistry,
@@ -104,7 +104,9 @@ describe("external skill loader", () => {
   });
 
   it("rejects relative external directories", async () => {
-    await expect(loadExternalCapabilitySkills({ externalDirs: [relative(process.cwd(), root)] }))
+    // 不能用 relative(process.cwd(), root)：Windows CI 上 cwd 和临时目录在不同盘符，
+    // path.relative 跨盘符会返回绝对路径，测试意图（传相对路径必须被拒绝）就失效了。
+    await expect(loadExternalCapabilitySkills({ externalDirs: [join("relative", "external-skills")] }))
       .rejects.toThrow(/absolute/);
   });
 

--- a/packages/core/src/__tests__/play-runner.test.ts
+++ b/packages/core/src/__tests__/play-runner.test.ts
@@ -692,4 +692,52 @@ describe("PlayRunner", () => {
       .resolves
       .toContain("版本B");
   });
+
+  it("close() does not close a caller-provided db", () => {
+    const db = new FakePlayDB() as FakePlayDB & { close: () => void };
+    db.close = vi.fn();
+    const runner = new PlayRunner({
+      projectRoot: root,
+      worldId: "close-owned-db",
+      runId: "main",
+      db,
+      agents: {
+        actionInterpreter: { interpret: vi.fn() },
+        worldMutator: { proposeMutation: vi.fn() },
+        sceneRenderer: { render: vi.fn() },
+      },
+    });
+
+    runner.close();
+
+    expect(db.close).not.toHaveBeenCalled();
+  });
+
+  it("close() releases the self-created db and is idempotent", async () => {
+    const store = new PlayStore(root);
+    await store.createWorld({
+      id: "close-self-db",
+      title: "收摊测试",
+      premise: "验证 runner 自建数据库连接会被关闭。",
+      language: "zh",
+      mode: "open",
+    });
+    await store.ensureRun("close-self-db", "main");
+    const runner = new PlayRunner({
+      projectRoot: root,
+      worldId: "close-self-db",
+      runId: "main",
+      agents: {
+        actionInterpreter: { interpret: vi.fn() },
+        worldMutator: { proposeMutation: vi.fn() },
+        sceneRenderer: { render: vi.fn() },
+      },
+    });
+
+    runner.close();
+    // Windows 上句柄未释放会让 play.db 无法删除；这里至少保证重复 close 不抛异常。
+    runner.close();
+
+    await expect(rm(join(root, "worlds", "close-self-db"), { recursive: true })).resolves.toBeUndefined();
+  });
 });

--- a/packages/core/src/__tests__/posix-path.test.ts
+++ b/packages/core/src/__tests__/posix-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { toPosixPath } from "../utils/posix-path.js";
+
+describe("toPosixPath", () => {
+  it("converts Windows separators", () => {
+    expect(toPosixPath(".inkos\\materials\\a.md")).toBe(".inkos/materials/a.md");
+  });
+
+  it("keeps posix paths unchanged", () => {
+    expect(toPosixPath("storyboards/cold-ledger/assets.json")).toBe("storyboards/cold-ledger/assets.json");
+  });
+
+  it("normalizes mixed separators", () => {
+    expect(toPosixPath("interactive-films\\demo/story-graph.json")).toBe("interactive-films/demo/story-graph.json");
+  });
+});

--- a/packages/core/src/agent/agent-tools.ts
+++ b/packages/core/src/agent/agent-tools.ts
@@ -70,6 +70,11 @@ function closePlayDB(db: PlayGraphDB): void {
   db.close?.();
 }
 
+// runnerFactory 注入的测试替身没有 close 方法，可选调用兜底。
+function closePlayRunner(runner: unknown): void {
+  (runner as { close?: () => void }).close?.();
+}
+
 function safePlayId(value: string | undefined, fallback: string): string {
   const raw = (value?.trim() || fallback).slice(0, 80);
   if (!raw || raw === "." || raw === ".." || raw.includes("/") || raw.includes("\\") || raw.includes("\0")) {
@@ -2014,6 +2019,8 @@ export function createPlayStepTool(
             error: err instanceof Error ? err.message : String(err),
           },
         );
+      } finally {
+        closePlayRunner(runner);
       }
 
       const db = createPlayDB(store.runDir(target.worldId, target.runId));
@@ -2078,52 +2085,57 @@ export function createPlayReviseTool(
         ctx,
       });
 
-      if (params.action === "restore_variant") {
-        const turn = params.turn;
-        const variantId = params.variantId?.trim();
-        if (typeof turn !== "number" || !Number.isFinite(turn) || !variantId) {
-          return textResult("恢复版本需要 turn 和 variantId。");
-        }
-        onUpdate?.(textResult(`Restoring play variant "${variantId}"...`));
-        const restored = await runner.restoreVariant({
-          turn: Math.trunc(turn),
-          variantId,
-        });
-        return textResult(
-          restored.sceneText || "已切换到指定互动回合版本。",
-          {
-            kind: "play_variant_restored",
-            worldId,
-            runId,
-            title: world.title,
-            turn: restored.turn,
-            variantId: restored.variantId,
-            sceneText: restored.sceneText,
-          },
-        );
-      }
-
-      const replacement = params.action === "edit_last_input" ? params.input?.trim() : undefined;
-      if (params.action === "edit_last_input" && !replacement) {
-        return textResult("编辑上一条玩家动作需要提供新的 input。");
-      }
-      onUpdate?.(textResult(params.action === "edit_last_input" ? "Replaying edited play turn..." : "Regenerating last play turn..."));
       let replay: PlayReplayResult;
+      // finally 关闭 runner 自建的 play.db 连接：句柄不关闭时 Windows 上无法删除数据库文件。
       try {
-        replay = await runner.regenerateLastTurn(replacement);
-      } catch (err) {
-        const isZh = (world.language ?? "zh") !== "en";
-        return textResult(
-          isZh
-            ? "（上一回合暂时不能安全重做。继续输入新的动作，我会从当前状态推进。）"
-            : "(The previous turn cannot be safely regenerated yet. Enter a new action and I will continue from the current state.)",
-          {
-            kind: "play_revise_failed",
-            worldId,
-            runId,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        );
+        if (params.action === "restore_variant") {
+          const turn = params.turn;
+          const variantId = params.variantId?.trim();
+          if (typeof turn !== "number" || !Number.isFinite(turn) || !variantId) {
+            return textResult("恢复版本需要 turn 和 variantId。");
+          }
+          onUpdate?.(textResult(`Restoring play variant "${variantId}"...`));
+          const restored = await runner.restoreVariant({
+            turn: Math.trunc(turn),
+            variantId,
+          });
+          return textResult(
+            restored.sceneText || "已切换到指定互动回合版本。",
+            {
+              kind: "play_variant_restored",
+              worldId,
+              runId,
+              title: world.title,
+              turn: restored.turn,
+              variantId: restored.variantId,
+              sceneText: restored.sceneText,
+            },
+          );
+        }
+
+        const replacement = params.action === "edit_last_input" ? params.input?.trim() : undefined;
+        if (params.action === "edit_last_input" && !replacement) {
+          return textResult("编辑上一条玩家动作需要提供新的 input。");
+        }
+        onUpdate?.(textResult(params.action === "edit_last_input" ? "Replaying edited play turn..." : "Regenerating last play turn..."));
+        try {
+          replay = await runner.regenerateLastTurn(replacement);
+        } catch (err) {
+          const isZh = (world.language ?? "zh") !== "en";
+          return textResult(
+            isZh
+              ? "（上一回合暂时不能安全重做。继续输入新的动作，我会从当前状态推进。）"
+              : "(The previous turn cannot be safely regenerated yet. Enter a new action and I will continue from the current state.)",
+            {
+              kind: "play_revise_failed",
+              worldId,
+              runId,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+        }
+      } finally {
+        closePlayRunner(runner);
       }
 
       const db = createPlayDB(store.runDir(worldId, runId));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -201,6 +201,7 @@ export {
 } from "./utils/proxy-fetch.js";
 export { assertSafeBookId, deriveBookIdFromTitle, isSafeBookId } from "./utils/book-id.js";
 export { safeChildPath } from "./utils/path-safety.js";
+export { toPosixPath } from "./utils/posix-path.js";
 export {
   AutomationModeSchema,
   type AutomationMode,

--- a/packages/core/src/materials/ingest.ts
+++ b/packages/core/src/materials/ingest.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, extname, join, relative } from "node:path";
 import { extractText, getDocumentProxy } from "unpdf";
 import { safeChildPath } from "../utils/path-safety.js";
+import { toPosixPath } from "../utils/posix-path.js";
 
 export type MaterialPurpose = "reference" | "worldbuilding" | "script" | "storyboard" | "research" | "general";
 export type MaterialSourceKind = "url" | "file";
@@ -71,8 +72,8 @@ export async function ingestMaterial(
     purpose,
     source: source.source,
     mimeType: source.mimeType,
-    markdownPath: relative(projectRoot, markdownPathAbs),
-    manifestPath: relative(projectRoot, manifestPathAbs),
+    markdownPath: toPosixPath(relative(projectRoot, markdownPathAbs)),
+    manifestPath: toPosixPath(relative(projectRoot, manifestPathAbs)),
     charCount: source.text.length,
     excerpt: source.text.slice(0, EXCERPT_CHARS),
     ...(source.totalPages !== undefined ? { totalPages: source.totalPages } : {}),
@@ -108,7 +109,7 @@ async function readMaterialSource(
   const filename = input.filename || basename(safePath);
   const mimeType = input.mimeType || mimeFromFilename(filename);
   return extractBufferMaterial(buffer, {
-    source: relative(projectRoot, safePath),
+    source: toPosixPath(relative(projectRoot, safePath)),
     filename,
     mimeType,
   });

--- a/packages/core/src/materials/retrieve.ts
+++ b/packages/core/src/materials/retrieve.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { safeChildPath } from "../utils/path-safety.js";
+import { toPosixPath } from "../utils/posix-path.js";
 import type { MaterialAsset, MaterialPurpose } from "./ingest.js";
 
 export interface RetrieveMaterialsInput {
@@ -51,7 +52,8 @@ export async function retrieveMaterials(
       kind: asset.kind,
       purpose: asset.purpose,
       source: asset.source,
-      markdownPath: asset.markdownPath,
+      // Manifests written by older Windows builds may contain "\" separators.
+      markdownPath: toPosixPath(asset.markdownPath),
       score,
       excerpt: snippet.excerpt,
       charStart: snippet.charStart,

--- a/packages/core/src/pipeline/script-storyboard-runner.ts
+++ b/packages/core/src/pipeline/script-storyboard-runner.ts
@@ -20,6 +20,7 @@ import {
   type StoryboardCreationInput,
 } from "../agents/script-storyboard.js";
 import { safeChildPath } from "../utils/path-safety.js";
+import { toPosixPath } from "../utils/posix-path.js";
 
 export interface ScriptCreationRunOptions {
   readonly projectRoot: string;
@@ -175,8 +176,8 @@ export async function runScriptCreation(
   return {
     projectId,
     baseDir,
-    specPath: join(baseDir, "script-spec.md"),
-    scriptPath: join(baseDir, "script.md"),
+    specPath: relPath(baseDir, "script-spec.md"),
+    scriptPath: relPath(baseDir, "script.md"),
   };
 }
 
@@ -231,7 +232,7 @@ export async function runInteractiveFilmCreation(
     "Storyboard",
   ], packageMarkdown);
   const imagePrompts = extractStoryboardImagePrompts(storyboard);
-  const storyGraphPath = join("interactive-films", projectId, "story-graph.json");
+  const storyGraphPath = relPath("interactive-films", projectId, "story-graph.json");
 
   await writeProjectText(options.projectRoot, join(baseDir, "story-tree.md"), storyTree);
   await writeProjectText(options.projectRoot, join(baseDir, "flags.md"), flags);
@@ -279,14 +280,14 @@ export async function runInteractiveFilmCreation(
     projectId,
     baseDir,
     storyGraphPath,
-    specPath: join(baseDir, "interactive-spec.md"),
-    storyTreePath: join(baseDir, "story-tree.md"),
-    flagsPath: join(baseDir, "flags.md"),
-    scriptPath: join(baseDir, "script.md"),
-    storyboardPath: join(baseDir, "storyboard.md"),
-    imagePromptsPath: join(baseDir, "image-prompts.md"),
-    assetsManifestPath: join(baseDir, "assets.json"),
-    assetsDir: join(baseDir, "assets"),
+    specPath: relPath(baseDir, "interactive-spec.md"),
+    storyTreePath: relPath(baseDir, "story-tree.md"),
+    flagsPath: relPath(baseDir, "flags.md"),
+    scriptPath: relPath(baseDir, "script.md"),
+    storyboardPath: relPath(baseDir, "storyboard.md"),
+    imagePromptsPath: relPath(baseDir, "image-prompts.md"),
+    assetsManifestPath: relPath(baseDir, "assets.json"),
+    assetsDir: relPath(baseDir, "assets"),
   };
 }
 
@@ -343,11 +344,11 @@ export async function runStoryboardCreation(
   return {
     projectId,
     baseDir,
-    specPath: join(baseDir, "storyboard-spec.md"),
-    storyboardPath: join(baseDir, "storyboard.md"),
-    imagePromptsPath: join(baseDir, "image-prompts.md"),
-    assetsManifestPath: join(baseDir, "assets.json"),
-    assetsDir: join(baseDir, "assets"),
+    specPath: relPath(baseDir, "storyboard-spec.md"),
+    storyboardPath: relPath(baseDir, "storyboard.md"),
+    imagePromptsPath: relPath(baseDir, "image-prompts.md"),
+    assetsManifestPath: relPath(baseDir, "assets.json"),
+    assetsDir: relPath(baseDir, "assets"),
   };
 }
 
@@ -496,20 +497,20 @@ export function createStoryboardAssetsManifest(args: {
   readonly imagePrompts: string;
   readonly createdAt: string;
 }): StoryboardAssetsManifest {
-  const assetsDir = join(args.baseDir, "assets");
+  const assetsDir = relPath(args.baseDir, "assets");
   const prompts = parseStoryboardPromptLines(args.imagePrompts);
   return {
     version: 1,
     kind: "storyboard_assets",
     title: args.title,
     projectId: args.projectId,
-    baseDir: args.baseDir,
-    storyboardPath: args.storyboardPath,
-    imagePromptsPath: args.imagePromptsPath,
+    baseDir: toPosixPath(args.baseDir),
+    storyboardPath: toPosixPath(args.storyboardPath),
+    imagePromptsPath: toPosixPath(args.imagePromptsPath),
     assetsDir,
-    sourceDir: join(assetsDir, "source"),
-    generatedDir: join(assetsDir, "generated"),
-    selectedDir: join(assetsDir, "selected"),
+    sourceDir: relPath(assetsDir, "source"),
+    generatedDir: relPath(assetsDir, "generated"),
+    selectedDir: relPath(assetsDir, "selected"),
     createdAt: args.createdAt,
     assets: prompts.map((prompt, index) => {
       const shotId = `shot-${String(index + 1).padStart(3, "0")}`;
@@ -563,7 +564,12 @@ function normalizeOutputDir(value: string): string {
 
 function resolveProjectBaseDir(outDir: string, projectId: string): string {
   const outputDir = normalizeOutputDir(outDir);
-  return basename(outputDir) === projectId ? outputDir : join(outputDir, projectId);
+  return basename(outputDir) === projectId ? outputDir : relPath(outputDir, projectId);
+}
+
+// Project-relative path for results and manifests: always "/" separators.
+function relPath(...segments: string[]): string {
+  return toPosixPath(join(...segments));
 }
 
 function safeSegment(value: string): string {

--- a/packages/core/src/pipeline/short-fiction-runner.ts
+++ b/packages/core/src/pipeline/short-fiction-runner.ts
@@ -26,6 +26,7 @@ import {
 import { coverSecretKey, resolveCoverProviderPreset, type CoverProviderPreset } from "../llm/cover-providers.js";
 import { loadSecrets } from "../llm/secrets.js";
 import { safeChildPath } from "../utils/path-safety.js";
+import { toPosixPath as projectPath } from "../utils/posix-path.js";
 
 const SHORT_FICTION_DRAFT_COMPLETION_ATTEMPTS = 3;
 
@@ -869,10 +870,6 @@ function normalizeOutputDir(value: string): string {
   const normalized = projectPath(trimmed).replace(/^\/+/u, "").replace(/\/+$/u, "") || "shorts";
   safeChildPath("/", normalized);
   return normalized;
-}
-
-function projectPath(value: string): string {
-  return value.replace(/\\/gu, "/");
 }
 
 function boundedInteger(value: number | undefined, fallback: number, name: string, min: number, max: number): number {

--- a/packages/core/src/play/play-runner.ts
+++ b/packages/core/src/play/play-runner.ts
@@ -104,6 +104,8 @@ export interface PlayOpeningSeedResult {
 export class PlayRunner {
   private readonly store: PlayStore;
   private readonly db: PlayReducerDB;
+  private readonly ownsDb: boolean;
+  private dbClosed = false;
   private readonly actionInterpreter: PlayActionInterpreterLike;
   private readonly worldMutator: PlayWorldMutatorLike;
   private readonly sceneRenderer: PlaySceneRendererLike;
@@ -111,6 +113,7 @@ export class PlayRunner {
 
   constructor(private readonly options: PlayRunnerOptions) {
     this.store = options.store ?? new PlayStore(options.projectRoot);
+    this.ownsDb = !options.db;
     this.db = options.db ?? createPlayDB(this.store.runDir(options.worldId, options.runId));
     if (!options.ctx && (!options.agents?.actionInterpreter || !options.agents.worldMutator || !options.agents.sceneRenderer)) {
       throw new Error("PlayRunner requires ctx when default play agents are used.");
@@ -120,6 +123,18 @@ export class PlayRunner {
     this.worldMutator = options.agents?.worldMutator ?? new PlayWorldMutatorAgent(ctx!);
     this.sceneRenderer = options.agents?.sceneRenderer ?? new PlaySceneRendererAgent(ctx!);
     this.sceneReconciler = options.agents?.sceneReconciler ?? (ctx ? new PlaySceneReconcilerAgent(ctx) : null);
+  }
+
+  /**
+   * 关闭 runner 自己创建的数据库连接（外部传入的 db 由调用方负责关闭）。
+   * SQLite 文件句柄不关闭时 Windows 上无法删除 play.db；node:sqlite 的
+   * close 不允许二次调用，所以这里做幂等保护。
+   */
+  close(): void {
+    if (this.ownsDb && !this.dbClosed) {
+      this.dbClosed = true;
+      (this.db as { close?: () => void }).close?.();
+    }
   }
 
   async seedOpening(input: {

--- a/packages/core/src/utils/posix-path.ts
+++ b/packages/core/src/utils/posix-path.ts
@@ -1,0 +1,6 @@
+// Normalizes a project-relative path to "/" separators before it is persisted
+// into manifests, returned in pipeline results, or used as a URL — on Windows,
+// node:path join()/relative() produce "\" which those consumers must not see.
+export function toPosixPath(value: string): string {
+  return value.replace(/\\/gu, "/");
+}

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -75,6 +75,7 @@ import {
   listBuiltinPrompts,
   loadPromptPackPrompt,
   promptOverridePath,
+  toPosixPath,
   type ActionPayload,
   type ActionSource,
   type BuiltinPrompt,
@@ -722,7 +723,8 @@ async function toStudioPromptPackPrompt(root: string, prompt: BuiltinPrompt) {
     content: loaded.content,
     source: loaded.source,
     overridden: loaded.source === "project",
-    path: loaded.source === "project" ? relative(root, overridePath) : undefined,
+    // Windows 上 relative() 产生反斜杠，这个 path 会被前端展示/断言为 posix 相对路径
+    path: loaded.source === "project" ? toPosixPath(relative(root, overridePath)) : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

修复 master 上 Windows CI 长期失败的全部 9 个测试，三类根因各一个提交：

**1. 路径分隔符（7 个失败）** — `join()`/`relative()` 在 Windows 产生反斜杠，而这些"项目相对路径"会写进 manifest JSON、作为结果字段返回、被 Studio 当 URL 用：
- 新增共享工具 `toPosixPath`；`materials/ingest|retrieve`、`script-storyboard-runner` 所有返回/持久化的项目相对路径在源头归一化，纯文件系统操作的 join 不动
- `retrieve` 对旧版本在 Windows 写出的含 `\` 的 manifest 做兼容归一化
- `short-fiction-runner` 已有的局部同款 helper 改用共享实现
- 排查过 `graph-store` / `authoring-store` / `agent-tools`：join 均为文件系统绝对路径或已是 posix 拼接，无需修改

**2. play.db 文件句柄泄漏（1 个失败，同时是真实资源泄漏）** — `play_step`/`play_revise` 构造的 `PlayRunner` 在构造函数打开 play.db 且从不关闭；POSIX 允许删除打开中的文件所以一直没暴露，Windows 上 EBUSY。`PlayRunner` 新增幂等 `close()`（只关自己创建的 db），两个工具全部返回路径 finally 关闭。

**3. 测试夹具跨盘符（1 个失败）** — `relative(process.cwd(), root)` 在 CI 上 cwd（D:）与临时目录（C:）跨盘符时返回绝对路径，"拒绝相对路径"断言意图失效；改用字面相对路径。

## Test plan

- [x] macOS：core 全量 163 文件 / 1576 测试通过，typecheck 通过
- [x] 新增回归测试：posix-path 工具、PlayRunner close 所有权与幂等
- [x] 本 PR 的 windows-latest 三个 job 全部通过（run 28850293461），连同 ubuntu 三个 job 和 verify-pack 全绿 — 仓库 Windows CI 首次完整通过
