### PR TITLE
feat(core): add DashScope (通义万相) cover image generation provider

### DIFF
--- a/packages/core/src/__tests__/dashscope-cover.test.ts
+++ b/packages/core/src/__tests__/dashscope-cover.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { resolveCoverProviderPreset, COVER_PROVIDER_PRESETS, type CoverProviderId } from "../llm/cover-providers.js";
+
+describe("DashScope cover provider preset", () => {
+  it("is included in COVER_PROVIDER_PRESETS", () => {
+    const preset = COVER_PROVIDER_PRESETS.find((p) => p.service === "dashscope");
+    expect(preset).toBeDefined();
+    expect(preset!.label).toContain("DashScope");
+    expect(preset!.api).toBe("dashscope");
+    expect(preset!.defaultModel).toBe("wan2.6-t2i");
+    expect(preset!.models).toContain("wan2.6-t2i");
+    expect(preset!.baseUrl).toContain("dashscope.aliyuncs.com");
+  });
+
+  it("resolveCoverProviderPreset returns DashScope preset", () => {
+    const preset = resolveCoverProviderPreset("dashscope");
+    expect(preset).toBeDefined();
+    expect(preset!.service).toBe("dashscope");
+    expect(preset!.api).toBe("dashscope");
+  });
+
+  it("resolveCoverProviderPreset returns undefined for unknown service", () => {
+    const preset = resolveCoverProviderPreset("nonexistent");
+    expect(preset).toBeUndefined();
+  });
+});
+
+describe("resolveCoverGenerationRequest with DashScope", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("detects DashScope URL and sets api to dashscope", async () => {
+    vi.stubEnv("INKOS_COVER_BASE_URL", "https://dashscope.aliyuncs.com/api/v1");
+    vi.stubEnv("INKOS_COVER_MODEL", "wan2.6-t2i");
+    vi.stubEnv("INKOS_COVER_API_KEY", "test-key");
+
+    const { resolveCoverGenerationRequest } = await import("../pipeline/short-fiction-runner.js");
+    const request = await resolveCoverGenerationRequest({ root: "/tmp/test" });
+
+    expect(request.api).toBe("dashscope");
+    expect(request.model).toBe("wan2.6-t2i");
+    expect(request.baseUrl).toContain("dashscope.aliyuncs.com");
+  });
+
+  it("falls back to wan2.6-t2i as default model for DashScope", async () => {
+    vi.stubEnv("INKOS_COVER_BASE_URL", "https://dashscope.aliyuncs.com/api/v1");
+    vi.stubEnv("INKOS_COVER_API_KEY", "test-key");
+    // Do not set INKOS_COVER_MODEL — should default
+
+    const { resolveCoverGenerationRequest } = await import("../pipeline/short-fiction-runner.js");
+    const request = await resolveCoverGenerationRequest({ root: "/tmp/test" });
+
+    expect(request.api).toBe("dashscope");
+    expect(request.model).toBe("wan2.6-t2i");
+  });
+});
+
+describe("generateImageFromPrompt DashScope routing", () => {
+  it("routes dashscope api to generateDashScopeCover", async () => {
+    const mockBuffer = Buffer.from("fake-image-data");
+
+    // Mock global fetch
+    const fetchMock = vi.fn();
+    // First call: POST to DashScope API returns image URL
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({
+        output: {
+          choices: [{
+            message: {
+              content: [
+                { type: "text", text: "generated" },
+                { type: "image", image: "https://example.com/image.png" },
+              ],
+            },
+          }],
+        },
+      })),
+    });
+    // Second call: GET image URL returns binary
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Map([["content-type", "image/png"]]),
+      arrayBuffer: () => Promise.resolve(mockBuffer.buffer),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { generateImageFromPrompt } = await import("../pipeline/short-fiction-runner.js");
+    const result = await generateImageFromPrompt(
+      {
+        api: "dashscope",
+        baseUrl: "https://dashscope.aliyuncs.com/api/v1",
+        model: "wan2.6-t2i",
+        apiKey: "test-key",
+      },
+      "a beautiful sunset over mountains",
+      "1024x1360",
+    );
+
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    expect(result.extension).toBe("png");
+
+    // Verify the POST request was made to the correct endpoint
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-key",
+        }),
+      }),
+    );
+
+    // Verify the body format
+    const postCall = fetchMock.mock.calls[0];
+    const body = JSON.parse(postCall[1].body);
+    expect(body.model).toBe("wan2.6-t2i");
+    expect(body.input.messages[0].content[0].text).toBe("a beautiful sunset over mountains");
+    expect(body.parameters.size).toBe("1024*1360");
+    expect(body.parameters.n).toBe(1);
+    expect(body.parameters.watermark).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on DashScope HTTP error", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { generateImageFromPrompt } = await import("../pipeline/short-fiction-runner.js");
+    await expect(
+      generateImageFromPrompt(
+        {
+          api: "dashscope",
+          baseUrl: "https://dashscope.aliyuncs.com/api/v1",
+          model: "wan2.6-t2i",
+          apiKey: "bad-key",
+        },
+        "test prompt",
+        "1024x1360",
+      ),
+    ).rejects.toThrow("DashScope image generation failed: HTTP 401");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when DashScope response has no image", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({
+        output: {
+          choices: [{
+            message: {
+              content: [{ type: "text", text: "no image here" }],
+            },
+          }],
+        },
+      })),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { generateImageFromPrompt } = await import("../pipeline/short-fiction-runner.js");
+    await expect(
+      generateImageFromPrompt(
+        {
+          api: "dashscope",
+          baseUrl: "https://dashscope.aliyuncs.com/api/v1",
+          model: "wan2.6-t2i",
+          apiKey: "test-key",
+        },
+        "test prompt",
+        "1024x1360",
+      ),
+    ).rejects.toThrow("did not include image URL");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/core/src/llm/cover-providers.ts
+++ b/packages/core/src/llm/cover-providers.ts
@@ -1,10 +1,10 @@
-export type CoverProviderId = "kkaiapi" | "openai" | "google";
+export type CoverProviderId = "kkaiapi" | "openai" | "google" | "dashscope";
 
 export interface CoverProviderPreset {
   readonly service: CoverProviderId;
   readonly label: string;
   readonly baseUrl: string;
-  readonly api: "responses" | "images" | "gemini";
+  readonly api: "responses" | "images" | "gemini" | "dashscope";
   readonly defaultModel: string;
   readonly models: readonly string[];
 }
@@ -33,6 +33,14 @@ export const COVER_PROVIDER_PRESETS: readonly CoverProviderPreset[] = [
     api: "gemini",
     defaultModel: "gemini-3.1-flash-image-preview",
     models: ["gemini-3.1-flash-image-preview", "gemini-2.5-flash-image"],
+  },
+  {
+    service: "dashscope",
+    label: "通义万相 (DashScope)",
+    baseUrl: "https://dashscope.aliyuncs.com/api/v1",
+    api: "dashscope",
+    defaultModel: "wan2.6-t2i",
+    models: ["wan2.6-t2i", "wan2.5-t2i", "wan2.1-t2i-plus", "wan2.1-t2i-turbo", "wanx-v1"],
   },
 ];
 

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -11,7 +11,7 @@ const LLMServiceEntrySchema = z.object({
 });
 
 const LLMCoverConfigSchema = z.object({
-  service: z.enum(["kkaiapi", "openai", "google"]),
+  service: z.enum(["kkaiapi", "openai", "google", "dashscope"]),
   model: z.string().min(1),
 }).optional();
 

--- a/packages/core/src/pipeline/short-fiction-runner.ts
+++ b/packages/core/src/pipeline/short-fiction-runner.ts
@@ -573,6 +573,9 @@ export async function generateImageFromPrompt(
     const payload = await generateGeminiCover(request, prompt);
     return { buffer: Buffer.from(payload.base64, "base64"), extension: payload.extension };
   }
+  if (request.api === "dashscope") {
+    return generateDashScopeCover(request, prompt, size);
+  }
   if (request.api === "images") {
     return generateImagesCover(request, prompt, size);
   }
@@ -629,11 +632,12 @@ export async function resolveCoverGenerationRequest(input: {
     const baseUrl = input.coverBaseUrl || process.env.INKOS_COVER_BASE_URL || endpoint
       .replace(/\/responses\/?$/u, "")
       .replace(/\/images\/generations\/?$/u, "");
+    const isDashScope = baseUrl.includes("dashscope.aliyuncs.com");
     return {
-      api: endpoint.includes("/responses") ? "responses" : "images",
+      api: isDashScope ? "dashscope" : endpoint.includes("/responses") ? "responses" : "images",
       baseUrl,
       endpoint,
-      model: input.coverModel || process.env.INKOS_COVER_MODEL || "gpt-image-2",
+      model: input.coverModel || process.env.INKOS_COVER_MODEL || (isDashScope ? "wan2.6-t2i" : "gpt-image-2"),
       apiKey: resolveCoverApiKey(input.coverApiKeyEnv || "INKOS_COVER_API_KEY"),
     };
   }
@@ -747,6 +751,71 @@ export function extractImagesGenerationImage(payload: unknown): (
   }
 
   return undefined;
+}
+
+async function generateDashScopeCover(
+  request: ShortFictionCoverRequest,
+  prompt: string,
+  size: string,
+): Promise<{ readonly buffer: Buffer; readonly extension: "png" | "jpg" }> {
+  const baseUrl = request.baseUrl.replace(/\/+$/u, "").replace(/\/images\/generations\/?$/u, "");
+  const endpoint = `${baseUrl}/services/aigc/multimodal-generation/generation`;
+  const [width, height] = size.split("x").map(Number);
+  const dashSize = `${width ?? 1024}*${height ?? 1360}`;
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${request.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: request.model,
+      input: {
+        messages: [
+          {
+            role: "user",
+            content: [{ text: prompt }],
+          },
+        ],
+      },
+      parameters: {
+        n: 1,
+        size: dashSize,
+        watermark: false,
+      },
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`DashScope image generation failed: HTTP ${response.status} ${text.slice(0, 500)}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`DashScope image generation returned non-JSON: ${String(error)}`);
+  }
+
+  const output = (payload as { output?: { choices?: Array<{ message?: { content?: Array<{ image?: string; type?: string }> } }> } }).output;
+  const choices = output?.choices;
+  if (!choices?.length) {
+    throw new Error("DashScope image generation response did not include choices.");
+  }
+
+  const content = choices[0]?.message?.content;
+  if (!content?.length) {
+    throw new Error("DashScope image generation response did not include content.");
+  }
+
+  const imageUrl = content.find((c) => c.type === "image")?.image;
+  if (!imageUrl) {
+    throw new Error("DashScope image generation response did not include image URL.");
+  }
+
+  return downloadGeneratedCoverImage(imageUrl, request.apiKey);
 }
 
 async function downloadGeneratedCoverImage(


### PR DESCRIPTION
Add DashScope/通义万相 as a fourth cover image generation option alongside kkaiapi, OpenAI, and Google Gemini. Supports models: wan2.6-t2i, wan2.5-t2i, wan2.1-t2i-plus, wan2.1-t2i-turbo, wanx-v1.

这段PR可能写的很烂，但真心建议开发组把几个国产生图模型都接入一下
- Add "dashscope" to CoverProviderId union and api type
- Add DashScope preset with correct API endpoint
- Add generateDashScopeCover() using multimodal-generation endpoint
- Auto-detect DashScope URLs in resolveCoverGenerationRequest()
- Add Zod schema validation for "dashscope" service
- Add unit tests (8 passing)

## Summary
<!-- 1-3 bullet points: what changed and why -->

-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation (optional)
<!-- Why this change is needed. Link issues if applicable. Closes #xxx -->

## Changes
<!-- File-level change list: what each file does -->

| File | Change |
|------|--------|
| | |

## Usage (optional)
<!-- Code snippets, CLI examples, or config samples showing how to use the new feature -->

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (all existing + new tests)
- [ ] Manual verification: <!-- describe manual test steps -->

## Breaking changes (optional)
<!-- List any breaking changes to public API, CLI flags, config format, etc. -->
