### PR TITLE
Add GLM 5.2 to the OpenRouter model picker

### DIFF
--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -57,6 +57,17 @@ describe("providers structural integrity", () => {
     expect(zhipu?.models.some((model) => model.id === "glm-4-flash" && model.enabled !== false)).toBe(true);
   });
 
+  it("OpenRouter exposes GLM 5.2 in the provider bank", () => {
+    const openrouter = getEndpoint("openrouter");
+    expect(openrouter?.models).toContainEqual({
+      id: "z-ai/glm-5.2",
+      maxOutput: 32_768,
+      contextWindowTokens: 1_048_576,
+      enabled: true,
+      releasedAt: "2026-06-16",
+    });
+  });
+
   it("A 组至少有 5 个核心 provider", () => {
     const ids = getAllEndpoints().map((p) => p.id);
     expect(ids).toContain("anthropic");

--- a/packages/core/src/llm/providers/endpoints/openrouter.ts
+++ b/packages/core/src/llm/providers/endpoints/openrouter.ts
@@ -26,6 +26,7 @@ export const OPENROUTER: InkosEndpoint = {
   writingTemperature: 1,
   models: [
     { id: "openrouter/auto", maxOutput: 4096, contextWindowTokens: 2000000, enabled: true },
+    { id: "z-ai/glm-5.2", maxOutput: 32768, contextWindowTokens: 1048576, enabled: true, releasedAt: "2026-06-16" },
     { id: "deepseek/deepseek-chat-v3.1", maxOutput: 4096, contextWindowTokens: 163840, releasedAt: "2025-08-21" },
     { id: "google/gemini-3.1-flash-image-preview", maxOutput: 65536, contextWindowTokens: 131072, releasedAt: "2026-02-26" },
     { id: "google/gemini-3-pro-image-preview", maxOutput: 32768, contextWindowTokens: 163840, releasedAt: "2025-11-20" },


### PR DESCRIPTION
## What changed

- add `z-ai/glm-5.2` to the built-in OpenRouter provider bank
- record its 32,768-token maximum output, 1,048,576-token context window, and release date
- add a regression test covering the exact provider-bank entry

## Why

The Studio model picker is populated from the built-in provider bank for configured non-custom services. GLM 5.2 was available through OpenRouter's live model API but absent from that bank, so it could not be selected from the built-in OpenRouter dropdown.

## Impact

Users with OpenRouter configured can select `z-ai/glm-5.2` directly in Studio without creating a custom service.

## Validation

- `pnpm --filter @actalk/inkos-core exec vitest run src/__tests__/providers-schema.test.ts src/__tests__/providers-lookup.test.ts` (32 tests)
- `pnpm --filter @actalk/inkos-studio exec vitest run src/api/server.test.ts src/pages/chat-page-state.test.ts` (148 tests)
- `pnpm typecheck`
- `pnpm build`
- verified in the Studio UI that the OpenRouter dropdown includes and selects `z-ai/glm-5.2`, with no console errors
