### PR TITLE
fix(core): update SenseNova endpoint to new platform (token.sensenova.cn)

### DIFF
--- a/packages/core/src/llm/providers/endpoints/sensenova.ts
+++ b/packages/core/src/llm/providers/endpoints/sensenova.ts
@@ -1,9 +1,10 @@
 /**
- * 商汤日日新 (SenseNova)
+ * 商汤日日新 (SenseNova) — 公测新平台
  *
- * - 官网：https://platform.sensenova.cn/
- * - 控制台 / API key：https://console.sensecore.cn/aistudio/management/access-key
- * - API 文档：https://platform.sensenova.cn/doc
+ * - 平台：https://platform.sensenova.cn/
+ * - API key：控制台 → API Keys（sk- 开头）
+ * - OpenAI 兼容端点：https://token.sensenova.cn/v1
+ * - 平台 max_tokens 硬上限 384000；各模型实际 max_output 见下方卡片。
  */
 import type { InkosEndpoint } from "../types.js";
 
@@ -12,34 +13,15 @@ export const SENSENOVA: InkosEndpoint = {
   label: "商汤日日新",
   group: "china",
   api: "openai-completions",
-  baseUrl: "https://api.sensenova.cn/compatible-mode/v1",
-  checkModel: "SenseChat-Turbo",
+  baseUrl: "https://token.sensenova.cn/v1",
+  checkModel: "sensenova-6.7-flash-lite",
   temperatureRange: [0, 2],
   defaultTemperature: 0.7,
   writingTemperature: 1,
   models: [
-    { id: "SenseNova-V6-5-Pro", maxOutput: 4096, contextWindowTokens: 131072, enabled: true, releasedAt: "2025-07-23" },
-    { id: "SenseNova-V6-5-Turbo", maxOutput: 4096, contextWindowTokens: 131072, enabled: true, releasedAt: "2025-07-23" },
-    { id: "Qwen3-235B", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2025-05-27" },
-    { id: "Qwen3-32B", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2025-05-27" },
-    { id: "SenseNova-V6-Reasoner", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2025-04-14" },
-    { id: "SenseNova-V6-Turbo", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2025-04-14" },
-    { id: "SenseNova-V6-Pro", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2025-04-14" },
-    { id: "SenseChat-5-beta", maxOutput: 4096, contextWindowTokens: 32768 },
-    { id: "SenseChat-5-1202", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2024-12-30" },
-    { id: "SenseChat-Turbo-1202", maxOutput: 4096, contextWindowTokens: 32768, releasedAt: "2024-12-30" },
-    { id: "SenseChat-5", maxOutput: 131072, contextWindowTokens: 131072 },
-    { id: "SenseChat-Vision", maxOutput: 16384, contextWindowTokens: 16384, releasedAt: "2024-09-12" },
-    { id: "SenseChat-Turbo", maxOutput: 32768, contextWindowTokens: 32768 },
-    { id: "SenseChat-128K", maxOutput: 131072, contextWindowTokens: 131072 },
-    { id: "SenseChat-32K", maxOutput: 32768, contextWindowTokens: 32768 },
-    { id: "SenseChat", maxOutput: 4096, contextWindowTokens: 4096 },
-    { id: "SenseChat-5-Cantonese", maxOutput: 32768, contextWindowTokens: 32768 },
-    { id: "SenseChat-Character", maxOutput: 1024, contextWindowTokens: 8192 },
-    { id: "SenseChat-Character-Pro", maxOutput: 4096, contextWindowTokens: 32768 },
-    { id: "DeepSeek-V3", maxOutput: 4096, contextWindowTokens: 32768 },
-    { id: "DeepSeek-R1", maxOutput: 4096, contextWindowTokens: 32768 },
-    { id: "DeepSeek-R1-Distill-Qwen-14B", maxOutput: 4096, contextWindowTokens: 32768 },
-    { id: "DeepSeek-R1-Distill-Qwen-32B", maxOutput: 4096, contextWindowTokens: 8192 },
+    { id: "sensenova-6.7-flash-lite", maxOutput: 65536, contextWindowTokens: 262144, enabled: true, releasedAt: "2026-07-11" },
+    { id: "deepseek-v4-flash", maxOutput: 65536, contextWindowTokens: 1048576, enabled: true, releasedAt: "2026-07-11" },
+    { id: "glm-5.2", maxOutput: 131072, contextWindowTokens: 1048576, enabled: true, releasedAt: "2026-07-11" },
+    { id: "sensenova-u1-fast", maxOutput: 65536, contextWindowTokens: 262144, releasedAt: "2026-07-11" },
   ],
 };


### PR DESCRIPTION
## Summary

- 商汤公测平台已迁移：旧地址 `api.sensenova.cn/compatible-mode/v1` 已失效（403/全部模型404），新平台为 `token.sensenova.cn/v1`
- 旧模型列表（23个，SenseNova-V6-5-Pro / SenseChat-* / DeepSeek-V3/R1 等）全部过时，替换为新平台当前可用的 4 个模型
- 修复 deepseek-v4-flash 等模型因从官方 provider 卡继承 maxOutput=393216 超过平台 384000 上限而报 400 的问题

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation

旧平台 `api.sensenova.cn/compatible-mode/v1` 已停止服务，所有模型调用返回 403/404。新公测平台 `token.sensenova.cn/v1` 使用不同的模型命名体系和 API 端点。

此外，对 deepseek-v4-flash 等模型，因 lookup 未命中商汤卡而回退到官方 provider 卡（maxOutput=393216），超出平台 384000 上限，建书时返回 `400 field MaxTokens invalid, should be in [1, 384000]`。

## Changes

| File | Change |
|------|--------|
| packages/core/src/llm/providers/endpoints/sensenova.ts | baseUrl 更新为 `https://token.sensenova.cn/v1`，checkModel 更新为 `sensenova-6.7-flash-lite`，模型列表替换为当前平台 4 个可用模型及正确 maxOutput/contextWindow |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (184 files, 1797 tests)
- [x] Manual verification: curl 测试新平台 4 个模型均返回 200；`inkos --model deepseek-v4-flash book create` 完整建书成功（基设→审核→快照→完成）

## Breaking changes

无。旧平台已死，此更新是让商汤 provider 重新可用。配置从旧平台迁移的用户需更新 baseUrl 和 model 名。