### PR TITLE
feat: add OpenAI Codex OAuth, GPT-5.6 models, and cover generation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -161,12 +161,14 @@ inkos
 
 Open Studio, then go to **Model Settings**:
 
-1. Choose a service such as Google Gemini, Moonshot, MiniMax, DeepSeek, kkaiapi, OpenRouter, or a custom endpoint.
+1. Choose a service such as OpenAI Codex (ChatGPT), Google Gemini, Moonshot, MiniMax, DeepSeek, kkaiapi, OpenRouter, or a custom endpoint.
 2. Paste the API key and test the connection.
 3. Pick an available model and save.
 4. Return to Studio Chat or your book page.
 
 Studio uses project service settings and `.inkos/secrets.json`. It may show env-detection hints, but env files do not override the Studio-selected service/model/base URL/API key.
+
+OpenAI Codex does not require an API key. Select **Sign in with ChatGPT** on its service page; InkOS stores and refreshes the OAuth credentials. Its model picker prefers the signed-in account's live Codex catalog and retains GPT-5.6 fallback entries when discovery is temporarily unavailable. Studio, CLI, and the daemon share these project credentials.
 
 MiniMax uses the official OpenAI-compatible `/v1/chat/completions` endpoint. InkOS disables returned thinking by default for `MiniMax-M3*`; M2.x thinking cannot be disabled by the upstream service.
 
@@ -297,7 +299,7 @@ To generate only a cover for an existing title or synopsis, do not rerun the sho
 Generate a short-fiction cover for "The Divorce Papers He Regretted", modern city, high-drama reversal.
 ```
 
-The cover tool writes `covers/<title>/cover-prompt.md` and `covers/<title>/cover.png`. If no cover provider is configured yet, set the cover provider and API key in Studio model settings first.
+The cover tool writes `covers/<title>/cover-prompt.md` and `covers/<title>/cover.png`. If no cover provider is configured yet, set one in Studio model settings. Choosing OpenAI Codex reuses the ChatGPT OAuth login and does not require a separate API key.
 
 After generation, you can keep editing the cover prompt through chat, for example: "move the character closer, make the title text bigger, and give her a colder smile." InkOS will pass the revised direction as `coverPrompt`, rewrite `cover-prompt.md`, and regenerate the cover without rewriting the story.
 

--- a/README.en.md
+++ b/README.en.md
@@ -42,7 +42,7 @@ InkOS Studio already supports Moonshot (Kimi). Get an API key from the Kimi Open
 
 InkOS 1.7 brings cross-language delivery, long-form forecasting, and continuous collaboration into the same Agent workbench. Translate complete works, compare several non-canonical futures, keep chatting while production runs in the background, or ask Chat to read references, import an existing manuscript, adjust prompts, revise chapters, and safely recover the creative state.
 
-- **Model setup** — Studio includes provider settings, model routing, cover-service settings, [kkaiapi](https://en.kkaiapi.com/) / OpenRouter aggregator entries, and custom OpenAI-compatible endpoints.
+- **Model setup** — Studio includes provider settings, model routing, ChatGPT OAuth for OpenAI Codex, cover-service settings, [kkaiapi](https://en.kkaiapi.com/) / OpenRouter aggregator entries, and custom OpenAI-compatible endpoints.
 - **Narrative forecasts**: Studio Chat and the CLI can create, re-check, and select 2-5 isolated futures from current canon, comparing chapter beats, character decisions, projected changes, risks, and author-intent alignment. Selecting one saves a plan only; it does not pre-emptively alter prose, foundations, or story state.
 - **Complete translation workbench**: import EPUB, text-based PDF, TXT, and Markdown; translate by chapter and semantic segment; maintain a glossary, generate side-by-side review reports, and export TXT, Markdown, or EPUB. Studio, Chat, and `inkos translate init / run / export` share the same capability.
 - **Native cross-language creation**: short fiction, scripts, storyboards, and interactive-film pipelines now include English-native prompt paths, with matching Studio copy and CLI language fallback rather than a translation-only menu.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ inkos
 3. 选择可用模型，保存配置。
 4. 回到书籍页面开始写作。
 
-OpenAI Codex 不需要 API Key：在服务详情页点击「使用 ChatGPT 登录」，浏览器授权成功后，InkOS 会保存 OAuth 凭据并在过期时自动刷新。Studio、CLI 和 daemon 共用这份项目凭据。
+OpenAI Codex 不需要 API Key：在服务详情页点击「使用 ChatGPT 登录」，浏览器授权成功后，InkOS 会保存并自动刷新 OAuth 凭据。模型列表会优先读取当前 ChatGPT 账号的 Codex 后端目录，并在目录暂时不可用时保留 GPT-5.6 兜底项；Studio、CLI 和 daemon 共用这份项目凭据。
 
 Studio 运行时只使用：
 
@@ -337,7 +337,7 @@ inkos short run \
 给《她签下离婚协议那天，他悔疯了》生成一张短篇封面，偏现代都市、强反转。
 ```
 
-封面工具会独立生成 `covers/<标题>/cover-prompt.md` 和 `covers/<标题>/cover.png`。如果还没有配置封面服务，先在 Studio 的模型配置里设置封面服务和 API Key。
+封面工具会独立生成 `covers/<标题>/cover-prompt.md` 和 `covers/<标题>/cover.png`。如果还没有配置封面服务，先在 Studio 的模型配置里设置封面服务；选择 OpenAI Codex 时会复用 ChatGPT OAuth 登录，不需要另填 API Key。
 
 生成后也可以继续通过 chat 改封面提示词，例如“把人物拉近一点、标题字更大、表情更冷笑”。系统会用新的 `coverPrompt` 重写 `cover-prompt.md` 并重生成封面，不需要重新写短篇。
 

--- a/README.md
+++ b/README.md
@@ -177,10 +177,12 @@ inkos
 
 打开 Studio 后进入「模型配置」：
 
-1. 选择服务商，例如 Google Gemini、Moonshot、MiniMax、智谱、百炼或自定义端点。
+1. 选择服务商，例如 OpenAI Codex (ChatGPT)、Google Gemini、Moonshot、MiniMax、智谱、百炼或自定义端点。
 2. 粘贴 API Key，点击「测试连接」。
 3. 选择可用模型，保存配置。
 4. 回到书籍页面开始写作。
+
+OpenAI Codex 不需要 API Key：在服务详情页点击「使用 ChatGPT 登录」，浏览器授权成功后，InkOS 会保存 OAuth 凭据并在过期时自动刷新。Studio、CLI 和 daemon 共用这份项目凭据。
 
 Studio 运行时只使用：
 

--- a/packages/core/src/__tests__/effective-llm-config.test.ts
+++ b/packages/core/src/__tests__/effective-llm-config.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveEffectiveLLMConfig } from "../utils/effective-llm-config.js";
+import type { ServiceSecret } from "../llm/secrets.js";
 
 describe("resolveEffectiveLLMConfig", () => {
   let root = "";
@@ -23,7 +24,7 @@ describe("resolveEffectiveLLMConfig", () => {
     }, null, 2), "utf-8");
   }
 
-  async function writeSecrets(services: Record<string, { apiKey: string }>) {
+  async function writeSecrets(services: Record<string, ServiceSecret>) {
     await mkdir(join(root, ".inkos"), { recursive: true });
     await writeFile(join(root, ".inkos", "secrets.json"), JSON.stringify({ services }, null, 2), "utf-8");
   }
@@ -55,6 +56,39 @@ describe("resolveEffectiveLLMConfig", () => {
     expect(result.llm.apiKey).toBe("sk-google");
     expect(result.diagnostics.apiKeySource).toBe("studio-secret");
     expect(result.diagnostics.warnings.join("\n")).toContain("旧顶层");
+  });
+
+  it("CLI consumer reuses OpenAI Codex OAuth credentials saved by Studio", async () => {
+    await writeProject({
+      configSource: "studio",
+      service: "openaiCodex",
+      services: [{ service: "openaiCodex", apiFormat: "responses", stream: true }],
+      defaultModel: "gpt-5.4",
+    });
+    await writeSecrets({
+      openaiCodex: {
+        oauth: {
+          provider: "openai-codex",
+          credentials: {
+            access: "oauth-access",
+            refresh: "oauth-refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+    });
+
+    const result = await resolveEffectiveLLMConfig({
+      consumer: "cli",
+      projectRoot: root,
+      envLayers: { global: {}, project: {}, process: {} },
+    });
+
+    expect(result.llm.service).toBe("openaiCodex");
+    expect(result.llm.model).toBe("gpt-5.4");
+    expect(result.llm.baseUrl).toBe("https://chatgpt.com/backend-api");
+    expect(result.llm.apiFormat).toBe("responses");
+    expect(result.llm.apiKey).toBe("oauth-access");
   });
 
   it("CLI consumer 允许 INKOS_LLM_SERVICE 切换服务，并从 provider bank 推导 baseUrl", async () => {

--- a/packages/core/src/__tests__/models.test.ts
+++ b/packages/core/src/__tests__/models.test.ts
@@ -370,6 +370,18 @@ describe("ProjectConfigSchema", () => {
     expect(parsed.writing.reviewMode).toBe("manual");
   });
 
+  it("accepts OpenAI Codex as an OAuth-backed cover provider", () => {
+    const parsed = ProjectConfigSchema.parse({
+      ...validProject,
+      llm: {
+        ...validProject.llm,
+        cover: { service: "openaiCodex", model: "gpt-image-2" },
+      },
+    });
+
+    expect(parsed.llm.cover).toEqual({ service: "openaiCodex", model: "gpt-image-2" });
+  });
+
   it("applies default empty notify array", () => {
     const withoutNotify = {
       name: "p1",

--- a/packages/core/src/__tests__/openai-codex-auth.test.ts
+++ b/packages/core/src/__tests__/openai-codex-auth.test.ts
@@ -41,6 +41,7 @@ describe("OpenAI Codex model discovery", () => {
     expect(models).toContain("gpt-5.6-sol");
     expect(models).toContain("gpt-5.6-terra");
     expect(models).toContain("gpt-5.6-luna");
+    expect(models.some((model) => model.endsWith("-pro"))).toBe(false);
     expect(models).not.toContain("hidden-model");
   });
 

--- a/packages/core/src/__tests__/openai-codex-auth.test.ts
+++ b/packages/core/src/__tests__/openai-codex-auth.test.ts
@@ -1,0 +1,57 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it, vi } from "vitest";
+import {
+  addOpenAICodexForwardCompatibleModels,
+  extractOpenAICodexAccountId,
+  listOpenAICodexModels,
+  OPENAI_CODEX_MODELS_URL,
+} from "../llm/openai-codex-auth.js";
+
+function accessToken(accountId = "acct-test"): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+  })}.signature`;
+}
+
+describe("OpenAI Codex model discovery", () => {
+  it("extracts the ChatGPT account id from an OAuth JWT", () => {
+    expect(extractOpenAICodexAccountId(accessToken())).toBe("acct-test");
+    expect(extractOpenAICodexAccountId("not-a-jwt")).toBeNull();
+  });
+
+  it("fetches, filters, and prioritizes the account model catalog", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      models: [
+        { slug: "gpt-5.4", priority: 20 },
+        { slug: "hidden-model", priority: 1, visibility: "hidden" },
+        { slug: "gpt-5.5", priority: 10 },
+      ],
+    }), { status: 200 })) as unknown as typeof fetch;
+
+    const models = await listOpenAICodexModels(accessToken(), { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(OPENAI_CODEX_MODELS_URL, expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: expect.stringContaining("Bearer "),
+        "ChatGPT-Account-Id": "acct-test",
+      }),
+    }));
+    expect(models.slice(0, 2)).toEqual(["gpt-5.5", "gpt-5.4"]);
+    expect(models).toContain("gpt-5.6-sol");
+    expect(models).toContain("gpt-5.6-terra");
+    expect(models).toContain("gpt-5.6-luna");
+    expect(models).not.toContain("hidden-model");
+  });
+
+  it("adds GPT-5.6 compatibility entries only when a compatible template exists", () => {
+    expect(addOpenAICodexForwardCompatibleModels(["gpt-5.4"])).toContain("gpt-5.6-sol");
+    expect(addOpenAICodexForwardCompatibleModels(["unrelated-model"])).toEqual(["unrelated-model"]);
+  });
+
+  it("rejects catalog discovery errors instead of pretending the account has no models", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 503 })) as unknown as typeof fetch;
+    await expect(listOpenAICodexModels(accessToken(), { fetchImpl }))
+      .rejects.toThrow("HTTP 503");
+  });
+});

--- a/packages/core/src/__tests__/openai-codex-images.test.ts
+++ b/packages/core/src/__tests__/openai-codex-images.test.ts
@@ -1,0 +1,74 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it, vi } from "vitest";
+import {
+  generateOpenAICodexImage,
+  OPENAI_CODEX_IMAGE_RESPONSES_URL,
+} from "../llm/openai-codex-images.js";
+
+function accessToken(accountId = "acct-image"): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+  })}.signature`;
+}
+
+describe("OpenAI Codex OAuth image generation", () => {
+  it("sends the hosted image tool through Codex Responses and parses the final SSE image", async () => {
+    const image = Buffer.from("fake-image").toString("base64");
+    const fetchMock = vi.fn(async (_input: unknown, _init?: RequestInit) => new Response([
+      "event: response.created",
+      "data: {\"type\":\"response.created\"}",
+      "",
+      "event: response.output_item.done",
+      `data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "image_generation_call", result: image } })}`,
+      "",
+    ].join("\n"), { status: 200, headers: { "content-type": "text/event-stream" } }));
+
+    const result = await generateOpenAICodexImage({
+      accessToken: accessToken(),
+      prompt: "竖版小说封面",
+      size: "1024x1360",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result.buffer).toEqual(Buffer.from("fake-image"));
+    expect(fetchMock).toHaveBeenCalledWith(OPENAI_CODEX_IMAGE_RESPONSES_URL, expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({
+        "ChatGPT-Account-Id": "acct-image",
+        Accept: "text/event-stream",
+      }),
+    }));
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(body.model).toBe("gpt-5.6-sol");
+    expect(body).not.toHaveProperty("tool_choice");
+    expect(body.tools).toEqual([expect.objectContaining({
+      type: "image_generation",
+      model: "gpt-image-2",
+      size: "1024x1536",
+      quality: "medium",
+    })]);
+  });
+
+  it("falls back to an older host model only when Codex rejects the model slug", async () => {
+    const image = Buffer.from("fallback-image").toString("base64");
+    const fetchMock = vi.fn(async (_input: unknown, _init?: RequestInit) => new Response())
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: { message: "The 'gpt-5.6-sol' model is not supported" },
+      }), { status: 400 }))
+      .mockResolvedValueOnce(new Response(
+        `data: ${JSON.stringify({ type: "image_generation_call", result: image })}\n\n`,
+        { status: 200 },
+      ));
+
+    await expect(generateOpenAICodexImage({
+      accessToken: accessToken(),
+      prompt: "cover",
+      size: "1024x1024",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    })).resolves.toMatchObject({ buffer: Buffer.from("fallback-image") });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)).model).toBe("gpt-5.5");
+  });
+});

--- a/packages/core/src/__tests__/provider.test.ts
+++ b/packages/core/src/__tests__/provider.test.ts
@@ -886,6 +886,28 @@ describe("createLLMClient per-call maxTokens not capped (v2.0.0)", () => {
     const opts = mockStreamSimple.mock.calls[0]?.[2] as Record<string, unknown>;
     expect(opts.maxTokens).toBe(16384);
   });
+
+  it("omits temperature for the OpenAI Codex Responses transport", async () => {
+    mockStreamSimple.mockReturnValue(makeTextStream("ok"));
+    const client = makeClient(1, {
+      service: "openaiCodex",
+      apiFormat: "responses",
+      _piModel: {
+        ...MOCK_PI_MODEL,
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+      },
+    });
+
+    await chatCompletion(client, "gpt-5.4", [
+      { role: "user", content: "write" },
+    ], { temperature: 1.5 });
+
+    const opts = mockStreamSimple.mock.calls.at(-1)?.[2] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty("temperature");
+    expect(opts.maxTokens).toBe(512);
+  });
 });
 
 describe("createLLMClient with providers lookup", () => {

--- a/packages/core/src/__tests__/provider.test.ts
+++ b/packages/core/src/__tests__/provider.test.ts
@@ -987,6 +987,22 @@ describe("createLLMClient with providers lookup", () => {
     expect(client._piModel?.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
     expect(client._piModel?.compat).toBeUndefined();
   });
+
+  it("OpenAI Codex uses the native OAuth Responses transport", async () => {
+    const { createLLMClient } = await import("../llm/provider.js");
+    const { LLMConfigSchema } = await import("../models/project.js");
+    const client = createLLMClient(LLMConfigSchema.parse({
+      provider: "openai",
+      service: "openaiCodex",
+      model: "gpt-5.4",
+      apiKey: "oauth-access-token",
+      baseUrl: "https://chatgpt.com/backend-api",
+      apiFormat: "responses",
+    }));
+    expect(client._piModel?.api).toBe("openai-codex-responses");
+    expect(client._piModel?.provider).toBe("openai-codex");
+    expect(client._piModel?.baseUrl).toBe("https://chatgpt.com/backend-api");
+  });
 });
 
 describe("stream interruption detection", () => {

--- a/packages/core/src/__tests__/providers-group.test.ts
+++ b/packages/core/src/__tests__/providers-group.test.ts
@@ -11,7 +11,7 @@ describe("InkosEndpoint.group", () => {
     const all = getAllEndpoints();
     const byGroup = (g: string) => all.filter((ep) => ep.group === g).map((e) => e.id).sort();
 
-    expect(byGroup("overseas")).toEqual(["anthropic", "google", "mistral", "openai", "xai"].sort());
+    expect(byGroup("overseas")).toEqual(["anthropic", "google", "mistral", "openai", "openaiCodex", "xai"].sort());
     expect(byGroup("china")).toEqual([
       "ai360", "baichuan", "bailian", "deepseek", "hunyuan", "internlm", "longcat",
       "minimax", "moonshot", "sensenova", "spark", "stepfun", "tencentcloud",

--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -125,6 +125,19 @@ describe("providers structural integrity", () => {
     expect(getEndpoint("newapi")?.baseUrl).toBe("");
   });
 
+  it("OpenAI Codex uses the ChatGPT OAuth Responses transport", () => {
+    const codex = getEndpoint("openaiCodex");
+    expect(codex).toMatchObject({
+      label: "OpenAI Codex (ChatGPT)",
+      group: "overseas",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      checkModel: "gpt-5.4",
+      transportDefaults: { apiFormat: "responses", stream: true },
+    });
+    expect(codex?.models.some((model) => model.id === "gpt-5.4")).toBe(true);
+  });
+
   it("B4：总 provider 数 = 31（不含 CodingPlan 分组）", () => {
     const nonCoding = getAllEndpoints().filter((p) => p.group !== "codingPlan");
     expect(nonCoding.length).toBe(31);

--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -132,9 +132,12 @@ describe("providers structural integrity", () => {
       group: "overseas",
       api: "openai-codex-responses",
       baseUrl: "https://chatgpt.com/backend-api",
-      checkModel: "gpt-5.4",
+      checkModel: "gpt-5.6-sol",
       transportDefaults: { apiFormat: "responses", stream: true },
     });
+    expect(codex?.models.some((model) => model.id === "gpt-5.6-sol")).toBe(true);
+    expect(codex?.models.some((model) => model.id === "gpt-5.6-terra")).toBe(true);
+    expect(codex?.models.some((model) => model.id === "gpt-5.6-luna")).toBe(true);
     expect(codex?.models.some((model) => model.id === "gpt-5.4")).toBe(true);
   });
 

--- a/packages/core/src/__tests__/providers-schema.test.ts
+++ b/packages/core/src/__tests__/providers-schema.test.ts
@@ -7,7 +7,7 @@ describe("providers structural integrity", () => {
     for (const p of getAllEndpoints()) {
       expect(p.id).toBeTruthy();
       expect(p.label).toBeTruthy();
-      expect(p.api).toMatch(/^(openai-completions|openai-responses|anthropic-messages|google-generative-ai)$/);
+      expect(p.api).toMatch(/^(openai-completions|openai-responses|openai-codex-responses|anthropic-messages|google-generative-ai)$/);
       // gateway/anchor provider 允许 baseUrl 为空（由用户填）
       if (gatewayProviders.has(p.id)) {
         expect(typeof p.baseUrl).toBe("string");
@@ -125,9 +125,9 @@ describe("providers structural integrity", () => {
     expect(getEndpoint("newapi")?.baseUrl).toBe("");
   });
 
-  it("B4：总 provider 数 = 30（不含 CodingPlan 分组，R5 删 qwen / higress 且精简聚合入口后）", () => {
+  it("B4：总 provider 数 = 31（不含 CodingPlan 分组）", () => {
     const nonCoding = getAllEndpoints().filter((p) => p.group !== "codingPlan");
-    expect(nonCoding.length).toBe(30);
+    expect(nonCoding.length).toBe(31);
   });
 
   it("B6：CodingPlan 8 个 provider 全部收录", () => {
@@ -141,8 +141,8 @@ describe("providers structural integrity", () => {
     }
   });
 
-  it("B6：总 provider 数 = 38 (30 base + 8 CodingPlan)", () => {
-    expect(getAllEndpoints().length).toBe(38);
+  it("B6：总 provider 数 = 39 (31 base + 8 CodingPlan)", () => {
+    expect(getAllEndpoints().length).toBe(39);
   });
 
   it("B6：CodingPlan provider 都走 anthropic-messages", () => {

--- a/packages/core/src/__tests__/secrets.test.ts
+++ b/packages/core/src/__tests__/secrets.test.ts
@@ -11,11 +11,29 @@ import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+const oauthMocks = vi.hoisted(() => ({
+  getOAuthApiKey: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-ai/oauth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@mariozechner/pi-ai/oauth")>()),
+  getOAuthApiKey: oauthMocks.getOAuthApiKey,
+}));
+
 describe("secrets", () => {
   let root: string;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "inkos-secrets-"));
+    oauthMocks.getOAuthApiKey.mockReset();
+    oauthMocks.getOAuthApiKey.mockImplementation(async (provider: string, credentials: Record<string, {
+      access: string;
+      refresh: string;
+      expires: number;
+    }>) => ({
+      newCredentials: credentials[provider],
+      apiKey: credentials[provider].access,
+    }));
   });
 
   afterEach(async () => {
@@ -115,6 +133,75 @@ describe("secrets", () => {
         expiresAt: expect.any(Number),
       });
       expect(secret.apiKey).toBeUndefined();
+    });
+
+    it("coalesces concurrent OAuth refreshes and persists the refreshed credentials", async () => {
+      await saveServiceOAuthCredentials(root, "openaiCodex", "openai-codex", {
+        access: "expired-access",
+        refresh: "old-refresh",
+        expires: 1,
+      });
+      let releaseRefresh!: () => void;
+      const refreshGate = new Promise<void>((resolve) => { releaseRefresh = resolve; });
+      oauthMocks.getOAuthApiKey.mockImplementationOnce(async () => {
+        await refreshGate;
+        return {
+          apiKey: "fresh-access",
+          newCredentials: {
+            access: "fresh-access",
+            refresh: "fresh-refresh",
+            expires: Date.now() + 60_000,
+          },
+        };
+      });
+
+      const first = getServiceApiKey(root, "openaiCodex");
+      const second = getServiceApiKey(root, "openaiCodex");
+      await vi.waitFor(() => expect(oauthMocks.getOAuthApiKey).toHaveBeenCalledTimes(1));
+      releaseRefresh();
+
+      await expect(Promise.all([first, second])).resolves.toEqual(["fresh-access", "fresh-access"]);
+      expect((await loadSecrets(root)).services.openaiCodex.oauth?.credentials).toMatchObject({
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+      });
+    });
+
+    it("does not overwrite a newer login with a stale refresh result", async () => {
+      await saveServiceOAuthCredentials(root, "openaiCodex", "openai-codex", {
+        access: "expired-access",
+        refresh: "old-refresh",
+        expires: 1,
+      });
+      let releaseRefresh!: () => void;
+      const refreshGate = new Promise<void>((resolve) => { releaseRefresh = resolve; });
+      oauthMocks.getOAuthApiKey.mockImplementationOnce(async () => {
+        await refreshGate;
+        return {
+          apiKey: "stale-refreshed-access",
+          newCredentials: {
+            access: "stale-refreshed-access",
+            refresh: "stale-refreshed-refresh",
+            expires: Date.now() + 60_000,
+          },
+        };
+      });
+
+      const staleRefresh = getServiceApiKey(root, "openaiCodex");
+      await vi.waitFor(() => expect(oauthMocks.getOAuthApiKey).toHaveBeenCalledTimes(1));
+      await saveServiceOAuthCredentials(root, "openaiCodex", "openai-codex", {
+        access: "new-login-access",
+        refresh: "new-login-refresh",
+        expires: Date.now() + 120_000,
+      });
+      await expect(getServiceApiKey(root, "openaiCodex")).resolves.toBe("new-login-access");
+      releaseRefresh();
+      await expect(staleRefresh).resolves.toBe("stale-refreshed-access");
+
+      expect((await loadSecrets(root)).services.openaiCodex.oauth?.credentials).toMatchObject({
+        access: "new-login-access",
+        refresh: "new-login-refresh",
+      });
     });
   });
 });

--- a/packages/core/src/__tests__/secrets.test.ts
+++ b/packages/core/src/__tests__/secrets.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { loadSecrets, saveSecrets, getServiceApiKey } from "../llm/secrets.js";
+import {
+  loadSecrets,
+  saveSecrets,
+  getServiceApiKey,
+  getServiceAuthStatus,
+  hasServiceCredentials,
+  saveServiceOAuthCredentials,
+} from "../llm/secrets.js";
 import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -90,6 +97,24 @@ describe("secrets", () => {
       );
       const key = await getServiceApiKey(root, "custom:内网GPT");
       expect(key).toBe("sk-custom");
+    });
+
+    it("returns a valid OAuth access token", async () => {
+      await saveServiceOAuthCredentials(root, "openaiCodex", "openai-codex", {
+        access: "oauth-access",
+        refresh: "oauth-refresh",
+        expires: Date.now() + 60_000,
+      });
+
+      expect(await getServiceApiKey(root, "openaiCodex")).toBe("oauth-access");
+      const secret = (await loadSecrets(root)).services.openaiCodex;
+      expect(hasServiceCredentials(secret)).toBe(true);
+      expect(getServiceAuthStatus(secret)).toEqual({
+        authType: "oauth",
+        connected: true,
+        expiresAt: expect.any(Number),
+      });
+      expect(secret.apiKey).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/__tests__/short-fiction-public.test.ts
+++ b/packages/core/src/__tests__/short-fiction-public.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { Buffer } from "node:buffer";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -165,6 +166,44 @@ describe("public short-fiction chain", () => {
         baseUrl: "https://api.kkaiapi.com/v1",
         model: "gpt-image-2",
         apiKey: "sk-cover",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves Codex cover generation from the shared ChatGPT OAuth credentials", async () => {
+    const root = await mkdtemp(join(tmpdir(), "inkos-short-codex-cover-"));
+    const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const access = `${encode({ alg: "none" })}.${encode({
+      "https://api.openai.com/auth": { chatgpt_account_id: "acct-cover" },
+    })}.signature`;
+    try {
+      await writeFile(join(root, "inkos.json"), JSON.stringify({
+        name: "codex-cover-test",
+        version: "0.1.0",
+        language: "zh",
+        llm: {
+          cover: { service: "openaiCodex", model: "gpt-image-2" },
+        },
+        notify: [],
+      }), "utf-8");
+      await saveSecrets(root, {
+        services: {
+          openaiCodex: {
+            oauth: {
+              provider: "openai-codex",
+              credentials: { access, refresh: "refresh", expires: Date.now() + 60_000 },
+            },
+          },
+        },
+      });
+
+      await expect(resolveCoverGenerationRequest({ root })).resolves.toMatchObject({
+        api: "codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        model: "gpt-image-2",
+        apiKey: access,
       });
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -449,7 +449,25 @@ export {
   type ModelInfo,
 } from "./llm/service-presets.js";
 export { resolveServiceModel, type ResolvedModel } from "./llm/service-resolver.js";
-export { loadSecrets, saveSecrets, getServiceApiKey, type SecretsFile } from "./llm/secrets.js";
+export {
+  loadSecrets,
+  saveSecrets,
+  getServiceApiKey,
+  hasServiceCredentials,
+  getServiceAuthStatus,
+  saveServiceOAuthCredentials,
+  type SecretsFile,
+  type ServiceSecret,
+  type OAuthServiceSecret,
+} from "./llm/secrets.js";
+export {
+  loginOpenAICodex,
+  OPENAI_CODEX_SERVICE_ID,
+  OPENAI_CODEX_OAUTH_PROVIDER_ID,
+  OPENAI_CODEX_DEFAULT_MODEL,
+  type OpenAICodexLoginOptions,
+  type OAuthCredentials,
+} from "./llm/openai-codex-auth.js";
 export {
   COVER_PROVIDER_PRESETS,
   coverSecretKey,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -465,9 +465,20 @@ export {
   OPENAI_CODEX_SERVICE_ID,
   OPENAI_CODEX_OAUTH_PROVIDER_ID,
   OPENAI_CODEX_DEFAULT_MODEL,
+  OPENAI_CODEX_FALLBACK_MODEL_IDS,
+  extractOpenAICodexAccountId,
+  addOpenAICodexForwardCompatibleModels,
+  listOpenAICodexModels,
   type OpenAICodexLoginOptions,
   type OAuthCredentials,
 } from "./llm/openai-codex-auth.js";
+export {
+  generateOpenAICodexImage,
+  OPENAI_CODEX_IMAGE_RESPONSES_URL,
+  OPENAI_CODEX_IMAGE_MODEL,
+  OPENAI_CODEX_IMAGE_HOST_MODELS,
+  type OpenAICodexImageRequest,
+} from "./llm/openai-codex-images.js";
 export {
   COVER_PROVIDER_PRESETS,
   coverSecretKey,

--- a/packages/core/src/llm/cover-providers.ts
+++ b/packages/core/src/llm/cover-providers.ts
@@ -1,10 +1,10 @@
-export type CoverProviderId = "kkaiapi" | "openai" | "google";
+export type CoverProviderId = "kkaiapi" | "openai" | "openaiCodex" | "google";
 
 export interface CoverProviderPreset {
   readonly service: CoverProviderId;
   readonly label: string;
   readonly baseUrl: string;
-  readonly api: "responses" | "images" | "gemini";
+  readonly api: "responses" | "codex-responses" | "images" | "gemini";
   readonly defaultModel: string;
   readonly models: readonly string[];
 }
@@ -23,6 +23,14 @@ export const COVER_PROVIDER_PRESETS: readonly CoverProviderPreset[] = [
     label: "OpenAI Images",
     baseUrl: "https://api.openai.com/v1",
     api: "images",
+    defaultModel: "gpt-image-2",
+    models: ["gpt-image-2"],
+  },
+  {
+    service: "openaiCodex",
+    label: "OpenAI Codex (ChatGPT OAuth)",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    api: "codex-responses",
     defaultModel: "gpt-image-2",
     models: ["gpt-image-2"],
   },

--- a/packages/core/src/llm/cover-providers.ts
+++ b/packages/core/src/llm/cover-providers.ts
@@ -1,4 +1,5 @@
-export type CoverProviderId = "kkaiapi" | "openai" | "openaiCodex" | "google";
+export const COVER_PROVIDER_IDS = ["kkaiapi", "openai", "openaiCodex", "google"] as const;
+export type CoverProviderId = typeof COVER_PROVIDER_IDS[number];
 
 export interface CoverProviderPreset {
   readonly service: CoverProviderId;

--- a/packages/core/src/llm/openai-codex-auth.ts
+++ b/packages/core/src/llm/openai-codex-auth.ts
@@ -1,0 +1,24 @@
+import {
+  loginOpenAICodex as loginWithPiAi,
+  type OAuthCredentials,
+  type OAuthPrompt,
+} from "@mariozechner/pi-ai/oauth";
+
+export const OPENAI_CODEX_SERVICE_ID = "openaiCodex";
+export const OPENAI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
+export const OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.4";
+
+export interface OpenAICodexLoginOptions {
+  onAuth: (info: { url: string; instructions?: string }) => void;
+  onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+  onProgress?: (message: string) => void;
+  onManualCodeInput?: () => Promise<string>;
+}
+
+export async function loginOpenAICodex(
+  options: OpenAICodexLoginOptions,
+): Promise<OAuthCredentials> {
+  return loginWithPiAi({ ...options, originator: "inkos" });
+}
+
+export type { OAuthCredentials };

--- a/packages/core/src/llm/openai-codex-auth.ts
+++ b/packages/core/src/llm/openai-codex-auth.ts
@@ -3,10 +3,27 @@ import {
   type OAuthCredentials,
   type OAuthPrompt,
 } from "@mariozechner/pi-ai/oauth";
+import { Buffer } from "node:buffer";
 
 export const OPENAI_CODEX_SERVICE_ID = "openaiCodex";
 export const OPENAI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
-export const OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.4";
+export const OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.6-sol";
+export const OPENAI_CODEX_MODELS_URL = "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0";
+export const OPENAI_CODEX_FALLBACK_MODEL_IDS = [
+  "gpt-5.6-sol",
+  "gpt-5.6-sol-pro",
+  "gpt-5.6-terra",
+  "gpt-5.6-terra-pro",
+  "gpt-5.6-luna",
+  "gpt-5.6-luna-pro",
+  "gpt-5.5",
+  "gpt-5.4-mini",
+  "gpt-5.4",
+  "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
+] as const;
+
+const OPENAI_AUTH_CLAIM = "https://api.openai.com/auth";
 
 export interface OpenAICodexLoginOptions {
   onAuth: (info: { url: string; instructions?: string }) => void;
@@ -19,6 +36,68 @@ export async function loginOpenAICodex(
   options: OpenAICodexLoginOptions,
 ): Promise<OAuthCredentials> {
   return loginWithPiAi({ ...options, originator: "inkos" });
+}
+
+export function extractOpenAICodexAccountId(accessToken: string): string | null {
+  try {
+    const parts = accessToken.split(".");
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf-8")) as Record<string, unknown>;
+    const auth = payload[OPENAI_AUTH_CLAIM];
+    if (!auth || typeof auth !== "object") return null;
+    const accountId = (auth as Record<string, unknown>).chatgpt_account_id;
+    return typeof accountId === "string" && accountId.trim() ? accountId.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function addOpenAICodexForwardCompatibleModels(modelIds: readonly string[]): string[] {
+  const result = Array.from(new Set(modelIds.map((id) => id.trim()).filter(Boolean)));
+  const templates = new Set(result);
+  if (["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"].some((id) => templates.has(id))) {
+    for (const id of OPENAI_CODEX_FALLBACK_MODEL_IDS.slice(0, 6)) {
+      if (!templates.has(id)) result.push(id);
+    }
+  }
+  return result;
+}
+
+export async function listOpenAICodexModels(
+  accessToken: string,
+  options: { readonly fetchImpl?: typeof fetch; readonly timeoutMs?: number } = {},
+): Promise<string[]> {
+  const accountId = extractOpenAICodexAccountId(accessToken);
+  if (!accountId) throw new Error("OpenAI Codex access token does not contain a ChatGPT account ID.");
+
+  const response = await (options.fetchImpl ?? fetch)(OPENAI_CODEX_MODELS_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "ChatGPT-Account-Id": accountId,
+      originator: "inkos",
+    },
+    signal: AbortSignal.timeout(options.timeoutMs ?? 10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`OpenAI Codex model discovery failed: HTTP ${response.status}`);
+  }
+
+  const payload = await response.json() as { models?: unknown };
+  const entries = Array.isArray(payload.models) ? payload.models : [];
+  const visible = entries.flatMap((entry, index) => {
+    if (!entry || typeof entry !== "object") return [];
+    const item = entry as Record<string, unknown>;
+    const slug = typeof item.slug === "string" ? item.slug.trim() : "";
+    const visibility = typeof item.visibility === "string" ? item.visibility.trim().toLowerCase() : "";
+    if (!slug || visibility === "hide" || visibility === "hidden") return [];
+    return [{
+      slug,
+      priority: typeof item.priority === "number" && Number.isFinite(item.priority) ? item.priority : 10_000,
+      index,
+    }];
+  });
+  visible.sort((left, right) => left.priority - right.priority || left.index - right.index || left.slug.localeCompare(right.slug));
+  return addOpenAICodexForwardCompatibleModels(visible.map((item) => item.slug));
 }
 
 export type { OAuthCredentials };

--- a/packages/core/src/llm/openai-codex-auth.ts
+++ b/packages/core/src/llm/openai-codex-auth.ts
@@ -9,13 +9,13 @@ export const OPENAI_CODEX_SERVICE_ID = "openaiCodex";
 export const OPENAI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
 export const OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.6-sol";
 export const OPENAI_CODEX_MODELS_URL = "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0";
-export const OPENAI_CODEX_FALLBACK_MODEL_IDS = [
+const OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS = [
   "gpt-5.6-sol",
-  "gpt-5.6-sol-pro",
   "gpt-5.6-terra",
-  "gpt-5.6-terra-pro",
   "gpt-5.6-luna",
-  "gpt-5.6-luna-pro",
+] as const;
+export const OPENAI_CODEX_FALLBACK_MODEL_IDS = [
+  ...OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS,
   "gpt-5.5",
   "gpt-5.4-mini",
   "gpt-5.4",
@@ -56,7 +56,7 @@ export function addOpenAICodexForwardCompatibleModels(modelIds: readonly string[
   const result = Array.from(new Set(modelIds.map((id) => id.trim()).filter(Boolean)));
   const templates = new Set(result);
   if (["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"].some((id) => templates.has(id))) {
-    for (const id of OPENAI_CODEX_FALLBACK_MODEL_IDS.slice(0, 6)) {
+    for (const id of OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS) {
       if (!templates.has(id)) result.push(id);
     }
   }

--- a/packages/core/src/llm/openai-codex-images.ts
+++ b/packages/core/src/llm/openai-codex-images.ts
@@ -1,0 +1,190 @@
+import { Buffer } from "node:buffer";
+import { extractOpenAICodexAccountId } from "./openai-codex-auth.js";
+
+export const OPENAI_CODEX_IMAGE_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+export const OPENAI_CODEX_IMAGE_MODEL = "gpt-image-2";
+export const OPENAI_CODEX_IMAGE_HOST_MODELS = ["gpt-5.6-sol", "gpt-5.5", "gpt-5.4"] as const;
+
+const MAX_RESPONSE_BYTES = 80 * 1024 * 1024;
+const MAX_ERROR_CHARS = 500;
+
+export interface OpenAICodexImageRequest {
+  readonly accessToken: string;
+  readonly prompt: string;
+  readonly size: string;
+  readonly quality?: "low" | "medium" | "high";
+  readonly signal?: AbortSignal;
+  readonly fetchImpl?: typeof fetch;
+}
+
+class OpenAICodexImageHttpError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "OpenAICodexImageHttpError";
+  }
+}
+
+export async function generateOpenAICodexImage(
+  request: OpenAICodexImageRequest,
+): Promise<{ readonly buffer: Buffer; readonly extension: "png" }> {
+  const accountId = extractOpenAICodexAccountId(request.accessToken);
+  if (!accountId) throw new Error("OpenAI Codex access token does not contain a ChatGPT account ID.");
+
+  let lastError: unknown;
+  for (const hostModel of OPENAI_CODEX_IMAGE_HOST_MODELS) {
+    try {
+      return await requestOpenAICodexImage(request, accountId, hostModel);
+    } catch (error) {
+      lastError = error;
+      if (!(error instanceof OpenAICodexImageHttpError) || !isUnsupportedHostModel(error)) throw error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("OpenAI Codex image generation failed.");
+}
+
+async function requestOpenAICodexImage(
+  request: OpenAICodexImageRequest,
+  accountId: string,
+  hostModel: string,
+): Promise<{ readonly buffer: Buffer; readonly extension: "png" }> {
+  const timeoutSignal = AbortSignal.timeout(180_000);
+  const signal = request.signal ? AbortSignal.any([request.signal, timeoutSignal]) : timeoutSignal;
+  const response = await (request.fetchImpl ?? fetch)(OPENAI_CODEX_IMAGE_RESPONSES_URL, {
+    method: "POST",
+    headers: {
+      Accept: "text/event-stream",
+      Authorization: `Bearer ${request.accessToken}`,
+      "ChatGPT-Account-Id": accountId,
+      "Content-Type": "application/json",
+      "OpenAI-Beta": "responses=experimental",
+      originator: "inkos",
+    },
+    body: JSON.stringify({
+      model: hostModel,
+      store: false,
+      stream: true,
+      instructions: "You are an image generation assistant. Use the image_generation tool to fulfill the request.",
+      input: [{
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: request.prompt }],
+      }],
+      tools: [{
+        type: "image_generation",
+        model: OPENAI_CODEX_IMAGE_MODEL,
+        size: normalizeOpenAICodexImageSize(request.size),
+        quality: request.quality ?? "medium",
+        output_format: "png",
+        background: "opaque",
+      }],
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, MAX_ERROR_CHARS);
+    throw new OpenAICodexImageHttpError(
+      response.status,
+      `OpenAI Codex image generation failed: HTTP ${response.status}${body ? ` ${summarizeError(body)}` : ""}`,
+    );
+  }
+
+  const imageBase64 = await extractImageFromSse(response);
+  if (!imageBase64) {
+    throw new Error("OpenAI Codex response did not include an image_generation_call result.");
+  }
+  return { buffer: Buffer.from(imageBase64, "base64"), extension: "png" };
+}
+
+function normalizeOpenAICodexImageSize(size: string): "1024x1024" | "1024x1536" | "1536x1024" {
+  if (size === "1024x1536" || size === "1536x1024" || size === "1024x1024") return size;
+  const match = /^(\d+)x(\d+)$/u.exec(size.trim());
+  if (!match) return "1024x1024";
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (height > width) return "1024x1536";
+  if (width > height) return "1536x1024";
+  return "1024x1024";
+}
+
+function isUnsupportedHostModel(error: OpenAICodexImageHttpError): boolean {
+  return error.status === 400 && /model.+(?:not supported|unsupported|does not exist|not found)/iu.test(error.message);
+}
+
+function summarizeError(body: string): string {
+  try {
+    const payload = JSON.parse(body) as { error?: { message?: unknown } };
+    const message = payload.error?.message;
+    return typeof message === "string" && message.trim() ? message.trim() : body;
+  } catch {
+    return body;
+  }
+}
+
+async function extractImageFromSse(response: Response): Promise<string | null> {
+  if (!response.body) return null;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let totalBytes = 0;
+  let latestImage: string | null = null;
+
+  const consumeBlock = (block: string): void => {
+    const data = block.split(/\r?\n/u)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart())
+      .join("\n")
+      .trim();
+    if (!data || data === "[DONE]") return;
+    try {
+      const found = findImageBase64(JSON.parse(data));
+      if (found) latestImage = found;
+    } catch {
+      // Ignore non-JSON keepalives and continue parsing subsequent events.
+    }
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error("OpenAI Codex image response exceeded the 80 MB safety limit.");
+    }
+    buffered += decoder.decode(value, { stream: true });
+    let boundary = findSseBoundary(buffered);
+    while (boundary) {
+      consumeBlock(buffered.slice(0, boundary.index));
+      buffered = buffered.slice(boundary.index + boundary.length);
+      boundary = findSseBoundary(buffered);
+    }
+  }
+  buffered += decoder.decode();
+  if (buffered.trim()) consumeBlock(buffered);
+  return latestImage;
+}
+
+function findSseBoundary(value: string): { readonly index: number; readonly length: number } | null {
+  const match = /\r?\n\r?\n/u.exec(value);
+  return match ? { index: match.index, length: match[0].length } : null;
+}
+
+function findImageBase64(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    let found: string | null = null;
+    for (const item of value) found = findImageBase64(item) ?? found;
+    return found;
+  }
+  if (!value || typeof value !== "object") return null;
+  const item = value as Record<string, unknown>;
+  let found: string | null = null;
+  if (item.type === "image_generation_call" && typeof item.result === "string" && item.result) {
+    found = item.result;
+  }
+  if (typeof item.partial_image_b64 === "string" && item.partial_image_b64) {
+    found = item.partial_image_b64;
+  }
+  for (const child of Object.values(item)) found = findImageBase64(child) ?? found;
+  return found;
+}

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -175,6 +175,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
   // api.x.ai / deepseek.com / anthropic.com 等）。这里只列 pi-ai 嗅探不到、需要显式指定的少数情况。
   let piProvider: string;
   if (inkosProvider?.id === "google") piProvider = "google";
+  else if (inkosProvider?.id === "openaiCodex") piProvider = "openai-codex";
   else if (inkosProvider?.id === "zhipu") piProvider = "zai";
   else if (inkosProvider?.id === "openrouter") piProvider = "openrouter";
   else if (inkosProvider?.id === "githubCopilot") piProvider = "githubCopilot";

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -1319,7 +1319,9 @@ async function chatCompletionViaPiAi(
   const piModel = resolvePiModel(client, model);
   const context = toPiContext(messages);
   const streamOpts = {
-    temperature: resolved.temperature,
+    ...(piModel.api === "openai-codex-responses"
+      ? {}
+      : { temperature: resolved.temperature }),
     maxTokens: resolved.maxTokens,
     apiKey: client._apiKey,
     headers: mergeUserAgent(piModel.headers),

--- a/packages/core/src/llm/providers/endpoints/openaiCodex.ts
+++ b/packages/core/src/llm/providers/endpoints/openaiCodex.ts
@@ -1,0 +1,25 @@
+import type { InkosEndpoint } from "../types.js";
+
+export const OPENAI_CODEX: InkosEndpoint = {
+  id: "openaiCodex",
+  label: "OpenAI Codex (ChatGPT)",
+  group: "overseas",
+  api: "openai-codex-responses",
+  baseUrl: "https://chatgpt.com/backend-api",
+  checkModel: "gpt-5.4",
+  temperatureRange: [0, 2],
+  defaultTemperature: 1,
+  writingTemperature: 1,
+  transportDefaults: { apiFormat: "responses", stream: true },
+  models: [
+    { id: "gpt-5.1", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.1-codex-max", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.1-codex-mini", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.2", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.2-codex", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.3-codex", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.3-codex-spark", maxOutput: 128_000, contextWindowTokens: 128_000 },
+    { id: "gpt-5.4", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.4-mini", maxOutput: 128_000, contextWindowTokens: 272_000 },
+  ],
+};

--- a/packages/core/src/llm/providers/endpoints/openaiCodex.ts
+++ b/packages/core/src/llm/providers/endpoints/openaiCodex.ts
@@ -14,11 +14,8 @@ export const OPENAI_CODEX: InkosEndpoint = {
   transportDefaults: { apiFormat: "responses", stream: true },
   models: [
     { id: "gpt-5.6-sol", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
-    { id: "gpt-5.6-sol-pro", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
     { id: "gpt-5.6-terra", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
-    { id: "gpt-5.6-terra-pro", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
     { id: "gpt-5.6-luna", maxOutput: 128_000, contextWindowTokens: 400_000 },
-    { id: "gpt-5.6-luna-pro", maxOutput: 128_000, contextWindowTokens: 400_000 },
     { id: "gpt-5.5", maxOutput: 128_000, contextWindowTokens: 1_000_000 },
     { id: "gpt-5.4-mini", maxOutput: 128_000, contextWindowTokens: 272_000 },
     { id: "gpt-5.4", maxOutput: 128_000, contextWindowTokens: 272_000 },

--- a/packages/core/src/llm/providers/endpoints/openaiCodex.ts
+++ b/packages/core/src/llm/providers/endpoints/openaiCodex.ts
@@ -1,4 +1,5 @@
 import type { InkosEndpoint } from "../types.js";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "../../openai-codex-auth.js";
 
 export const OPENAI_CODEX: InkosEndpoint = {
   id: "openaiCodex",
@@ -6,20 +7,22 @@ export const OPENAI_CODEX: InkosEndpoint = {
   group: "overseas",
   api: "openai-codex-responses",
   baseUrl: "https://chatgpt.com/backend-api",
-  checkModel: "gpt-5.4",
+  checkModel: OPENAI_CODEX_DEFAULT_MODEL,
   temperatureRange: [0, 2],
   defaultTemperature: 1,
   writingTemperature: 1,
   transportDefaults: { apiFormat: "responses", stream: true },
   models: [
-    { id: "gpt-5.1", maxOutput: 128_000, contextWindowTokens: 272_000 },
-    { id: "gpt-5.1-codex-max", maxOutput: 128_000, contextWindowTokens: 272_000 },
-    { id: "gpt-5.1-codex-mini", maxOutput: 128_000, contextWindowTokens: 272_000 },
-    { id: "gpt-5.2", maxOutput: 128_000, contextWindowTokens: 272_000 },
-    { id: "gpt-5.2-codex", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.6-sol", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
+    { id: "gpt-5.6-sol-pro", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
+    { id: "gpt-5.6-terra", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
+    { id: "gpt-5.6-terra-pro", maxOutput: 128_000, contextWindowTokens: 1_050_000 },
+    { id: "gpt-5.6-luna", maxOutput: 128_000, contextWindowTokens: 400_000 },
+    { id: "gpt-5.6-luna-pro", maxOutput: 128_000, contextWindowTokens: 400_000 },
+    { id: "gpt-5.5", maxOutput: 128_000, contextWindowTokens: 1_000_000 },
+    { id: "gpt-5.4-mini", maxOutput: 128_000, contextWindowTokens: 272_000 },
+    { id: "gpt-5.4", maxOutput: 128_000, contextWindowTokens: 272_000 },
     { id: "gpt-5.3-codex", maxOutput: 128_000, contextWindowTokens: 272_000 },
     { id: "gpt-5.3-codex-spark", maxOutput: 128_000, contextWindowTokens: 128_000 },
-    { id: "gpt-5.4", maxOutput: 128_000, contextWindowTokens: 272_000 },
-    { id: "gpt-5.4-mini", maxOutput: 128_000, contextWindowTokens: 272_000 },
   ],
 };

--- a/packages/core/src/llm/providers/index.ts
+++ b/packages/core/src/llm/providers/index.ts
@@ -1,6 +1,7 @@
 import type { InkosEndpoint } from "./types.js";
 import { ANTHROPIC } from "./endpoints/anthropic.js";
 import { OPENAI } from "./endpoints/openai.js";
+import { OPENAI_CODEX } from "./endpoints/openaiCodex.js";
 import { GOOGLE } from "./endpoints/google.js";
 import { DEEPSEEK } from "./endpoints/deepseek.js";
 import { MINIMAX } from "./endpoints/minimax.js";
@@ -49,7 +50,7 @@ export type { InkosEndpoint, InkosModel, ApiProtocol, EndpointGroup } from "./ty
  * 但 Layer 2 还会按 PROVIDER_PRIORITY 显式排序，所以此处顺序不影响结果。
  */
 const ALL_PROVIDERS: readonly InkosEndpoint[] = [
-  ANTHROPIC, OPENAI, GOOGLE, DEEPSEEK, MINIMAX,
+  ANTHROPIC, OPENAI, OPENAI_CODEX, GOOGLE, DEEPSEEK, MINIMAX,
   MOONSHOT, ZHIPU, SILICONCLOUD, BAILIAN, VOLCENGINE, HUNYUAN, BAICHUAN, STEPFUN, WENXIN,
   SPARK, SENSENOVA, TENCENTCLOUD, XIAOMI_MIMO, LONGCAT, INTERNLM,
   ZEROONE, AI360,

--- a/packages/core/src/llm/providers/types.ts
+++ b/packages/core/src/llm/providers/types.ts
@@ -9,6 +9,7 @@
 export type ApiProtocol =
   | "openai-completions"
   | "openai-responses"
+  | "openai-codex-responses"
   | "anthropic-messages"
   | "google-generative-ai";
 

--- a/packages/core/src/llm/secrets.ts
+++ b/packages/core/src/llm/secrets.ts
@@ -1,8 +1,19 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { getOAuthApiKey, type OAuthCredentials } from "@mariozechner/pi-ai/oauth";
+
+export interface OAuthServiceSecret {
+  provider: string;
+  credentials: OAuthCredentials;
+}
+
+export interface ServiceSecret {
+  apiKey?: string;
+  oauth?: OAuthServiceSecret;
+}
 
 export interface SecretsFile {
-  services: Record<string, { apiKey: string }>;
+  services: Record<string, ServiceSecret>;
 }
 
 const SECRETS_DIR = ".inkos";
@@ -69,9 +80,62 @@ export async function getServiceApiKey(
   const entry = secrets.services[service];
   if (entry?.apiKey) return entry.apiKey;
 
+  if (entry?.oauth) {
+    const result = await getOAuthApiKey(entry.oauth.provider, {
+      [entry.oauth.provider]: entry.oauth.credentials,
+    });
+    if (result) {
+      if (result.newCredentials !== entry.oauth.credentials) {
+        const latest = await loadSecrets(projectRoot);
+        const latestEntry = latest.services[service];
+        if (latestEntry?.oauth?.provider === entry.oauth.provider) {
+          latest.services[service] = {
+            oauth: {
+              provider: entry.oauth.provider,
+              credentials: result.newCredentials,
+            },
+          };
+          await saveSecrets(projectRoot, latest);
+        }
+      }
+      return result.apiKey;
+    }
+  }
+
   // 2. Environment variable: MOONSHOT_API_KEY, DEEPSEEK_API_KEY, etc.
   const envKey = `${service.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase()}_API_KEY`;
   if (process.env[envKey]) return process.env[envKey]!;
 
   return null;
+}
+
+export function hasServiceCredentials(secret: ServiceSecret | undefined): boolean {
+  return Boolean(secret?.apiKey || secret?.oauth?.credentials.access);
+}
+
+export function getServiceAuthStatus(secret: ServiceSecret | undefined): {
+  authType: "apiKey" | "oauth" | null;
+  connected: boolean;
+  expiresAt?: number;
+} {
+  if (secret?.apiKey) return { authType: "apiKey", connected: true };
+  if (secret?.oauth?.credentials.access) {
+    return {
+      authType: "oauth",
+      connected: true,
+      expiresAt: secret.oauth.credentials.expires,
+    };
+  }
+  return { authType: null, connected: false };
+}
+
+export async function saveServiceOAuthCredentials(
+  projectRoot: string,
+  service: string,
+  provider: string,
+  credentials: OAuthCredentials,
+): Promise<void> {
+  const secrets = await loadSecrets(projectRoot);
+  secrets.services[service] = { oauth: { provider, credentials } };
+  await saveSecrets(projectRoot, secrets);
 }

--- a/packages/core/src/llm/secrets.ts
+++ b/packages/core/src/llm/secrets.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import { getOAuthApiKey, type OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 
 export interface OAuthServiceSecret {
@@ -18,6 +19,7 @@ export interface SecretsFile {
 
 const SECRETS_DIR = ".inkos";
 const SECRETS_FILE = "secrets.json";
+const oauthApiKeyRequests = new Map<string, Promise<string | null>>();
 
 const LEGACY_SERVICE_ID_REMAP: Record<string, string> = {
   siliconflow: "siliconcloud",
@@ -81,24 +83,22 @@ export async function getServiceApiKey(
   if (entry?.apiKey) return entry.apiKey;
 
   if (entry?.oauth) {
-    const result = await getOAuthApiKey(entry.oauth.provider, {
-      [entry.oauth.provider]: entry.oauth.credentials,
-    });
-    if (result) {
-      if (result.newCredentials !== entry.oauth.credentials) {
-        const latest = await loadSecrets(projectRoot);
-        const latestEntry = latest.services[service];
-        if (latestEntry?.oauth?.provider === entry.oauth.provider) {
-          latest.services[service] = {
-            oauth: {
-              provider: entry.oauth.provider,
-              credentials: result.newCredentials,
-            },
-          };
-          await saveSecrets(projectRoot, latest);
-        }
+    const requestKey = [
+      join(projectRoot, SECRETS_DIR, SECRETS_FILE),
+      service,
+      oauthCredentialVersion(entry.oauth.credentials),
+    ].join("\0");
+    const activeRequest = oauthApiKeyRequests.get(requestKey);
+    if (activeRequest) return await activeRequest;
+
+    const request = resolveOAuthApiKey(projectRoot, service, entry.oauth);
+    oauthApiKeyRequests.set(requestKey, request);
+    try {
+      return await request;
+    } finally {
+      if (oauthApiKeyRequests.get(requestKey) === request) {
+        oauthApiKeyRequests.delete(requestKey);
       }
-      return result.apiKey;
     }
   }
 
@@ -107,6 +107,53 @@ export async function getServiceApiKey(
   if (process.env[envKey]) return process.env[envKey]!;
 
   return null;
+}
+
+async function resolveOAuthApiKey(
+  projectRoot: string,
+  service: string,
+  oauth: OAuthServiceSecret,
+): Promise<string | null> {
+  const originalCredentials = oauth.credentials;
+  const result = await getOAuthApiKey(oauth.provider, {
+    [oauth.provider]: originalCredentials,
+  });
+  if (!result) return null;
+
+  if (!sameOAuthCredentials(result.newCredentials, originalCredentials)) {
+    const latest = await loadSecrets(projectRoot);
+    const latestOAuth = latest.services[service]?.oauth;
+    if (
+      latestOAuth?.provider === oauth.provider
+      && sameOAuthCredentials(latestOAuth.credentials, originalCredentials)
+    ) {
+      latest.services[service] = {
+        ...latest.services[service],
+        oauth: {
+          provider: oauth.provider,
+          credentials: result.newCredentials,
+        },
+      };
+      await saveSecrets(projectRoot, latest);
+    }
+  }
+  return result.apiKey;
+}
+
+function sameOAuthCredentials(left: OAuthCredentials, right: OAuthCredentials): boolean {
+  return left.access === right.access
+    && left.refresh === right.refresh
+    && left.expires === right.expires;
+}
+
+function oauthCredentialVersion(credentials: OAuthCredentials): string {
+  return createHash("sha256")
+    .update(credentials.access)
+    .update("\0")
+    .update(credentials.refresh)
+    .update("\0")
+    .update(String(credentials.expires))
+    .digest("hex");
 }
 
 export function hasServiceCredentials(secret: ServiceSecret | undefined): boolean {

--- a/packages/core/src/llm/service-presets.ts
+++ b/packages/core/src/llm/service-presets.ts
@@ -87,6 +87,7 @@ export function resolveServiceProviderFamily(service: string): "openai" | "anthr
 
 export function resolveServicePiProvider(service: string): string | undefined {
   if (service === "google") return "google";
+  if (service === "openaiCodex") return "openai-codex";
   const preset = resolveServicePreset(service);
   if (!preset) return undefined;
   return preset.piProvider ?? preset.providerFamily;
@@ -129,6 +130,7 @@ export const SERVICE_TO_PI_PROVIDER: Record<string, string> = Object.fromEntries
     .map(([service, preset]) => [service, preset.piProvider ?? preset.providerFamily]),
 ) as Record<string, string>;
 SERVICE_TO_PI_PROVIDER.google = "google";
+SERVICE_TO_PI_PROVIDER.openaiCodex = "openai-codex";
 
 export interface ModelInfo {
   readonly id: string;

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { COVER_PROVIDER_IDS } from "../llm/cover-providers.js";
 
 // C1 (v2.0.0 breaking): `maxTokens` 字段已被 providers bank 接管；zod 用 strip mode 静默丢弃老配置里的 `maxTokens`。
 const LLMServiceEntrySchema = z.object({
@@ -11,7 +12,7 @@ const LLMServiceEntrySchema = z.object({
 });
 
 const LLMCoverConfigSchema = z.object({
-  service: z.enum(["kkaiapi", "openai", "google"]),
+  service: z.enum(COVER_PROVIDER_IDS),
   model: z.string().min(1),
 }).optional();
 

--- a/packages/core/src/pipeline/short-fiction-runner.ts
+++ b/packages/core/src/pipeline/short-fiction-runner.ts
@@ -29,7 +29,8 @@ import {
   type ShortFictionSalesPackage,
 } from "../agents/short-fiction.js";
 import { coverSecretKey, resolveCoverProviderPreset, type CoverProviderPreset } from "../llm/cover-providers.js";
-import { loadSecrets } from "../llm/secrets.js";
+import { generateOpenAICodexImage } from "../llm/openai-codex-images.js";
+import { getServiceApiKey, loadSecrets } from "../llm/secrets.js";
 import { safeChildPath } from "../utils/path-safety.js";
 import { toPosixPath as projectPath } from "../utils/posix-path.js";
 
@@ -585,6 +586,14 @@ export async function generateImageFromPrompt(
   size: string,
   signal?: AbortSignal,
 ): Promise<{ readonly buffer: Buffer; readonly extension: "png" | "jpg" }> {
+  if (request.api === "codex-responses") {
+    return generateOpenAICodexImage({
+      accessToken: request.apiKey,
+      prompt,
+      size,
+      signal,
+    });
+  }
   if (request.api === "gemini") {
     const payload = await generateGeminiCover(request, prompt, signal);
     return { buffer: Buffer.from(payload.base64, "base64"), extension: payload.extension };
@@ -666,7 +675,7 @@ export async function resolveCoverGenerationRequest(input: {
   }
   const apiKey = await resolveProjectCoverApiKey(input.root, projectCover.service);
   if (!apiKey) {
-    throw new Error(`Cover API key is required. Configure a cover key for ${preset.label}.`);
+    throw new Error(`Cover credentials are required. Connect ${preset.label} in Studio first.`);
   }
 
   return {
@@ -697,7 +706,7 @@ async function readProjectCoverConfig(root: string): Promise<{ readonly service:
 async function resolveProjectCoverApiKey(root: string, service: string): Promise<string> {
   const secrets = await loadSecrets(root);
   return secrets.services[coverSecretKey(service)]?.apiKey
-    || secrets.services[service]?.apiKey
+    || await getServiceApiKey(root, service)
     || process.env[`${service.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase()}_API_KEY`]
     || "";
 }

--- a/packages/core/src/utils/effective-llm-config.ts
+++ b/packages/core/src/utils/effective-llm-config.ts
@@ -1,7 +1,7 @@
 import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ProjectConfigSchema, type LLMConfig, type ProjectConfig } from "../models/project.js";
-import { loadSecrets } from "../llm/secrets.js";
+import { getServiceApiKey } from "../llm/secrets.js";
 import { getEndpoint } from "../llm/providers/index.js";
 import { guessServiceFromBaseUrl, resolveServicePreset, resolveServiceProviderFamily } from "../llm/service-presets.js";
 import { isApiKeyOptionalForEndpoint } from "./llm-endpoint-auth.js";
@@ -344,8 +344,7 @@ function applyCommonEnv(
 }
 
 async function getStudioServiceApiKey(projectRoot: string, serviceKey: string): Promise<string> {
-  const secrets = await loadSecrets(projectRoot);
-  return secrets.services[serviceKey]?.apiKey ?? "";
+  return await getServiceApiKey(projectRoot, serviceKey) ?? "";
 }
 
 function normalizeServiceEntries(raw: unknown): ServiceConfigEntry[] {

--- a/packages/studio/src/api/openai-codex-oauth.test.ts
+++ b/packages/studio/src/api/openai-codex-oauth.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenAICodexLoginOptions } from "@actalk/inkos-core";
-import { OpenAICodexOAuthSessionManager } from "./openai-codex-oauth.js";
+import {
+  OpenAICodexOAuthBusyError,
+  OpenAICodexOAuthSessionManager,
+} from "./openai-codex-oauth.js";
 
 describe("OpenAICodexOAuthSessionManager", () => {
   it("publishes the authorization URL and persists successful credentials", async () => {
@@ -45,7 +48,7 @@ describe("OpenAICodexOAuthSessionManager", () => {
     );
 
     const started = await manager.start();
-    await expect(manager.start()).rejects.toThrow("already in progress");
+    await expect(manager.start()).rejects.toBeInstanceOf(OpenAICodexOAuthBusyError);
     manager.submitCode(started.sessionId, "done");
   });
 });

--- a/packages/studio/src/api/openai-codex-oauth.test.ts
+++ b/packages/studio/src/api/openai-codex-oauth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenAICodexLoginOptions } from "@actalk/inkos-core";
+import { OpenAICodexOAuthSessionManager } from "./openai-codex-oauth.js";
+
+describe("OpenAICodexOAuthSessionManager", () => {
+  it("publishes the authorization URL and persists successful credentials", async () => {
+    const onCredentials = vi.fn(async () => {});
+    const login = vi.fn(async (options: OpenAICodexLoginOptions) => {
+      options.onAuth({ url: "https://auth.example/login", instructions: "Sign in" });
+      options.onProgress?.("Waiting for callback");
+      return { access: "access", refresh: "refresh", expires: 123 };
+    });
+    const manager = new OpenAICodexOAuthSessionManager(onCredentials, login);
+
+    const started = await manager.start();
+    expect(started.url).toBe("https://auth.example/login");
+    await vi.waitFor(() => expect(manager.status(started.sessionId)).toEqual({ state: "success" }));
+    expect(onCredentials).toHaveBeenCalledWith({ access: "access", refresh: "refresh", expires: 123 });
+  });
+
+  it("accepts a manual callback code", async () => {
+    const manager = new OpenAICodexOAuthSessionManager(
+      async () => {},
+      async (options) => {
+        options.onAuth({ url: "https://auth.example/login" });
+        const code = await options.onManualCodeInput!();
+        expect(code).toBe("code-from-browser");
+        return { access: "access", refresh: "refresh", expires: 123 };
+      },
+    );
+
+    const started = await manager.start();
+    expect(manager.submitCode(started.sessionId, " code-from-browser ")).toBe(true);
+    await vi.waitFor(() => expect(manager.status(started.sessionId)).toEqual({ state: "success" }));
+  });
+
+  it("rejects a second concurrent login", async () => {
+    const manager = new OpenAICodexOAuthSessionManager(
+      async () => {},
+      async (options) => {
+        options.onAuth({ url: "https://auth.example/login" });
+        await options.onManualCodeInput!();
+        return { access: "access", refresh: "refresh", expires: 123 };
+      },
+    );
+
+    const started = await manager.start();
+    await expect(manager.start()).rejects.toThrow("already in progress");
+    manager.submitCode(started.sessionId, "done");
+  });
+});

--- a/packages/studio/src/api/openai-codex-oauth.ts
+++ b/packages/studio/src/api/openai-codex-oauth.ts
@@ -23,6 +23,13 @@ export interface OpenAICodexOAuthSessionManagerLike {
   submitCode(sessionId: string, code: string): boolean;
 }
 
+export class OpenAICodexOAuthBusyError extends Error {
+  constructor() {
+    super("An OpenAI Codex login is already in progress.");
+    this.name = "OpenAICodexOAuthBusyError";
+  }
+}
+
 export class OpenAICodexOAuthSessionManager implements OpenAICodexOAuthSessionManagerLike {
   private readonly sessions = new Map<string, Session>();
   private activeSessionId: string | undefined;
@@ -35,7 +42,7 @@ export class OpenAICodexOAuthSessionManager implements OpenAICodexOAuthSessionMa
 
   async start(): Promise<{ sessionId: string; url: string; instructions?: string }> {
     if (this.activeSessionId) {
-      throw new Error("An OpenAI Codex login is already in progress.");
+      throw new OpenAICodexOAuthBusyError();
     }
 
     const sessionId = randomUUID();
@@ -82,7 +89,7 @@ export class OpenAICodexOAuthSessionManager implements OpenAICodexOAuthSessionMa
     }).finally(() => {
       clearTimeout(timeout);
       if (this.activeSessionId === sessionId) this.activeSessionId = undefined;
-      const cleanup = setTimeout(() => this.sessions.delete(sessionId), 5 * 60 * 1000);
+      const cleanup = setTimeout(() => this.sessions.delete(sessionId), 15 * 60 * 1000);
       cleanup.unref?.();
     });
 

--- a/packages/studio/src/api/openai-codex-oauth.ts
+++ b/packages/studio/src/api/openai-codex-oauth.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import type { OAuthCredentials, OpenAICodexLoginOptions } from "@actalk/inkos-core";
+
+export type OpenAICodexOAuthStatus =
+  | { state: "pending"; progress?: string }
+  | { state: "success" }
+  | { state: "error"; error: string };
+
+interface Session {
+  status: OpenAICodexOAuthStatus;
+  submitCode: (code: string) => void;
+}
+
+type Login = (options: OpenAICodexLoginOptions) => Promise<OAuthCredentials>;
+const defaultLogin: Login = async (options) => {
+  const { loginOpenAICodex } = await import("@actalk/inkos-core");
+  return await loginOpenAICodex(options);
+};
+
+export interface OpenAICodexOAuthSessionManagerLike {
+  start(): Promise<{ sessionId: string; url: string; instructions?: string }>;
+  status(sessionId: string): OpenAICodexOAuthStatus | undefined;
+  submitCode(sessionId: string, code: string): boolean;
+}
+
+export class OpenAICodexOAuthSessionManager implements OpenAICodexOAuthSessionManagerLike {
+  private readonly sessions = new Map<string, Session>();
+  private activeSessionId: string | undefined;
+
+  constructor(
+    private readonly onCredentials: (credentials: OAuthCredentials) => Promise<void>,
+    private readonly login: Login = defaultLogin,
+    private readonly timeoutMs = 10 * 60 * 1000,
+  ) {}
+
+  async start(): Promise<{ sessionId: string; url: string; instructions?: string }> {
+    if (this.activeSessionId) {
+      throw new Error("An OpenAI Codex login is already in progress.");
+    }
+
+    const sessionId = randomUUID();
+    let resolveCode!: (code: string) => void;
+    let rejectCode!: (error: Error) => void;
+    const manualCode = new Promise<string>((resolve, reject) => {
+      resolveCode = resolve;
+      rejectCode = reject;
+    });
+    const session: Session = {
+      status: { state: "pending" },
+      submitCode: resolveCode,
+    };
+    this.sessions.set(sessionId, session);
+    this.activeSessionId = sessionId;
+
+    let resolveAuth!: (value: { sessionId: string; url: string; instructions?: string }) => void;
+    let rejectAuth!: (error: Error) => void;
+    const auth = new Promise<{ sessionId: string; url: string; instructions?: string }>((resolve, reject) => {
+      resolveAuth = resolve;
+      rejectAuth = reject;
+    });
+    let authPublished = false;
+    const timeout = setTimeout(() => rejectCode(new Error("OpenAI Codex login timed out.")), this.timeoutMs);
+    timeout.unref?.();
+
+    void this.login({
+      onAuth: ({ url, instructions }) => {
+        authPublished = true;
+        resolveAuth({ sessionId, url, ...(instructions ? { instructions } : {}) });
+      },
+      onPrompt: async () => await manualCode,
+      onManualCodeInput: async () => await manualCode,
+      onProgress: (progress) => {
+        session.status = { state: "pending", progress };
+      },
+    }).then(async (credentials) => {
+      await this.onCredentials(credentials);
+      session.status = { state: "success" };
+    }).catch((error: unknown) => {
+      const normalized = error instanceof Error ? error : new Error(String(error));
+      session.status = { state: "error", error: normalized.message };
+      if (!authPublished) rejectAuth(normalized);
+    }).finally(() => {
+      clearTimeout(timeout);
+      if (this.activeSessionId === sessionId) this.activeSessionId = undefined;
+      const cleanup = setTimeout(() => this.sessions.delete(sessionId), 5 * 60 * 1000);
+      cleanup.unref?.();
+    });
+
+    return await auth;
+  }
+
+  status(sessionId: string): OpenAICodexOAuthStatus | undefined {
+    return this.sessions.get(sessionId)?.status;
+  }
+
+  submitCode(sessionId: string, code: string): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session || session.status.state !== "pending" || !code.trim()) return false;
+    session.submitCode(code.trim());
+    return true;
+  }
+}

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -105,7 +105,7 @@ const listModelsForServiceMock = vi.fn(async (service: string, apiKey?: string, 
   }));
 });
 const endpointIdsByGroup = {
-  overseas: ["anthropic", "google", "mistral", "openai", "xai"],
+  overseas: ["anthropic", "google", "mistral", "openai", "openaiCodex", "xai"],
   china: [
     "ai360", "baichuan", "bailian", "deepseek", "hunyuan", "internlm", "longcat",
     "minimax", "moonshot", "sensenova", "spark", "stepfun", "tencentcloud",
@@ -315,6 +315,13 @@ vi.mock("@actalk/inkos-core", async (importOriginal) => {
     loadSecrets: loadSecretsMock,
     saveSecrets: saveSecretsMock,
     getServiceApiKey: getServiceApiKeyMock,
+    hasServiceCredentials: actual.hasServiceCredentials,
+    getServiceAuthStatus: actual.getServiceAuthStatus,
+    saveServiceOAuthCredentials: actual.saveServiceOAuthCredentials,
+    loginOpenAICodex: actual.loginOpenAICodex,
+    OPENAI_CODEX_SERVICE_ID: actual.OPENAI_CODEX_SERVICE_ID,
+    OPENAI_CODEX_OAUTH_PROVIDER_ID: actual.OPENAI_CODEX_OAUTH_PROVIDER_ID,
+    OPENAI_CODEX_DEFAULT_MODEL: actual.OPENAI_CODEX_DEFAULT_MODEL,
     listModelsForService: listModelsForServiceMock,
     getAllEndpoints: getAllEndpointsMock,
     probeModelsFromUpstream: probeModelsFromUpstreamMock,
@@ -1026,9 +1033,9 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { services: Array<{ service: string; group?: string; connected: boolean }> };
     const bank = body.services.filter((s) => !s.service.startsWith("custom"));
-    expect(bank.length).toBe(37);
+    expect(bank.length).toBe(38);
     expect(bank.every((s) => typeof s.group === "string")).toBe(true);
-    expect(bank.filter((s) => s.group === "overseas")).toHaveLength(5);
+    expect(bank.filter((s) => s.group === "overseas")).toHaveLength(6);
     expect(bank.filter((s) => s.group === "china")).toHaveLength(18);
     expect(bank.filter((s) => s.group === "aggregator")).toHaveLength(4);
     expect(bank.filter((s) => s.group === "local")).toHaveLength(2);
@@ -1037,6 +1044,41 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(body.services.find((s) => s.service === "moonshot")?.connected).toBe(true);
     expect(body.services.find((s) => s.service === "custom:内网GPT")).toMatchObject({
       connected: true,
+    });
+  });
+
+  it("starts and polls OpenAI Codex OAuth without exposing tokens", async () => {
+    loadSecretsMock.mockResolvedValue({
+      services: {
+        openaiCodex: {
+          oauth: {
+            provider: "openai-codex",
+            credentials: { access: "secret-access", refresh: "secret-refresh", expires: 123 },
+          },
+        },
+      },
+    });
+    const oauth = {
+      start: vi.fn(async () => ({ sessionId: "oauth-1", url: "https://auth.example" })),
+      status: vi.fn(() => ({ state: "success" as const })),
+      submitCode: vi.fn(() => true),
+    };
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root, { openAICodexOAuth: oauth });
+
+    const start = await app.request("http://localhost/api/v1/services/openaiCodex/oauth/start", { method: "POST" });
+    expect(start.status).toBe(200);
+    await expect(start.json()).resolves.toEqual({ sessionId: "oauth-1", url: "https://auth.example" });
+
+    const status = await app.request("http://localhost/api/v1/services/openaiCodex/oauth/oauth-1");
+    await expect(status.json()).resolves.toEqual({ state: "success" });
+
+    const secret = await app.request("http://localhost/api/v1/services/openaiCodex/secret");
+    await expect(secret.json()).resolves.toEqual({
+      apiKey: "",
+      authType: "oauth",
+      connected: true,
+      expiresAt: 123,
     });
   });
 

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -48,6 +48,7 @@ const resolveServiceModelMock = vi.fn();
 const loadSecretsMock = vi.fn();
 const saveSecretsMock = vi.fn();
 const getServiceApiKeyMock = vi.fn();
+const listOpenAICodexModelsMock = vi.fn(async () => [] as string[]);
 const createLLMTranslationModelMock = vi.fn();
 const createShortFictionRunToolMock = vi.fn((_pipeline: unknown, _root: string, _options?: unknown) => ({
   name: "short_fiction_run",
@@ -127,7 +128,11 @@ const endpointMocks = [
     ...(id === "minimax" ? { checkModel: "MiniMax-M2.7" } : {}),
     ...(id === "ollama" ? { checkModel: "llama3.2:3b" } : {}),
     ...(id === "volcengine" ? { checkModel: "doubao-lite-32k" } : {}),
-    models: [
+    models: id === "openaiCodex" ? [
+      { id: "gpt-5.6-sol", maxOutput: 128_000, contextWindowTokens: 1_050_000, enabled: true },
+      { id: "gpt-5.6-terra", maxOutput: 128_000, contextWindowTokens: 1_050_000, enabled: true },
+      { id: "gpt-5.6-luna", maxOutput: 128_000, contextWindowTokens: 400_000, enabled: true },
+    ] : [
       { id: `${id}-model`, maxOutput: 4096, contextWindowTokens: 32768, enabled: true },
       { id: `${id}-disabled`, maxOutput: 4096, contextWindowTokens: 32768, enabled: false },
     ],
@@ -322,6 +327,7 @@ vi.mock("@actalk/inkos-core", async (importOriginal) => {
     OPENAI_CODEX_SERVICE_ID: actual.OPENAI_CODEX_SERVICE_ID,
     OPENAI_CODEX_OAUTH_PROVIDER_ID: actual.OPENAI_CODEX_OAUTH_PROVIDER_ID,
     OPENAI_CODEX_DEFAULT_MODEL: actual.OPENAI_CODEX_DEFAULT_MODEL,
+    listOpenAICodexModels: listOpenAICodexModelsMock,
     listModelsForService: listModelsForServiceMock,
     getAllEndpoints: getAllEndpointsMock,
     probeModelsFromUpstream: probeModelsFromUpstreamMock,
@@ -587,6 +593,7 @@ describe("createStudioServer daemon lifecycle", () => {
     loadSecretsMock.mockReset();
     saveSecretsMock.mockReset();
     getServiceApiKeyMock.mockReset();
+    listOpenAICodexModelsMock.mockReset();
     resolveServicePresetMock.mockClear();
     resolveServiceProviderFamilyMock.mockClear();
     resolveServiceModelsBaseUrlMock.mockClear();
@@ -625,6 +632,7 @@ describe("createStudioServer daemon lifecycle", () => {
     loadSecretsMock.mockResolvedValue({ services: {} });
     saveSecretsMock.mockResolvedValue(undefined);
     getServiceApiKeyMock.mockResolvedValue(undefined);
+    listOpenAICodexModelsMock.mockResolvedValue([]);
   });
 
   afterEach(async () => {
@@ -1089,6 +1097,41 @@ describe("createStudioServer daemon lifecycle", () => {
       connected: true,
       expiresAt: 123,
     });
+  });
+
+  it("discovers the signed-in Codex account model catalog and exposes GPT-5.6", async () => {
+    loadSecretsMock.mockResolvedValue({
+      services: {
+        openaiCodex: {
+          oauth: {
+            provider: "openai-codex",
+            credentials: { access: "access", refresh: "refresh", expires: Date.now() + 60_000 },
+          },
+        },
+      },
+    });
+    getServiceApiKeyMock.mockResolvedValue("refreshed-access");
+    listOpenAICodexModelsMock.mockResolvedValue([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "account-specific-model",
+    ]);
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+    const response = await app.request("http://localhost/api/v1/services/openaiCodex/models?refresh=1");
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { models: Array<{ id: string; contextWindow: number }> };
+    expect(body.models.map((model) => model.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "account-specific-model",
+    ]);
+    expect(body.models.find((model) => model.id === "gpt-5.6-sol")?.contextWindow).toBe(1_050_000);
+    expect(listOpenAICodexModelsMock).toHaveBeenCalledWith("refreshed-access");
   });
 
   it("returns connected bank model groups from the local bank", async () => {
@@ -2335,6 +2378,45 @@ describe("createStudioServer daemon lifecycle", () => {
         "cover:kkaiapi": { apiKey: "sk-cover" },
       },
     });
+  });
+
+  it("offers Codex OAuth as a cover provider without exposing or accepting a cover API key", async () => {
+    loadSecretsMock.mockResolvedValue({
+      services: {
+        openaiCodex: {
+          oauth: {
+            provider: "openai-codex",
+            credentials: { access: "secret", refresh: "refresh", expires: Date.now() + 60_000 },
+          },
+        },
+      },
+    });
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+    const configResponse = await app.request("http://localhost/api/v1/cover/config");
+    const config = await configResponse.json() as {
+      providers: Array<{ service: string; authType: string; connected: boolean }>;
+    };
+    expect(config.providers.find((provider) => provider.service === "openaiCodex")).toMatchObject({
+      authType: "oauth",
+      connected: true,
+    });
+
+    const secretResponse = await app.request("http://localhost/api/v1/cover/secret/openaiCodex");
+    await expect(secretResponse.json()).resolves.toEqual({
+      apiKey: "",
+      authType: "oauth",
+      connected: true,
+    });
+
+    const rejected = await app.request("http://localhost/api/v1/cover/secret/openaiCodex", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiKey: "must-not-be-saved" }),
+    });
+    expect(rejected.status).toBe(400);
+    expect(saveSecretsMock).not.toHaveBeenCalled();
   });
 
   it("serves generated project cover images without exposing arbitrary files", async () => {

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -1073,6 +1073,15 @@ describe("createStudioServer daemon lifecycle", () => {
     const status = await app.request("http://localhost/api/v1/services/openaiCodex/oauth/oauth-1");
     await expect(status.json()).resolves.toEqual({ state: "success" });
 
+    const { OpenAICodexOAuthBusyError } = await import("./openai-codex-oauth.js");
+    oauth.start.mockRejectedValueOnce(new OpenAICodexOAuthBusyError());
+    const conflict = await app.request("http://localhost/api/v1/services/openaiCodex/oauth/start", { method: "POST" });
+    expect(conflict.status).toBe(409);
+
+    oauth.start.mockRejectedValueOnce(new Error("OAuth initialization failed"));
+    const failure = await app.request("http://localhost/api/v1/services/openaiCodex/oauth/start", { method: "POST" });
+    expect(failure.status).toBe(500);
+
     const secret = await app.request("http://localhost/api/v1/services/openaiCodex/secret");
     await expect(secret.json()).resolves.toEqual({
       apiKey: "",

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -132,6 +132,7 @@ import { ApiError } from "./errors.js";
 import { buildStudioBookConfig } from "./book-create.js";
 import {
   OpenAICodexOAuthSessionManager,
+  OpenAICodexOAuthBusyError,
   type OpenAICodexOAuthSessionManagerLike,
 } from "./openai-codex-oauth.js";
 import {
@@ -3714,7 +3715,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     } catch (error) {
       return c.json({
         error: error instanceof Error ? error.message : String(error),
-      }, 409);
+      }, error instanceof OpenAICodexOAuthBusyError ? 409 : 500);
     }
   });
 

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -32,6 +32,12 @@ import {
   resolveServiceModel,
   loadSecrets,
   saveSecrets,
+  hasServiceCredentials,
+  getServiceAuthStatus,
+  saveServiceOAuthCredentials,
+  OPENAI_CODEX_SERVICE_ID,
+  OPENAI_CODEX_OAUTH_PROVIDER_ID,
+  OPENAI_CODEX_DEFAULT_MODEL,
   listModelsForService,
   isApiKeyOptionalForEndpoint,
   getAllEndpoints,
@@ -124,6 +130,10 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { isSafeBookId } from "./safety.js";
 import { ApiError } from "./errors.js";
 import { buildStudioBookConfig } from "./book-create.js";
+import {
+  OpenAICodexOAuthSessionManager,
+  type OpenAICodexOAuthSessionManagerLike,
+} from "./openai-codex-oauth.js";
 import {
   deleteStudioTaskSnapshot,
   loadStudioTaskSnapshot,
@@ -2689,7 +2699,10 @@ async function probeServiceCapabilities(args: {
 
 // --- Server factory ---
 
-export function createStudioServer(initialConfig: ProjectConfig, root: string, overrides: { readonly nodeImageGenerator?: NodeImageDeps } = {}) {
+export function createStudioServer(initialConfig: ProjectConfig, root: string, overrides: {
+  readonly nodeImageGenerator?: NodeImageDeps;
+  readonly openAICodexOAuth?: OpenAICodexOAuthSessionManagerLike;
+} = {}) {
   const app = new Hono();
   const state = new StateManager(root);
   let cachedConfig = initialConfig;
@@ -2705,6 +2718,31 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
   // 已删除会话的 sessionId：删除会话时中止其生产任务，任务随后的错误持久化
   // 不能把快照文件重新写回来（给已删除的会话"还魂"）。同名会话重新创建时移除标记。
   const deletedSessionIds = new Set<string>();
+  const configureOpenAICodex = async (credentials: import("@actalk/inkos-core").OAuthCredentials): Promise<void> => {
+    await saveServiceOAuthCredentials(
+      root,
+      OPENAI_CODEX_SERVICE_ID,
+      OPENAI_CODEX_OAUTH_PROVIDER_ID,
+      credentials,
+    );
+    const config = await loadRawConfig(root);
+    config.llm = config.llm ?? {};
+    const llm = config.llm as Record<string, unknown>;
+    const existingServices = normalizeServiceConfig(llm.services);
+    llm.services = mergeServiceConfig(existingServices, [{
+      service: OPENAI_CODEX_SERVICE_ID,
+      temperature: 1,
+      apiFormat: "responses",
+      stream: true,
+    }]);
+    llm.service = OPENAI_CODEX_SERVICE_ID;
+    llm.defaultModel = OPENAI_CODEX_DEFAULT_MODEL;
+    llm.configSource = "studio";
+    syncTopLevelLlmMirror(llm);
+    await saveRawConfig(root, config);
+  };
+  const openAICodexOAuth = overrides.openAICodexOAuth
+    ?? new OpenAICodexOAuthSessionManager(configureOpenAICodex);
 
   // 已删除会话不再追加 transcript 消息：appendManualSessionMessages 底层的
   // appendTranscriptEvents 是 mkdir + appendFile，会把已删除会话的 sessions
@@ -3441,7 +3479,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
       service: ep.id,
       label: ep.label,
       group: ep.group,
-      connected: Boolean(secrets.services[ep.id]?.apiKey),
+      connected: hasServiceCredentials(secrets.services[ep.id]),
     })).sort(compareServiceListItems);
 
     // Add custom services from inkos.json
@@ -3454,7 +3492,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
             service: secretKey,
             label: svc.name ?? "Custom",
             group: undefined,
-            connected: Boolean(secrets.services[secretKey]?.apiKey),
+            connected: hasServiceCredentials(secrets.services[secretKey]),
           });
         }
       }
@@ -3670,6 +3708,27 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     return c.json({ ok: true, service });
   });
 
+  app.post("/api/v1/services/openaiCodex/oauth/start", async (c) => {
+    try {
+      return c.json(await openAICodexOAuth.start());
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : String(error),
+      }, 409);
+    }
+  });
+
+  app.get("/api/v1/services/openaiCodex/oauth/:sessionId", (c) => {
+    const status = openAICodexOAuth.status(c.req.param("sessionId"));
+    return status ? c.json(status) : c.json({ error: "OAuth session not found." }, 404);
+  });
+
+  app.post("/api/v1/services/openaiCodex/oauth/:sessionId/code", async (c) => {
+    const { code } = await c.req.json<{ code?: string }>();
+    const accepted = openAICodexOAuth.submitCode(c.req.param("sessionId"), code ?? "");
+    return accepted ? c.json({ ok: true }) : c.json({ error: "OAuth session is not pending." }, 409);
+  });
+
   app.post("/api/v1/services/:service/test", async (c) => {
     const service = c.req.param("service");
     const { apiKey, baseUrl, apiFormat, stream } = await c.req.json<{
@@ -3774,15 +3833,21 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
   app.get("/api/v1/services/:service/secret", async (c) => {
     const service = c.req.param("service");
     const secrets = await loadSecrets(root);
+    const secret = secrets.services[service];
+    const auth = getServiceAuthStatus(secret);
+    if (auth.authType === "apiKey") {
+      return c.json({ apiKey: secret?.apiKey ?? "" });
+    }
     return c.json({
-      apiKey: secrets.services[service]?.apiKey ?? "",
+      apiKey: "",
+      ...auth,
     });
   });
 
   app.get("/api/v1/services/models", async (c) => {
     const secrets = await loadSecrets(root);
     const endpoints = getAllEndpoints()
-      .filter((ep) => ep.id !== "custom" && Boolean(secrets.services[ep.id]?.apiKey));
+      .filter((ep) => ep.id !== "custom" && hasServiceCredentials(secrets.services[ep.id]));
 
     const groups = endpoints.map((ep) => ({
       service: ep.id,
@@ -3823,7 +3888,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
       service: s.id,
       label: s.label,
       models: filterTextChatModels(
-        await probeModelsFromUpstream(s.baseUrl, secrets.services[s.id].apiKey, 10_000),
+        await probeModelsFromUpstream(s.baseUrl, secrets.services[s.id].apiKey!, 10_000),
       ),
     })));
 
@@ -3834,6 +3899,19 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const service = c.req.param("service");
     const refresh = c.req.query("refresh") === "1";
     const secrets = await loadSecrets(root);
+    if (service === OPENAI_CODEX_SERVICE_ID && hasServiceCredentials(secrets.services[service])) {
+      const endpoint = getAllEndpoints().find((candidate) => candidate.id === service);
+      return c.json({
+        models: (endpoint?.models ?? [])
+          .filter((model) => model.enabled !== false)
+          .map((model) => ({
+            id: model.id,
+            name: model.id,
+            maxOutput: model.maxOutput,
+            contextWindow: model.contextWindowTokens,
+          })),
+      });
+    }
     const apiKey = c.req.query("apiKey") || secrets.services[service]?.apiKey || "";
 
     const resolvedBaseUrl = await resolveConfiguredServiceBaseUrl(root, service);

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -32,12 +32,14 @@ import {
   resolveServiceModel,
   loadSecrets,
   saveSecrets,
+  getServiceApiKey,
   hasServiceCredentials,
   getServiceAuthStatus,
   saveServiceOAuthCredentials,
   OPENAI_CODEX_SERVICE_ID,
   OPENAI_CODEX_OAUTH_PROVIDER_ID,
   OPENAI_CODEX_DEFAULT_MODEL,
+  listOpenAICodexModels,
   listModelsForService,
   isApiKeyOptionalForEndpoint,
   getAllEndpoints,
@@ -3604,7 +3606,8 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const cover = normalizeCoverConfig(llm.cover);
     const secrets = await loadSecrets(root);
     const keyFor = (service: string): boolean =>
-      Boolean(secrets.services[coverSecretKey(service)]?.apiKey || secrets.services[service]?.apiKey);
+      hasServiceCredentials(secrets.services[coverSecretKey(service)])
+      || hasServiceCredentials(secrets.services[service]);
     // "Configured" = a cover service is selected AND has a key, OR a cover
     // endpoint is provided via env (the CLI/power-user path). This is the gate
     // for the Play auto-illustration toggles.
@@ -3624,6 +3627,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
         defaultModel: provider.defaultModel,
         models: provider.models,
         connected: keyFor(provider.service),
+        authType: provider.service === OPENAI_CODEX_SERVICE_ID ? "oauth" : "apiKey",
       })),
     });
   });
@@ -3655,6 +3659,13 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
       return c.json({ error: "Unsupported cover service" }, 400);
     }
     const secrets = await loadSecrets(root);
+    if (service === OPENAI_CODEX_SERVICE_ID) {
+      return c.json({
+        apiKey: "",
+        authType: "oauth",
+        connected: hasServiceCredentials(secrets.services[service]),
+      });
+    }
     return c.json({ apiKey: secrets.services[coverSecretKey(service)]?.apiKey ?? "" });
   });
 
@@ -3662,6 +3673,9 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const service = c.req.param("service");
     if (!resolveCoverProviderPreset(service)) {
       return c.json({ error: "Unsupported cover service" }, 400);
+    }
+    if (service === OPENAI_CODEX_SERVICE_ID) {
+      return c.json({ error: "OpenAI Codex cover generation uses ChatGPT OAuth, not an API key." }, 400);
     }
     const body = await c.req.json<{ apiKey?: string }>();
     const trimmedKey = body.apiKey?.trim() ?? "";
@@ -3902,15 +3916,30 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const secrets = await loadSecrets(root);
     if (service === OPENAI_CODEX_SERVICE_ID && hasServiceCredentials(secrets.services[service])) {
       const endpoint = getAllEndpoints().find((candidate) => candidate.id === service);
+      let liveModelIds: string[] = [];
+      try {
+        const accessToken = await getServiceApiKey(root, service);
+        if (accessToken) liveModelIds = await listOpenAICodexModels(accessToken);
+      } catch {
+        // Keep the curated fallback available when catalog discovery is offline
+        // or the account endpoint temporarily rejects the request.
+      }
+      const fallbackModels = (endpoint?.models ?? []).filter((model) => model.enabled !== false);
+      const cardsById = new Map(fallbackModels.map((model) => [model.id, model]));
+      const models = liveModelIds.length > 0
+        ? liveModelIds.map((id) => cardsById.get(id) ?? {
+          id,
+          maxOutput: 128_000,
+          contextWindowTokens: 272_000,
+        })
+        : fallbackModels;
       return c.json({
-        models: (endpoint?.models ?? [])
-          .filter((model) => model.enabled !== false)
-          .map((model) => ({
-            id: model.id,
-            name: model.id,
-            maxOutput: model.maxOutput,
-            contextWindow: model.contextWindowTokens,
-          })),
+        models: models.map((model) => ({
+          id: model.id,
+          name: model.id,
+          maxOutput: model.maxOutput,
+          contextWindow: model.contextWindowTokens,
+        })),
       });
     }
     const apiKey = c.req.query("apiKey") || secrets.services[service]?.apiKey || "";

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { fetchJson } from "../hooks/use-api";
 import { useServiceStore } from "../store/service";
 import { Eye, EyeOff, Loader2, ArrowLeft, Trash2 } from "lucide-react";
@@ -64,6 +64,11 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [verifiedProbe, setVerifiedProbe] = useState<VerifiedProbe | null>(null);
   const [oauthSessionId, setOauthSessionId] = useState("");
   const [oauthCode, setOauthCode] = useState("");
+  const oauthAttemptRef = useRef(0);
+
+  useEffect(() => () => {
+    oauthAttemptRef.current += 1;
+  }, [serviceId]);
 
   // -- Unified connection status --
   const [status, setStatus] = useState<ConnectionStatus>({ state: "idle" });
@@ -187,22 +192,27 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   };
 
   const handleOpenAICodexLogin = async () => {
+    const attemptId = ++oauthAttemptRef.current;
     setStatus({ state: "testing" });
     const popup = window.open("about:blank", "inkos-openai-codex-oauth", "popup,width=720,height=820");
     if (popup) popup.opener = null;
     try {
       const login = await startOpenAICodexOAuth();
+      if (oauthAttemptRef.current !== attemptId) return;
       setOauthSessionId(login.sessionId);
       if (popup) popup.location.href = login.url;
       else window.location.assign(login.url);
 
       for (let attempt = 0; attempt < 600; attempt += 1) {
         await new Promise((resolve) => window.setTimeout(resolve, 1_000));
+        if (oauthAttemptRef.current !== attemptId) return;
         const current = await readOpenAICodexOAuthStatus(login.sessionId);
         if (current.state === "error") throw new Error(current.error);
         if (current.state === "success") {
           await refreshServices();
           await fetchLiveModels(serviceId);
+          if (oauthAttemptRef.current !== attemptId) return;
+          popup?.close();
           setStatus({ state: "idle" });
           setOauthSessionId("");
           setOauthCode("");
@@ -212,6 +222,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
       throw new Error(tr("登录超时，请重试", "Login timed out; try again"));
     } catch (error) {
       popup?.close();
+      if (oauthAttemptRef.current !== attemptId) return;
       setStatus({ state: "error", message: error instanceof Error ? error.message : tr("登录失败", "Login failed") });
     }
   };

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -10,6 +10,9 @@ import {
   probeServiceForDetail,
   rehydrateServiceConnectionStatus,
   saveServiceConfig,
+  startOpenAICodexOAuth,
+  readOpenAICodexOAuthStatus,
+  submitOpenAICodexOAuthCode,
   type ServiceDetailConnectionStatus as ConnectionStatus,
   type ServiceDetailDetectedConfig as DetectedConfig,
   type ServiceDetailModelInfo as ModelInfo,
@@ -37,6 +40,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const loading = useServiceStore((s) => s.servicesLoading);
   const fetchServices = useServiceStore((s) => s.fetchServices);
   const refreshServices = useServiceStore((s) => s.refreshServices);
+  const fetchLiveModels = useServiceStore((s) => s.fetchLiveModels);
   const setStoreModels = useServiceStore((s) => s.setLiveModels);
   const clearStoreModels = useServiceStore((s) => s.clearModels);
 
@@ -44,6 +48,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
 
   const svc = services.find((s) => s.service === serviceId);
   const isCustom = serviceId === "custom" || serviceId.startsWith("custom:");
+  const isOpenAICodex = serviceId === "openaiCodex";
   const persistedCustomName = serviceId.startsWith("custom:") ? decodeURIComponent(serviceId.slice("custom:".length)) : "";
 
   // -- Local form state --
@@ -57,6 +62,8 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [detectedModel, setDetectedModel] = useState<string>("");
   const [detectedConfig, setDetectedConfig] = useState<DetectedConfig | null>(null);
   const [verifiedProbe, setVerifiedProbe] = useState<VerifiedProbe | null>(null);
+  const [oauthSessionId, setOauthSessionId] = useState("");
+  const [oauthCode, setOauthCode] = useState("");
 
   // -- Unified connection status --
   const [status, setStatus] = useState<ConnectionStatus>({ state: "idle" });
@@ -179,6 +186,45 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
     }
   };
 
+  const handleOpenAICodexLogin = async () => {
+    setStatus({ state: "testing" });
+    const popup = window.open("about:blank", "inkos-openai-codex-oauth", "popup,width=720,height=820");
+    if (popup) popup.opener = null;
+    try {
+      const login = await startOpenAICodexOAuth();
+      setOauthSessionId(login.sessionId);
+      if (popup) popup.location.href = login.url;
+      else window.location.assign(login.url);
+
+      for (let attempt = 0; attempt < 600; attempt += 1) {
+        await new Promise((resolve) => window.setTimeout(resolve, 1_000));
+        const current = await readOpenAICodexOAuthStatus(login.sessionId);
+        if (current.state === "error") throw new Error(current.error);
+        if (current.state === "success") {
+          await refreshServices();
+          await fetchLiveModels(serviceId);
+          setStatus({ state: "idle" });
+          setOauthSessionId("");
+          setOauthCode("");
+          return;
+        }
+      }
+      throw new Error(tr("登录超时，请重试", "Login timed out; try again"));
+    } catch (error) {
+      popup?.close();
+      setStatus({ state: "error", message: error instanceof Error ? error.message : tr("登录失败", "Login failed") });
+    }
+  };
+
+  const handleOpenAICodexCode = async () => {
+    if (!oauthSessionId || !oauthCode.trim()) return;
+    try {
+      await submitOpenAICodexOAuthCode(oauthSessionId, oauthCode.trim());
+    } catch (error) {
+      setStatus({ state: "error", message: error instanceof Error ? error.message : tr("提交失败", "Submission failed") });
+    }
+  };
+
   const handleDelete = async () => {
     if (!window.confirm(tr(`删除“${label}”的配置和密钥？`, `Delete the config and key for “${label}”?`))) return;
     setStatus({ state: "saving" });
@@ -270,6 +316,50 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
           </div>
         )}
 
+        {isOpenAICodex ? (
+          <div className="space-y-3 rounded-xl border border-border/60 bg-card/60 p-4">
+            <p className="text-sm text-muted-foreground">
+              {tr(
+                "使用浏览器登录 ChatGPT。InkOS 会保存并自动刷新 OAuth 凭据，不需要填写 API Key。",
+                "Sign in to ChatGPT in your browser. InkOS stores and refreshes the OAuth credentials; no API key is needed.",
+              )}
+            </p>
+            <div className="flex items-center gap-2">
+              <button onClick={handleOpenAICodexLogin} disabled={isBusy}
+                className="flex items-center gap-1.5 px-3.5 py-2 text-xs rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50">
+                {status.state === "testing" && <Loader2 size={12} className="animate-spin" />}
+                {isConnected ? tr("重新登录 ChatGPT", "Sign in again") : tr("使用 ChatGPT 登录", "Sign in with ChatGPT")}
+              </button>
+              {isConnected && (
+                <button onClick={handleDelete} disabled={isBusy}
+                  className="flex items-center gap-1.5 px-3.5 py-2 text-xs rounded-lg border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50">
+                  <Trash2 size={12} />
+                  {tr("退出并删除配置", "Sign out and delete")}
+                </button>
+              )}
+            </div>
+            {status.state === "testing" && oauthSessionId && (
+              <div className="space-y-2 border-t border-border/40 pt-3">
+                <p className="text-xs text-muted-foreground">
+                  {tr(
+                    "如果浏览器无法自动返回 InkOS，请粘贴最终回调地址或授权码。",
+                    "If the browser cannot return to InkOS automatically, paste the final callback URL or authorization code.",
+                  )}
+                </p>
+                <div className="flex gap-2">
+                  <input value={oauthCode} onChange={(event) => setOauthCode(event.target.value)}
+                    className="min-w-0 flex-1 rounded-lg border border-border/60 bg-background px-3 py-2 text-xs font-mono"
+                    placeholder={tr("回调地址或授权码", "Callback URL or authorization code")} />
+                  <button onClick={handleOpenAICodexCode} disabled={!oauthCode.trim()}
+                    className="rounded-lg border border-border/60 px-3 py-2 text-xs hover:bg-secondary/50 disabled:opacity-50">
+                    {tr("提交", "Submit")}
+                  </button>
+                </div>
+              </div>
+            )}
+            {status.state === "error" && <p className="text-xs text-destructive">{status.message}</p>}
+          </div>
+        ) : <>
         {/* API Key */}
         <Field label="API Key">
           <div className="relative">
@@ -384,6 +474,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
             </Field>
           </div>
         </details>
+        </>}
       </div>
     </div>
   );

--- a/packages/studio/src/pages/ServiceListPage.tsx
+++ b/packages/studio/src/pages/ServiceListPage.tsx
@@ -59,6 +59,7 @@ interface CoverProviderInfo {
   readonly defaultModel: string;
   readonly models: readonly string[];
   readonly connected: boolean;
+  readonly authType: "apiKey" | "oauth";
 }
 
 interface CoverConfigPayload {
@@ -100,6 +101,11 @@ function CoverConfigCard() {
 
   useEffect(() => {
     if (!service) return;
+    const provider = providers.find((item) => item.service === service);
+    if (provider?.authType === "oauth") {
+      setApiKey("");
+      return;
+    }
     let cancelled = false;
     void fetchJson<{ apiKey?: string }>(`/cover/secret/${encodeURIComponent(service)}`)
       .then((payload) => {
@@ -110,7 +116,7 @@ function CoverConfigCard() {
         if (!cancelled) setApiKey("");
       });
     return () => { cancelled = true; };
-  }, [service]);
+  }, [providers, service]);
 
   const handleServiceChange = (nextService: string) => {
     const provider = providers.find((item) => item.service === nextService);
@@ -126,11 +132,13 @@ function CoverConfigCard() {
     setStatus("saving");
     setMessage("");
     try {
-      await fetchJson(`/cover/secret/${encodeURIComponent(provider.service)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ apiKey: apiKey.trim() }),
-      });
+      if (provider.authType === "apiKey") {
+        await fetchJson(`/cover/secret/${encodeURIComponent(provider.service)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ apiKey: apiKey.trim() }),
+        });
+      }
       await fetchJson("/cover/config", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -160,7 +168,7 @@ function CoverConfigCard() {
         </div>
         {selected?.connected && (
           <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-500">
-            {tr("已有密钥", "Key saved")}
+            {selected.authType === "oauth" ? tr("已登录", "Signed in") : tr("已有密钥", "Key saved")}
           </span>
         )}
       </div>
@@ -192,7 +200,13 @@ function CoverConfigCard() {
         </label>
       </div>
 
-      <label className="space-y-1.5">
+      {selected?.authType === "oauth" ? (
+        <div className="rounded-lg border border-border/60 bg-background px-3 py-2 text-xs text-muted-foreground">
+          {selected.connected
+            ? tr("将复用 OpenAI Codex 服务的 ChatGPT 登录凭据。", "Uses the ChatGPT credentials from the OpenAI Codex service.")
+            : tr("请先在下方服务商列表打开 OpenAI Codex，并使用 ChatGPT 登录。", "Open OpenAI Codex in the provider list below and sign in with ChatGPT first.")}
+        </div>
+      ) : <label className="space-y-1.5">
         <span className="block text-xs font-medium text-muted-foreground/70">API Key</span>
         <div className="relative">
           <input
@@ -210,12 +224,12 @@ function CoverConfigCard() {
             {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
           </button>
         </div>
-      </label>
+      </label>}
 
       <div className="flex flex-wrap items-center gap-3">
         <button
           onClick={handleSave}
-          disabled={status === "saving" || !selected}
+          disabled={status === "saving" || !selected || (selected.authType === "oauth" && !selected.connected)}
           className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-xs text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
         >
           {status === "saving" && <Loader2 size={12} className="animate-spin" />}

--- a/packages/studio/src/pages/service-detail-state.test.ts
+++ b/packages/studio/src/pages/service-detail-state.test.ts
@@ -4,7 +4,40 @@ import {
   matchServiceConfigEntryForDetail,
   rehydrateServiceConnectionStatus,
   saveServiceConfig,
+  startOpenAICodexOAuth,
+  readOpenAICodexOAuthStatus,
+  submitOpenAICodexOAuthCode,
 } from "./service-detail-state";
+
+describe("OpenAI Codex OAuth API", () => {
+  it("starts login and reads its status", async () => {
+    const fetchJsonImpl = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path === "/services/openaiCodex/oauth/start") {
+        expect(init?.method).toBe("POST");
+        return { sessionId: "session-1", url: "https://auth.example" };
+      }
+      if (path === "/services/openaiCodex/oauth/session-1") {
+        return { state: "success" };
+      }
+      if (path === "/services/openaiCodex/oauth/session-1/code") {
+        expect(init).toMatchObject({ method: "POST" });
+        expect(JSON.parse(String(init?.body))).toEqual({ code: "callback-code" });
+        return { ok: true };
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    await expect(startOpenAICodexOAuth({ fetchJsonImpl: fetchJsonImpl as never })).resolves.toEqual({
+      sessionId: "session-1",
+      url: "https://auth.example",
+    });
+    await expect(readOpenAICodexOAuthStatus("session-1", { fetchJsonImpl: fetchJsonImpl as never }))
+      .resolves.toEqual({ state: "success" });
+    await expect(submitOpenAICodexOAuthCode("session-1", "callback-code", {
+      fetchJsonImpl: fetchJsonImpl as never,
+    })).resolves.toBeUndefined();
+  });
+});
 
 describe("rehydrateServiceConnectionStatus", () => {
   it("loads saved key without probing models on page load", async () => {

--- a/packages/studio/src/pages/service-detail-state.ts
+++ b/packages/studio/src/pages/service-detail-state.ts
@@ -40,6 +40,50 @@ export interface ServiceDetailVerifiedProbe {
   readonly detected?: ServiceDetailDetectedConfig;
 }
 
+export interface OpenAICodexOAuthStart {
+  readonly sessionId: string;
+  readonly url: string;
+  readonly instructions?: string;
+}
+
+export type OpenAICodexOAuthStatus =
+  | { readonly state: "pending"; readonly progress?: string }
+  | { readonly state: "success" }
+  | { readonly state: "error"; readonly error: string };
+
+export async function startOpenAICodexOAuth(
+  deps?: { readonly fetchJsonImpl?: JsonFetcher },
+): Promise<OpenAICodexOAuthStart> {
+  return await (deps?.fetchJsonImpl ?? fetchJson)<OpenAICodexOAuthStart>(
+    "/services/openaiCodex/oauth/start",
+    { method: "POST" },
+  );
+}
+
+export async function readOpenAICodexOAuthStatus(
+  sessionId: string,
+  deps?: { readonly fetchJsonImpl?: JsonFetcher },
+): Promise<OpenAICodexOAuthStatus> {
+  return await (deps?.fetchJsonImpl ?? fetchJson)<OpenAICodexOAuthStatus>(
+    `/services/openaiCodex/oauth/${encodeURIComponent(sessionId)}`,
+  );
+}
+
+export async function submitOpenAICodexOAuthCode(
+  sessionId: string,
+  code: string,
+  deps?: { readonly fetchJsonImpl?: JsonFetcher },
+): Promise<void> {
+  await (deps?.fetchJsonImpl ?? fetchJson)(
+    `/services/openaiCodex/oauth/${encodeURIComponent(sessionId)}/code`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    },
+  );
+}
+
 export async function probeServiceForDetail(
   serviceId: string,
   body: {


### PR DESCRIPTION
## Summary

- add OpenAI Codex (ChatGPT) as a native provider using the existing pi-ai OAuth and Responses transport
- persist OAuth credentials per project, refresh expired access tokens automatically, and reuse them across Studio, CLI, and daemon runtimes
- add Studio browser login, callback polling, manual-code fallback, logout, model selection, and token-redacted service status
- discover the signed-in account's model catalog from the Codex backend and expose GPT-5.6 Sol, Terra, and Luna fallbacks when discovery is unavailable or lagging
- let cover generation reuse the same ChatGPT OAuth credentials and invoke the hosted `gpt-image-2` tool through Codex Responses
- parse bounded SSE image responses, normalize cover dimensions to supported image sizes, and fall back only when a host model slug is rejected
- harden the integration against concurrent token refreshes, stale credential overwrites, stale UI polling, and incorrect OAuth startup status codes
- document the login, dynamic-model, and OAuth cover flows in Chinese and English

## Why

The Studio Codex model list was curated statically, so newer GPT-5.6 variants were absent even when the signed-in account could use them. Cover generation also required a separate image-provider API key despite the Codex backend supporting the hosted image tool with the same ChatGPT OAuth session.

## Validation

- `npx --yes pnpm@10.28.2 typecheck`
- `npx --yes pnpm@10.28.2 build`
- Studio full suite: 59 files / 557 tests passed
- CLI full suite: 41 files / 229 tests passed
- Core affected suites: 7 files / 113 tests passed
- Core full suite: 181 files / 1773 tests passed; 2 pre-existing Windows symlink fixture tests still cannot create symlinks under the current account (`EPERM`)

## Security and compatibility

- OAuth access and refresh tokens remain in `.inkos/secrets.json` and are never returned to the browser
- model discovery and image generation derive the ChatGPT account ID from the OAuth JWT and send it only to the ChatGPT Codex backend
- concurrent refreshes are coalesced, and stale refreshes cannot overwrite credentials from a newer login
- image responses are streamed with an 80 MB cap and a 180-second timeout
- hosted image requests intentionally omit forced `tool_choice`, matching the Codex backend behavior used by OpenClaw and Hermes
