### PR TITLE
fix(studio): persist tested model catalogs on save

### DIFF
--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -1106,6 +1106,27 @@ describe("createStudioServer daemon lifecycle", () => {
     ]);
   });
 
+  it("includes the global default model in bank groups even when it is not in the static catalog", async () => {
+    await writeFile(join(root, "inkos.json"), JSON.stringify({
+      ...projectConfig,
+      llm: {
+        ...projectConfig.llm,
+        service: "openrouter",
+        defaultModel: "google/gemini-3.7-flash",
+        services: [{ service: "openrouter" }],
+      },
+    }, null, 2), "utf-8");
+    loadSecretsMock.mockResolvedValue({ services: { openrouter: { apiKey: "sk-openrouter" } } });
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+    const response = await app.request("http://localhost/api/v1/services/models");
+    const body = await response.json() as { groups: Array<{ service: string; models: Array<{ id: string }> }> };
+
+    expect(body.groups.find((group) => group.service === "openrouter")?.models.map((model) => model.id))
+      .toEqual(["openrouter-model", "google/gemini-3.7-flash"]);
+  });
+
   it("merges persisted discovered/user models ahead of the static fallback catalog", async () => {
     await writeFile(join(root, "inkos.json"), JSON.stringify({
       ...projectConfig,
@@ -6203,6 +6224,36 @@ describe("createStudioServer daemon lifecycle", () => {
     expect(raw.llm.service).toBe("kkaiapi");
     expect(raw.llm.defaultModel).toBe("deepseek-v4-flash");
     expect(raw.llm.model).toBe("deepseek-v4-flash");
+    expect(raw.llm.services).toEqual([
+      { service: "kkaiapi", models: ["deepseek-v4-flash"] },
+    ]);
+  });
+
+  it("adds a newly configured default model to the existing service catalog without replacing it", async () => {
+    await writeFile(join(root, "inkos.json"), JSON.stringify({
+      ...projectConfig,
+      llm: {
+        ...projectConfig.llm,
+        service: "openrouter",
+        defaultModel: "openrouter/auto",
+        services: [{ service: "openrouter", models: ["openrouter/auto"] }],
+      },
+    }, null, 2), "utf-8");
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+    const save = await app.request("http://localhost/api/v1/project/default-model", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ service: "openrouter", defaultModel: "google/gemini-3.7-flash" }),
+    });
+    expect(save.status).toBe(200);
+
+    const raw = JSON.parse(await readFile(join(root, "inkos.json"), "utf-8"));
+    expect(raw.llm.defaultModel).toBe("google/gemini-3.7-flash");
+    expect(raw.llm.services).toEqual([
+      { service: "openrouter", models: ["openrouter/auto", "google/gemini-3.7-flash"] },
+    ]);
   });
 
   it("project advanced settings expose input governance and detection config", async () => {

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -383,7 +383,7 @@ const NON_TEXT_MODEL_ID_PARTS = [
   "moderation",
 ] as const;
 
-const SERVICE_MODELS_PROBE_TIMEOUT_MS = 4_000;
+const SERVICE_MODELS_PROBE_TIMEOUT_MS = 15_000;
 const SERVICE_CHAT_PROBE_TIMEOUT_MS = 8_000;
 // Hard ceiling for the whole /doctor connectivity probe (models + chat fallback
 // loop) so the diagnostics page never spins on a slow/rate-limited upstream.
@@ -2114,6 +2114,30 @@ function mergeServiceConfig(existing: ServiceConfigEntry[], updates: ServiceConf
     });
   }
   return [...merged.values()];
+}
+
+function appendModelToServiceCatalog(
+  llm: Record<string, unknown>,
+  serviceId: string | undefined,
+  modelId: string,
+): void {
+  const trimmedService = serviceId?.trim() ?? "";
+  const trimmedModel = modelId.trim();
+  if (!trimmedService || !trimmedModel || !isTextChatModelId(trimmedModel)) return;
+
+  const existing = normalizeServiceConfig(llm.services);
+  const previous = existing.find((entry) => serviceConfigKey(entry) === trimmedService);
+  const nextEntry: ServiceConfigEntry = previous
+    ? { ...previous, models: mergeServiceModelIds(previous.models, [trimmedModel]) }
+    : isCustomServiceId(trimmedService)
+      ? {
+          service: "custom",
+          name: decodeURIComponent(trimmedService.slice("custom:".length)),
+          models: [trimmedModel],
+        }
+      : { service: trimmedService, models: [trimmedModel] };
+
+  llm.services = mergeServiceConfig(existing, [nextEntry]);
 }
 
 function normalizeCoverConfig(raw: unknown): { service: string; model: string; baseUrl?: string } | undefined {
@@ -4152,12 +4176,17 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
         return Boolean(secrets.services[ep.id]?.apiKey) || (optional && configured);
       });
 
+    const llm = (config.llm as Record<string, unknown> | undefined) ?? {};
+    const defaultModel = typeof llm.defaultModel === "string" ? llm.defaultModel.trim() : "";
+    const defaultService = typeof llm.service === "string" ? llm.service.trim() : "";
+
     const groups = endpoints.map((ep) => {
       const staticModels = ep.models
         .filter((m) => m.enabled !== false)
         .filter((m) => isTextChatModelId(m.id));
       const configuredModels = configuredById.get(ep.id)?.models ?? [];
-      const models = mergeServiceModelIds(staticModels.map((model) => model.id), configuredModels)
+      const preferredModel = defaultService === ep.id && defaultModel ? [defaultModel] : [];
+      const models = mergeServiceModelIds(staticModels.map((model) => model.id), configuredModels, preferredModel)
         .map((id) => {
           const known = staticModels.find((model) => model.id.toLowerCase() === id.toLowerCase());
           return {
@@ -5848,6 +5877,11 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     if (typeof body.service === "string" && body.service.trim()) {
       llm.service = body.service.trim();
     }
+    appendModelToServiceCatalog(
+      llm,
+      typeof llm.service === "string" ? llm.service : undefined,
+      defaultModel,
+    );
     syncTopLevelLlmMirror(llm);
     await saveRawConfig(root, raw);
     return c.json({

--- a/packages/studio/src/pages/ChatPage.tsx
+++ b/packages/studio/src/pages/ChatPage.tsx
@@ -50,6 +50,7 @@ import {
 } from "../components/ai-elements/message";
 import {
   type ChatPageModelPreference,
+  buildChatPageModelGroups,
   filterModelGroups,
   getChatScrollBehavior,
   getBookCreateSessionId,
@@ -502,23 +503,22 @@ export function ChatPage({ activeBookId, mode = activeBookId ? "book" : "book-cr
     };
   }, []);
 
+  const groupedModels = useMemo(
+    () => buildChatPageModelGroups(services, modelsByService, configuredModelSelection),
+    [configuredModelSelection, modelsByService, services],
+  );
+
   const modelPickerStatus = useMemo(() => {
     if (servicesLoading || services.length === 0) return "loading" as const;
     const connected = services.filter((s) => s.connected);
     if (connected.length === 0) return "no-models" as const;
     if (bankModelsLoading) return "loading" as const;
-    if (connected.some((s) => (modelsByService[s.service]?.length ?? 0) > 0)) return "ready" as const;
+    if (groupedModels.some((group) => group.models.length > 0)) return "ready" as const;
     const hasConnectedBank = connected.some((s) => !s.service.startsWith("custom"));
     const hasConnectedCustom = connected.some((s) => s.service.startsWith("custom"));
     if (!hasConnectedBank && hasConnectedCustom && customModelsLoading) return "loading" as const;
     return "no-models" as const;
-  }, [services, servicesLoading, bankModelsLoading, customModelsLoading, modelsByService]);
-
-  const groupedModels = useMemo(() => {
-    return services
-      .filter((s) => s.connected && (modelsByService[s.service]?.length ?? 0) > 0)
-      .map((s) => ({ service: s.service, label: s.label, models: modelsByService[s.service]! }));
-  }, [services, modelsByService]);
+  }, [customModelsLoading, groupedModels, services, servicesLoading, bankModelsLoading]);
 
   const selectedModelLabel = useMemo(() => {
     if (!selectedModel) return isZh ? "选择模型" : "Select model";

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -38,6 +38,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const loading = useServiceStore((s) => s.servicesLoading);
   const fetchServices = useServiceStore((s) => s.fetchServices);
   const refreshServices = useServiceStore((s) => s.refreshServices);
+  const fetchBankModels = useServiceStore((s) => s.fetchBankModels);
   const setStoreModels = useServiceStore((s) => s.setLiveModels);
   const clearStoreModels = useServiceStore((s) => s.clearModels);
 
@@ -60,6 +61,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [verifiedProbe, setVerifiedProbe] = useState<VerifiedProbe | null>(null);
   const [configuredModels, setConfiguredModels] = useState<ModelInfo[]>([]);
   const [modelIdInput, setModelIdInput] = useState("");
+  const [saveFeedback, setSaveFeedback] = useState<string | null>(null);
 
   // -- Unified connection status --
   const [status, setStatus] = useState<ConnectionStatus>({ state: "idle" });
@@ -151,6 +153,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
       return;
     }
     setApiKey(trimmedKey);
+    setSaveFeedback(null);
     setStatus({ state: "testing" });
     try {
       const result = await probeServiceForDetail(effectiveServiceId, {
@@ -236,14 +239,19 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
         if (isCustom && result.detectedConfig?.baseUrl) setBaseUrl(result.detectedConfig.baseUrl);
         setDetectedModel(result.detectedModel);
         setDetectedConfig(result.detectedConfig);
+        setConfiguredModels(result.status.models);
         setStoreModels(effectiveServiceId, result.status.models);
         setStatus(result.status);
+        setSaveFeedback(tr(
+          `已保存 ${result.status.models.length} 个模型，创作选择器将使用这份目录。`,
+          `Saved ${result.status.models.length} models. The writing picker will use this catalog.`,
+        ));
       } else {
         setStatus(result.status);
         if (result.status.state === "error") return;
       }
       await refreshServices();
-      nav.toServices();
+      await fetchBankModels();
     } catch (e) {
       setStatus({ state: "error", message: e instanceof Error ? e.message : tr("保存失败", "Save failed") });
     }
@@ -339,20 +347,24 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
           {/* Status feedback */}
           {status.state === "connected" && (
             <span className="text-xs text-emerald-500">
-              {tr(`连接成功，${models.length} 个模型`, `Connected, ${models.length} models`)}
-              {detectedModel
-                ? tr(
-                    `，已自动匹配 ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "responses" ? "Responses" : "Chat"} / ${detectedConfig.stream ? "流式" : "非流式"}` : ""}`,
-                    `, auto-matched ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "responses" ? "Responses" : "Chat"} / ${detectedConfig.stream ? "streaming" : "non-streaming"}` : ""}`,
-                  )
-                : ""}
+              {saveFeedback ?? (
+                <>
+                  {tr(`连接成功，${models.length} 个模型`, `Connected, ${models.length} models`)}
+                  {detectedModel
+                    ? tr(
+                        `，已自动匹配 ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "responses" ? "Responses" : "Chat"} / ${detectedConfig.stream ? "流式" : "非流式"}` : ""}`,
+                        `, auto-matched ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "responses" ? "Responses" : "Chat"} / ${detectedConfig.stream ? "streaming" : "non-streaming"}` : ""}`,
+                      )
+                    : ""}
+                </>
+              )}
             </span>
           )}
           {status.state === "error" && (
             <span className="text-xs text-destructive">{status.message}</span>
           )}
           {status.state === "saved" && (
-            <span className="text-xs text-emerald-500">{tr("已保存", "Saved")}</span>
+            <span className="text-xs text-emerald-500">{saveFeedback ?? tr("已保存", "Saved")}</span>
           )}
         </div>
 
@@ -410,7 +422,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
             </button>
           </div>
           <p className="text-xs text-muted-foreground/60">
-            {tr("测试连接发现的模型和手动添加的模型都会在保存后持久化；内置目录只作为兜底。", "Discovered and manually added models are persisted on save; the built-in catalog is only a fallback.")}
+            {tr("先点“测试连接”拉取最新列表，再点“保存”写入创作选择器。内置目录只在还没有保存过快照时作为兜底。", "Click “Test connection” to fetch the latest list, then “Save” to write it into the writing picker. The built-in catalog is only a fallback before a snapshot is saved.")}
           </p>
           {hasModelCatalog && (
           <div className="space-y-2">

--- a/packages/studio/src/pages/chat-page-state.test.ts
+++ b/packages/studio/src/pages/chat-page-state.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildChatPageModelGroups,
   clearBookCreateSessionId,
   filterModelGroups,
   getBookCreateSessionId,
@@ -116,6 +117,72 @@ describe("filterModelGroups", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("buildChatPageModelGroups", () => {
+  const services = [
+    { service: "openrouter", label: "OpenRouter", connected: true },
+    { service: "moonshot", label: "Moonshot", connected: true },
+    { service: "google", label: "Google", connected: false },
+  ];
+  const modelsByService = {
+    openrouter: [{ id: "openrouter/auto", name: "openrouter/auto" }],
+    moonshot: [{ id: "kimi-k2.5", name: "kimi-k2.5" }],
+  };
+
+  it("only includes connected services that have models", () => {
+    expect(buildChatPageModelGroups(services, modelsByService).map((group) => group.service))
+      .toEqual(["openrouter", "moonshot"]);
+  });
+
+  it("injects the configured default model into its service even when the bank lacks it", () => {
+    const groups = buildChatPageModelGroups(services, modelsByService, {
+      service: "openrouter",
+      model: "google/gemini-3.7-flash",
+    });
+    expect(groups.find((group) => group.service === "openrouter")?.models.map((model) => model.id))
+      .toEqual(["google/gemini-3.7-flash", "openrouter/auto"]);
+  });
+
+  it("still exposes a connected service that only has the configured default model", () => {
+    const groups = buildChatPageModelGroups(services, { moonshot: modelsByService.moonshot }, {
+      service: "openrouter",
+      model: "google/gemini-3.7-flash",
+    });
+    expect(groups.find((group) => group.service === "openrouter")?.models.map((model) => model.id))
+      .toEqual(["google/gemini-3.7-flash"]);
+  });
+
+  it("does not duplicate a default model already present in the catalog", () => {
+    const groups = buildChatPageModelGroups(services, {
+      openrouter: [
+        { id: "google/gemini-3.7-flash", name: "google/gemini-3.7-flash" },
+        { id: "openrouter/auto", name: "openrouter/auto" },
+      ],
+    }, {
+      service: "openrouter",
+      model: "Google/Gemini-3.7-Flash",
+    });
+    expect(groups.find((group) => group.service === "openrouter")?.models.map((model) => model.id))
+      .toEqual(["google/gemini-3.7-flash", "openrouter/auto"]);
+  });
+
+  it("injects a service-less default into the first connected group", () => {
+    const groups = buildChatPageModelGroups(services, modelsByService, {
+      model: "google/gemini-3.7-flash",
+    });
+    expect(groups[0]?.models.map((model) => model.id))
+      .toEqual(["google/gemini-3.7-flash", "openrouter/auto"]);
+  });
+
+  it("lets pickModelSelection keep a default that is missing from the static bank", () => {
+    const preference = { service: "openrouter", model: "google/gemini-3.7-flash" };
+    const groups = buildChatPageModelGroups(services, modelsByService, preference);
+    expect(pickModelSelection(groups, null, null, preference)).toEqual({
+      model: "google/gemini-3.7-flash",
+      service: "openrouter",
+    });
   });
 });
 

--- a/packages/studio/src/pages/chat-page-state.ts
+++ b/packages/studio/src/pages/chat-page-state.ts
@@ -61,6 +61,52 @@ export function filterModelGroups(
     .filter((group) => group.models.length > 0);
 }
 
+function modelIdKey(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+function hasModel(models: ReadonlyArray<ChatPageModelInfo>, modelId: string): boolean {
+  const key = modelIdKey(modelId);
+  return models.some((model) => modelIdKey(model.id) === key);
+}
+
+/**
+ * Build the writing-page model picker groups from the saved snapshot ∪ bank.
+ * The configured global default is injected even when it is missing from that
+ * catalog, so setting it in project settings still makes the model selectable.
+ */
+export function buildChatPageModelGroups(
+  services: ReadonlyArray<{ readonly service: string; readonly label: string; readonly connected: boolean }>,
+  modelsByService: Record<string, ReadonlyArray<ChatPageModelInfo> | undefined>,
+  preference?: ChatPageModelPreference | null,
+): ChatPageModelGroup[] {
+  const preferredService = preference?.service?.trim() ?? "";
+  const preferredModel = preference?.model?.trim() ?? "";
+
+  const groups: ChatPageModelGroup[] = [];
+  for (const svc of services) {
+    if (!svc.connected) continue;
+    const models = [...(modelsByService[svc.service] ?? [])];
+    if (preferredModel && preferredService === svc.service && !hasModel(models, preferredModel)) {
+      models.unshift({ id: preferredModel, name: preferredModel });
+    }
+    if (models.length === 0) continue;
+    groups.push({ service: svc.service, label: svc.label, models });
+  }
+
+  if (preferredModel && !preferredService && groups.length > 0) {
+    const alreadyPresent = groups.some((group) => hasModel(group.models, preferredModel));
+    if (!alreadyPresent) {
+      groups[0] = {
+        ...groups[0],
+        models: [{ id: preferredModel, name: preferredModel }, ...groups[0].models],
+      };
+    }
+  }
+
+  return groups;
+}
+
 export function pickModelSelection(
   groupedModels: ReadonlyArray<ChatPageModelGroup>,
   selectedModel: string | null,

--- a/packages/studio/src/pages/service-detail-state.test.ts
+++ b/packages/studio/src/pages/service-detail-state.test.ts
@@ -4,6 +4,7 @@ import {
   matchServiceConfigEntryForDetail,
   mergeServiceDetailModels,
   rehydrateServiceConnectionStatus,
+  resolveModelsToPersist,
   saveServiceConfig,
 } from "./service-detail-state";
 
@@ -16,6 +17,44 @@ describe("mergeServiceDetailModels", () => {
       { id: "MiniMax-M2.7" },
       { id: "MiniMax-M2.8" },
     ]);
+  });
+});
+
+describe("resolveModelsToPersist", () => {
+  it("keeps the on-screen live catalog when a later probe only returns the bank fallback", () => {
+    expect(resolveModelsToPersist({
+      displayedModels: [
+        { id: "google/gemini-3.7-flash" },
+        { id: "openrouter/auto" },
+      ],
+      probeModels: [{ id: "openrouter/auto" }],
+      modelsSource: "fallback",
+    }).map((model) => model.id)).toEqual([
+      "google/gemini-3.7-flash",
+      "openrouter/auto",
+    ]);
+  });
+
+  it("uses live probe results as the snapshot when modelsSource is api", () => {
+    expect(resolveModelsToPersist({
+      displayedModels: [{ id: "openrouter/auto" }],
+      probeModels: [
+        { id: "google/gemini-3.7-flash" },
+        { id: "openrouter/auto" },
+      ],
+      modelsSource: "api",
+    }).map((model) => model.id)).toEqual([
+      "google/gemini-3.7-flash",
+      "openrouter/auto",
+    ]);
+  });
+
+  it("falls back to the probe catalog when the screen has no models yet", () => {
+    expect(resolveModelsToPersist({
+      displayedModels: [],
+      probeModels: [{ id: "openrouter/auto" }],
+      modelsSource: "fallback",
+    }).map((model) => model.id)).toEqual(["openrouter/auto"]);
   });
 });
 
@@ -238,6 +277,49 @@ describe("saveServiceConfig", () => {
       detectedModel: "gpt-5.5",
       detectedConfig: { apiFormat: "chat", stream: true },
       status: { state: "connected", models: [{ id: "gpt-5.5" }] },
+    });
+  });
+
+  it("does not replace a tested live catalog with a bank-only fallback on save", async () => {
+    const bodies: unknown[] = [];
+    const fetchJsonImpl = vi.fn(async (path: string, init?: { body?: string }) => {
+      if (init?.body) bodies.push(JSON.parse(init.body));
+      if (path === "/services/openrouter/test") {
+        return {
+          ok: true,
+          models: [{ id: "openrouter/auto" }],
+          selectedModel: "openrouter/auto",
+          detected: { apiFormat: "chat", stream: true, modelsSource: "fallback" },
+        };
+      }
+      if (path === "/services/openrouter/secret") return { ok: true };
+      if (path === "/services/config") return { ok: true };
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    await saveServiceConfig({
+      effectiveServiceId: "openrouter",
+      serviceId: "openrouter",
+      isCustom: false,
+      resolvedCustomName: "",
+      apiKey: "sk-or",
+      baseUrl: "",
+      apiFormat: "chat",
+      stream: true,
+      temperature: "0.7",
+      detectedModel: "",
+      configuredModels: [
+        { id: "google/gemini-3.7-flash" },
+        { id: "openrouter/auto" },
+      ],
+      fetchJsonImpl: fetchJsonImpl as never,
+    });
+
+    expect(bodies[2]).toMatchObject({
+      services: [{
+        service: "openrouter",
+        models: ["google/gemini-3.7-flash", "openrouter/auto"],
+      }],
     });
   });
 

--- a/packages/studio/src/pages/service-detail-state.ts
+++ b/packages/studio/src/pages/service-detail-state.ts
@@ -23,6 +23,28 @@ export function mergeServiceDetailModels(
   return merged;
 }
 
+/**
+ * Decide which model ids to persist as the writing-picker snapshot.
+ * The on-screen catalog (test results + manual adds) is the contract:
+ * a later bank-only fallback must not replace a richer list the user already saw.
+ */
+export function resolveModelsToPersist(args: {
+  readonly displayedModels?: ReadonlyArray<ServiceDetailModelInfo | string>;
+  readonly probeModels?: ReadonlyArray<ServiceDetailModelInfo | string>;
+  readonly modelsSource?: "api" | "fallback";
+}): ServiceDetailModelInfo[] {
+  const displayed = mergeServiceDetailModels(args.displayedModels);
+  const probed = mergeServiceDetailModels(args.probeModels);
+
+  if (args.modelsSource === "fallback") {
+    return displayed.length > 0 ? displayed : probed;
+  }
+  if (args.modelsSource === "api") {
+    return mergeServiceDetailModels(probed, displayed);
+  }
+  return mergeServiceDetailModels(displayed, probed);
+}
+
 export interface ServiceDetailDetectedConfig {
   readonly apiFormat?: "chat" | "responses";
   readonly stream?: boolean;
@@ -204,8 +226,12 @@ export async function saveServiceConfig(args: {
   }
 
   const detectedModel = probe.selectedModel ?? args.detectedModel;
-  const savedModels = mergeServiceDetailModels(probe.models, args.configuredModels);
   const detectedConfig = probe.detected ?? null;
+  const savedModels = resolveModelsToPersist({
+    displayedModels: args.configuredModels,
+    probeModels: probe.models,
+    modelsSource: detectedConfig?.modelsSource ?? verified?.detected?.modelsSource,
+  });
   const savedApiFormat = detectedConfig?.apiFormat ?? args.apiFormat;
   const savedStream = typeof detectedConfig?.stream === "boolean" ? detectedConfig.stream : args.stream;
   const savedBaseUrl = args.isCustom ? (detectedConfig?.baseUrl ?? trimmedBaseUrl) : undefined;


### PR DESCRIPTION
## Summary
- Studio 模型配置里「测试连接」能拉到代理商新模型，但点保存后创作页选择器仍只显示内置 bank。保存现在会把页面上测到的目录写成快照，后续即使探测退回 bank 也不会覆盖。
- 创作页继续读「已保存快照 ∪ 内置目录」，不再自己打 live `/models`。
- 项目设置里的全局默认模型即使不在 bank 中，也会写入对应服务目录并出现在选择器里。

## Test plan
- [x] 打开已连接 OpenRouter 的项目，测试连接能看到 `google/gemini-3.7-flash`
- [x] 点保存后页面停留并提示已保存 N 个模型，不再立刻跳走
- [x] 回到创作页搜索 `gemini-3.7-flash`，可以选择并用于写作
- [x] 相关单测：`service-detail-state`、`chat-page-state`、`server.test` 中新增用例