### PR TITLE
feat: add Requesty as a dedicated endpoint provider

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -75,7 +75,7 @@ This release continues the v1.5 direction: heavy actions are confirmable, comple
 
 **Runtime skills and research** — add reusable professional skills under `.inkos/skills/`, force them with `@skill-id`, or ask for web research to generate a sourced Markdown report.
 
-**Model setup** — Studio includes provider settings, model routing, cover-service settings, [keaiapi](https://keaiapi.com/) / OpenRouter aggregator entries, and custom OpenAI-compatible endpoints.
+**Model setup** — Studio includes provider settings, model routing, cover-service settings, [keaiapi](https://keaiapi.com/) / OpenRouter / [Requesty](https://requesty.ai/) aggregator entries, and custom OpenAI-compatible endpoints.
 
 <p align="center">
   <img src="assets/play-item-warcraft.png" width="420" alt="InkOS Play item image example">
@@ -158,7 +158,7 @@ inkos
 
 Open Studio, then go to **Model Settings**:
 
-1. Choose a service such as Google Gemini, Moonshot, MiniMax, DeepSeek, keaiapi, OpenRouter, or a custom endpoint.
+1. Choose a service such as Google Gemini, Moonshot, MiniMax, DeepSeek, keaiapi, OpenRouter, Requesty, or a custom endpoint.
 2. Paste the API key and test the connection.
 3. Pick an available model and save.
 4. Return to Studio Chat or your book page.
@@ -236,7 +236,7 @@ If a service test fails, first check that the service, model, and protocol match
 ### LLM Configuration Notes
 
 - **Studio / CLI config isolation**: Studio always uses the service page settings and `.inkos/secrets.json`; the CLI, daemon, and deployment environments support env overrides and one-off command flags.
-- **Provider bank capability table**: built-in baseUrl, protocol, models, and compatibility policies for 15 services — Google Gemini, Moonshot, MiniMax, Zhipu (GLM), Bailian (Alibaba Cloud Model Studio), DeepSeek, SiliconFlow, Volcengine, Tencent Hunyuan, Baidu ERNIE (Wenxin), iFlytek Spark, OpenRouter, keaiapi, Ollama, and CodingPlan.
+- **Provider bank capability table**: built-in baseUrl, protocol, models, and compatibility policies for 16 services — Google Gemini, Moonshot, MiniMax, Zhipu (GLM), Bailian (Alibaba Cloud Model Studio), DeepSeek, SiliconFlow, Volcengine, Tencent Hunyuan, Baidu ERNIE (Wenxin), iFlytek Spark, OpenRouter, Requesty, keaiapi, Ollama, and CodingPlan.
 - **Model ownership validation**: mismatches like `--service google --model kimi-k2.5` fail immediately, so requests are never sent to the wrong provider.
 - **Google Gemini compatibility fix**: AI Studio API keys work directly with the Gemini OpenAI-compatible endpoint; InkOS automatically disables the OpenAI `store` parameter Google does not support.
 - **MiniMax transport probing**: MiniMax / MiniMax CodingPlan use the official OpenAI-compatible `/v1` entry and automatically pick a working non-streaming transport, working around streams that report usage but return an empty body.

--- a/README.ja.md
+++ b/README.ja.md
@@ -75,7 +75,7 @@ v1.6.0 は、InkOS を開放世界 Play からさらにインタラクティブ�
 
 **Runtime Skill とリサーチ** — `.inkos/skills/` に専門 skill を追加し、`@skill-id` で強制使用できます。外部事実が必要な場合は出典付き Markdown リサーチレポートを生成できます。
 
-**モデル設定** — Studio はサービス設定、モデルルーティング、表紙サービス、[keaiapi](https://keaiapi.com/) / OpenRouter などのモデル集約入口、カスタム OpenAI-compatible エンドポイントに対応します。
+**モデル設定** — Studio はサービス設定、モデルルーティング、表紙サービス、[keaiapi](https://keaiapi.com/) / OpenRouter / [Requesty](https://requesty.ai/) などのモデル集約入口、カスタム OpenAI-compatible エンドポイントに対応します。
 
 <p align="center">
   <img src="assets/play-item-warcraft.png" width="420" alt="InkOS Play アイテム画像例">
@@ -123,7 +123,7 @@ inkos
 
 Studio を開き、**モデル設定**へ進みます：
 
-1. Google Gemini、Moonshot、MiniMax、DeepSeek、keaiapi、OpenRouter、またはカスタムエンドポイントを選択。
+1. Google Gemini、Moonshot、MiniMax、DeepSeek、keaiapi、OpenRouter、Requesty、またはカスタムエンドポイントを選択。
 2. API Key を貼り付けて接続をテスト。
 3. 利用可能なモデルを選んで保存。
 4. Studio Chat または書籍ページに戻って創作を開始。

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ InkOS Play 发布和 Studio 体验升级：你可以用一句自然语言创建�
 
 **Studio Chat** — 普通聊天、建书、短篇、封面、互动世界都走同一套 action surface。重动作先确认，生成物可预览，可通过聊天修改章节、封面提示词、世界状态和持久化文本产物。
 
-**模型配置** — Studio 内置多服务配置、模型路由和封面服务配置；也支持 [kkaiapi](https://kkaiapi.com/) / OpenRouter 等全球主流模型聚合入口，以及自定义 OpenAI-compatible 服务。
+**模型配置** — Studio 内置多服务配置、模型路由和封面服务配置；也支持 [kkaiapi](https://kkaiapi.com/) / OpenRouter / [Requesty](https://requesty.ai/) 等全球主流模型聚合入口，以及自定义 OpenAI-compatible 服务。
 
 
 
@@ -278,7 +278,7 @@ inkos doctor
 ### LLM 配置更新
 
 - **Studio / CLI 配置隔离**：Studio 固定使用服务页配置和 `.inkos/secrets.json`；CLI、daemon、部署环境支持 env 覆盖和一次性命令参数。
-- **Provider bank 能力表**：内置 Google Gemini、Moonshot、MiniMax、智谱、百炼、DeepSeek、硅基流动、火山、腾讯混元、文心、讯飞星火、OpenRouter、kkaiapi、Ollama、CodingPlan 等服务的 baseUrl、协议、模型和兼容策略。
+- **Provider bank 能力表**：内置 Google Gemini、Moonshot、MiniMax、智谱、百炼、DeepSeek、硅基流动、火山、腾讯混元、文心、讯飞星火、OpenRouter、Requesty、kkaiapi、Ollama、CodingPlan 等服务的 baseUrl、协议、模型和兼容策略。
 - **模型归属校验**：`--service google --model kimi-k2.5` 这类错配会直接报错，避免把请求发到错误服务商。
 - **Google Gemini 兼容修复**：AI Studio API Key 可直接用于 Gemini OpenAI-compatible endpoint，InkOS 会自动禁用 Google 不支持的 OpenAI `store` 参数。
 - **MiniMax transport 探测**：MiniMax / MiniMax CodingPlan 使用官方 OpenAI-compatible `/v1` 入口，并自动使用可工作的非流式 transport，规避流式 usage 正常但正文为空的问题。

--- a/packages/core/src/__tests__/providers-group.test.ts
+++ b/packages/core/src/__tests__/providers-group.test.ts
@@ -18,7 +18,7 @@ describe("InkosEndpoint.group", () => {
       "volcengine", "wenxin", "xiaomimimo", "zeroone", "zhipu",
     ].sort());
     expect(byGroup("aggregator")).toEqual([
-      "kkaiapi", "newapi", "openrouter", "siliconcloud",
+      "kkaiapi", "newapi", "openrouter", "requesty", "siliconcloud",
     ].sort());
     expect(byGroup("local")).toEqual(["githubCopilot", "ollama"].sort());
     expect(byGroup("codingPlan")).toEqual([

--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -108,9 +108,9 @@ describe("providers structural integrity", () => {
     expect(ids).not.toContain("higress");
   });
 
-  it("B4：海外/本地/自定义/聚合/GH 全部收录（8 个）", () => {
+  it("B4：海外/本地/自定义/聚合/GH 全部收录（含 Requesty 聚合入口）", () => {
     const ids = getAllEndpoints().map((p) => p.id);
-    for (const id of ["ollama", "openrouter", "custom", "mistral", "xai", "newapi", "githubCopilot", "kkaiapi"]) {
+    for (const id of ["ollama", "openrouter", "requesty", "custom", "mistral", "xai", "newapi", "githubCopilot", "kkaiapi"]) {
       expect(ids).toContain(id);
     }
   });
@@ -120,9 +120,15 @@ describe("providers structural integrity", () => {
     expect(getEndpoint("newapi")?.baseUrl).toBe("");
   });
 
-  it("B4：总 provider 数 = 30（不含 CodingPlan 分组，R5 删 qwen / higress 且精简聚合入口后）", () => {
+  it("B4：Requesty 走 OpenAI 兼容路由，固定 baseUrl", () => {
+    expect(getEndpoint("requesty")?.api).toBe("openai-responses");
+    expect(getEndpoint("requesty")?.baseUrl).toBe("https://router.requesty.ai/v1");
+    expect(getEndpoint("requesty")?.group).toBe("aggregator");
+  });
+
+  it("B4：总 provider 数 = 31（30 base + Requesty 聚合入口）", () => {
     const nonCoding = getAllEndpoints().filter((p) => p.group !== "codingPlan");
-    expect(nonCoding.length).toBe(30);
+    expect(nonCoding.length).toBe(31);
   });
 
   it("B6：CodingPlan 8 个 provider 全部收录", () => {
@@ -136,8 +142,8 @@ describe("providers structural integrity", () => {
     }
   });
 
-  it("B6：总 provider 数 = 38 (30 base + 8 CodingPlan)", () => {
-    expect(getAllEndpoints().length).toBe(38);
+  it("B6：总 provider 数 = 39 (31 base + 8 CodingPlan)", () => {
+    expect(getAllEndpoints().length).toBe(39);
   });
 
   it("B6：CodingPlan provider 都走 anthropic-messages", () => {

--- a/packages/core/src/llm/providers/endpoints/requesty.ts
+++ b/packages/core/src/llm/providers/endpoints/requesty.ts
@@ -1,0 +1,48 @@
+/**
+ * Requesty
+ *
+ * - 官网：https://requesty.ai/
+ * - 控制台 / API key：https://app.requesty.ai/api-keys
+ * - 模型广场：https://app.requesty.ai/router/list
+ * - API 文档：https://docs.requesty.ai/
+ * - 模型列表 JSON：https://router.requesty.ai/v1/models
+ *
+ * OpenAI 兼容的 LLM 路由/网关（与 OpenRouter 同类）。统一入口聚合 Anthropic /
+ * OpenAI / Google / DeepSeek / Meta 等多家上游，模型命名沿用 provider/model 形式
+ * （与 OpenRouter 相同）。600+ 模型，bank 只列最常用的；完整清单走用户侧 live /models probe。
+ */
+import type { InkosEndpoint } from "../types.js";
+
+export const REQUESTY: InkosEndpoint = {
+  id: "requesty",
+  label: "Requesty",
+  group: "aggregator",
+  api: "openai-responses",
+  baseUrl: "https://router.requesty.ai/v1",
+  // openai/gpt-4o-mini 是长期稳定的低成本入口，用作 apikey 两步验证的 hello 模型；
+  // 具体模型 id 会随上游增删变化，所以 Requesty 走动态 /models 清单（见 effective-llm-config）。
+  checkModel: "openai/gpt-4o-mini",
+  temperatureRange: [0, 2],
+  defaultTemperature: 0.7,
+  writingTemperature: 1,
+  models: [
+    { id: "deepseek/deepseek-chat", maxOutput: 8192, contextWindowTokens: 163840 },
+    { id: "deepseek/deepseek-reasoner", maxOutput: 8192, contextWindowTokens: 163840 },
+    { id: "google/gemini-2.5-pro", maxOutput: 65536, contextWindowTokens: 1048576 },
+    { id: "google/gemini-2.5-flash", maxOutput: 65535, contextWindowTokens: 1048576 },
+    { id: "openai/o3", maxOutput: 100000, contextWindowTokens: 200000, releasedAt: "2025-04-17" },
+    { id: "openai/o4-mini", maxOutput: 100000, contextWindowTokens: 200000, releasedAt: "2025-04-17" },
+    { id: "openai/gpt-4.1", maxOutput: 32768, contextWindowTokens: 1047576, releasedAt: "2025-04-14" },
+    { id: "openai/gpt-4.1-mini", maxOutput: 32768, contextWindowTokens: 1047576, releasedAt: "2025-04-14" },
+    { id: "openai/gpt-4.1-nano", maxOutput: 32768, contextWindowTokens: 1047576, releasedAt: "2025-04-14" },
+    { id: "openai/gpt-4o-mini", maxOutput: 16385, contextWindowTokens: 128000 },
+    { id: "openai/gpt-4o", maxOutput: 4096, contextWindowTokens: 128000 },
+    { id: "anthropic/claude-opus-4.5", maxOutput: 64000, contextWindowTokens: 200000, releasedAt: "2025-11-24" },
+    { id: "anthropic/claude-sonnet-4-5", maxOutput: 64000, contextWindowTokens: 200000, releasedAt: "2025-09-30" },
+    { id: "anthropic/claude-sonnet-4", maxOutput: 64000, contextWindowTokens: 200000, releasedAt: "2025-05-23" },
+    { id: "anthropic/claude-opus-4", maxOutput: 32000, contextWindowTokens: 200000, releasedAt: "2025-05-23" },
+    { id: "anthropic/claude-3.7-sonnet", maxOutput: 8192, contextWindowTokens: 200000, releasedAt: "2025-02-24" },
+    { id: "anthropic/claude-3.5-sonnet", maxOutput: 8192, contextWindowTokens: 200000, releasedAt: "2024-06-20" },
+    { id: "anthropic/claude-3.5-haiku", maxOutput: 8192, contextWindowTokens: 200000, releasedAt: "2024-11-05" },
+  ],
+};

--- a/packages/core/src/llm/providers/index.ts
+++ b/packages/core/src/llm/providers/index.ts
@@ -26,6 +26,7 @@ import { AI360 } from "./endpoints/ai360.js";
 // B4
 import { OLLAMA } from "./endpoints/ollama.js";
 import { OPENROUTER } from "./endpoints/openrouter.js";
+import { REQUESTY } from "./endpoints/requesty.js";
 import { CUSTOM } from "./endpoints/custom.js";
 import { MISTRAL } from "./endpoints/mistral.js";
 import { XAI } from "./endpoints/xai.js";
@@ -53,7 +54,7 @@ const ALL_PROVIDERS: readonly InkosEndpoint[] = [
   MOONSHOT, ZHIPU, SILICONCLOUD, BAILIAN, VOLCENGINE, HUNYUAN, BAICHUAN, STEPFUN, WENXIN,
   SPARK, SENSENOVA, TENCENTCLOUD, XIAOMI_MIMO, LONGCAT, INTERNLM,
   ZEROONE, AI360,
-  OLLAMA, OPENROUTER, CUSTOM, MISTRAL, XAI, NEWAPI, GITHUB_COPILOT, KKAIAPI,
+  OLLAMA, OPENROUTER, REQUESTY, CUSTOM, MISTRAL, XAI, NEWAPI, GITHUB_COPILOT, KKAIAPI,
   // B6 CodingPlan（8 个）
   KIMI_CODING_PLAN, KIMI_CODE, MINIMAX_CODING_PLAN, BAILIAN_CODING_PLAN, GLM_CODING_PLAN, VOLCENGINE_CODING_PLAN, OPENCODE_CODING_PLAN, ASTRON_CODING_PLAN,
 ];

--- a/packages/core/src/llm/providers/lookup.ts
+++ b/packages/core/src/llm/providers/lookup.ts
@@ -9,7 +9,7 @@ const PROVIDER_PRIORITY: readonly string[] = [
   "anthropic", "openai", "google", "deepseek", "bailian", "moonshot", "kimicode",
   "zhipu", "minimax", "xai",
   "siliconcloud",
-  "openrouter", "aihubmix", "novita",
+  "openrouter", "requesty", "aihubmix", "novita",
 ];
 
 /**

--- a/packages/core/src/utils/effective-llm-config.ts
+++ b/packages/core/src/utils/effective-llm-config.ts
@@ -469,6 +469,7 @@ function modelBelongsToService(service: string, model: string): boolean {
  * 所以用户显式配置的模型 id 直接透传，不做 bank 白名单校验（issue #300）：
  * - ollama：本地装了什么模型就有什么模型
  * - openrouter：聚合 350+ 上游模型，上游随时增删，bank 只列常用子集
+ * - requesty：聚合 600+ 上游模型（OpenAI 兼容路由），上游随时增删，bank 只列常用子集
  * - newapi：自建中转网关，模型清单由部署方自定义，bank 为空
  * - kkaiapi：多家大模型的 OpenAI 兼容中转站，上游清单随时变化
  * - ppio：聚合平台，每周都有新模型 id，bank 只维护主流子集
@@ -477,6 +478,7 @@ function modelBelongsToService(service: string, model: string): boolean {
 const SERVICES_WITH_DYNAMIC_MODELS: ReadonlySet<string> = new Set([
   "ollama",
   "openrouter",
+  "requesty",
   "newapi",
   "kkaiapi",
   "ppio",

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -98,7 +98,7 @@ const endpointIdsByGroup = {
     "minimax", "moonshot", "sensenova", "spark", "stepfun", "tencentcloud",
     "volcengine", "wenxin", "xiaomimimo", "zeroone", "zhipu",
   ],
-  aggregator: ["kkaiapi", "openrouter", "newapi", "siliconcloud"],
+  aggregator: ["kkaiapi", "openrouter", "requesty", "newapi", "siliconcloud"],
   local: ["githubCopilot", "ollama"],
   codingPlan: [
     "astronCodingPlan", "bailianCodingPlan", "glmCodingPlan", "kimiCodingPlan", "kimicode",
@@ -1004,11 +1004,11 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { services: Array<{ service: string; group?: string; connected: boolean }> };
     const bank = body.services.filter((s) => !s.service.startsWith("custom"));
-    expect(bank.length).toBe(37);
+    expect(bank.length).toBe(38);
     expect(bank.every((s) => typeof s.group === "string")).toBe(true);
     expect(bank.filter((s) => s.group === "overseas")).toHaveLength(5);
     expect(bank.filter((s) => s.group === "china")).toHaveLength(18);
-    expect(bank.filter((s) => s.group === "aggregator")).toHaveLength(4);
+    expect(bank.filter((s) => s.group === "aggregator")).toHaveLength(5);
     expect(bank.filter((s) => s.group === "local")).toHaveLength(2);
     expect(bank.filter((s) => s.group === "codingPlan")).toHaveLength(8);
     expect(bank.filter((s) => s.group === "aggregator").map((s) => s.service)[0]).toBe("kkaiapi");

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -226,7 +226,7 @@ function compareServiceListItems(
   left: { readonly service: string },
   right: { readonly service: string },
 ): number {
-  const priority = ["kkaiapi", "openrouter", "newapi", "siliconcloud"];
+  const priority = ["kkaiapi", "openrouter", "requesty", "newapi", "siliconcloud"];
   const leftPriority = priority.indexOf(left.service);
   const rightPriority = priority.indexOf(right.service);
   if (leftPriority !== -1 || rightPriority !== -1) {

--- a/packages/studio/src/components/ServiceQuickLinks.tsx
+++ b/packages/studio/src/components/ServiceQuickLinks.tsx
@@ -27,6 +27,11 @@ const SERVICE_QUICK_LINKS: Record<string, ReadonlyArray<{ zh: string; en: string
     { zh: "模型", en: "Models", href: "https://openrouter.ai/models" },
     { zh: "文档", en: "Docs", href: "https://openrouter.ai/docs/api-reference/overview" },
   ],
+  requesty: [
+    { zh: "API Keys", en: "API Keys", href: "https://app.requesty.ai/api-keys" },
+    { zh: "模型", en: "Models", href: "https://app.requesty.ai/router/list" },
+    { zh: "文档", en: "Docs", href: "https://docs.requesty.ai/" },
+  ],
 };
 
 export function getServiceQuickLinks(serviceId: string): ReadonlyArray<ServiceQuickLink> {


### PR DESCRIPTION
Adds Requesty as a dedicated endpoint provider, mirroring the existing OpenRouter endpoint provider. Requesty is an OpenAI-compatible LLM gateway that uses the same `provider/model` naming convention as OpenRouter (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`).

Changes:
- `packages/core/src/llm/providers/endpoints/requesty.ts`: new endpoint (id `requesty`, `baseUrl https://router.requesty.ai/v1`, `checkModel openai/gpt-4o-mini`, `provider/model` model list). Wired on the generic OpenAI-compatible path (falls through to the default `openai` piProvider, OpenRouter only gets a special branch because pi-ai ships an openrouter-specific provider).
- Registered in `ALL_PROVIDERS` (`providers/index.ts`) and `PROVIDER_PRIORITY` (`lookup.ts`) right after openrouter; added to `SERVICES_WITH_DYNAMIC_MODELS` so the full model list is fetched dynamically.
- Studio: aggregator sort priority (`api/server.ts`) + Requesty quick links (`ServiceQuickLinks.tsx`, api-keys / router list / docs).
- README (zh/en/ja): Requesty added to the provider/aggregator lists and the capability table.
- Tests updated to match (`providers-group`, `providers-schema` with a Requesty base-URL assertion, `server.test`).

Testing: `@actalk/inkos-core` typecheck clean; core tests 1659/1659 pass (including the updated provider tests). Live-tested against the real endpoint: a `POST /v1/chat/completions` to `https://router.requesty.ai/v1` with `openai/gpt-4o-mini` and the `HTTP-Referer`/`X-Title` headers returned successfully. (The pre-existing `packages/cli` and `packages/studio` typecheck errors are present on clean `master` and unrelated to this change, they stem from unbuilt core exports.)

Docs: https://requesty.ai · https://docs.requesty.ai · https://app.requesty.ai/api-keys · https://app.requesty.ai/router/list

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

