### PR TITLE
feat: add Anthropic Messages protocol to Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ InkOS 是一个面向故事创作与多语言翻译的 AI Agent 系统：长篇�
 
 InkOS 1.8.0 把“Chat Agent 调工具”和“各类作品管线”收敛成一套围绕 pi-agent 的生产 harness。模型负责理解、提议和调用能力；InkOS 负责确认、上下文、状态、原子落盘和产物真实性。长篇、短篇、剧本、分镜、互动影游、Play 与翻译继续保留各自的专业方法，但共享同一套执行、检索、观测和恢复基础设施。
 
-- **模型配置**：Studio 内置多服务配置、模型路由和封面服务配置；支持 [kkaiapi](https://kkaiapi.com/) / OpenRouter 等全球主流模型聚合入口，以及自定义 OpenAI-compatible 服务。
+- **模型配置**：Studio 内置多服务配置、模型路由和封面服务配置；支持 [kkaiapi](https://kkaiapi.com/) / OpenRouter 等全球主流模型聚合入口，以及自定义 OpenAI Chat Completions、OpenAI Responses 和 Anthropic Messages 服务。
 - **单一生产 Harness**：Studio Chat、TUI、`inkos interact` 与生产 worker 共用 pi-agent 工具循环和结构化 action/result；既有 pipeline 降为可直接调用、可中断、可观测的确定性能力，不再维护平行的自然语言决策内核。
 - **15 个内置专业 Skills**：长篇写作 / 审稿、商业短篇、Play、剧本、分镜、互动影游、翻译、拆稿、市场研究、导入、封面与去 AI 味都拥有独立 `SKILL.md`；各作品类型复用 Skill 架构，不复用不适合自己的长篇提示词。
 - **统一本地检索**：故事记忆、材料库和 Skill 参考资料共用 SQLite FTS5 / BM25 检索投影；原始文件仍是权威来源，索引可重建，检索结果保留来源与位置。
@@ -159,9 +159,10 @@ inkos
 打开 Studio 后进入「模型配置」：
 
 1. 选择服务商，例如 Google Gemini、Moonshot、MiniMax、智谱、百炼或自定义端点。
-2. 粘贴 API Key，点击「测试连接」。
-3. 选择可用模型，保存配置。
-4. 回到书籍页面开始写作。
+2. 选择协议类型：OpenAI Chat Completions、OpenAI Responses 或 Anthropic Messages；自定义端点应按上游实际协议选择。
+3. 粘贴 API Key，点击「测试连接」。
+4. 选择可用模型，保存配置。
+5. 回到书籍页面开始写作。
 
 Studio 运行时只使用：
 
@@ -611,7 +612,7 @@ Studio 里的「开放世界」和「分支互动」是交互式创作入口。�
 
 `[id]` 参数在项目只有一本书时可省略，自动检测。所有命令支持 `--json` 输出结构化数据。`draft` / `write next` / `plan chapter` / `compose chapter` 支持 `--context` 传入创作指导，`--words` 覆盖每章目标字数。`book create` 支持 `--brief <file>` 传入创作简报（你的脑洞/设定文档），Architect 会基于此生成设定而非凭空创作。`plan chapter` 会调用 LLM 生成章节意图；`compose chapter` 不要求在线 LLM，可在配置 API Key 之前先检查输入治理结果。
 
-CLI 运行时还支持一次性 LLM 覆盖参数：`--service`、`--model`、`--api-key-env`、`--base-url`、`--api-format <chat|responses>`、`--stream`、`--no-stream`。例如：
+CLI 运行时还支持一次性 LLM 覆盖参数：`--service`、`--model`、`--api-key-env`、`--base-url`、`--api-format <chat|responses|anthropic>`、`--stream`、`--no-stream`。`anthropic` 对应 Anthropic Messages 协议。例如：
 
 ```bash
 inkos write next --service google --model gemini-2.5-flash

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -19,12 +19,12 @@ import {
 } from "../localization.js";
 
 function buildDoctorProbePlans(
-  preferredApiFormat: "chat" | "responses" | undefined,
+  preferredApiFormat: "chat" | "responses" | "anthropic" | undefined,
   preferredStream: boolean | undefined,
-): Array<{ apiFormat: "chat" | "responses"; stream: boolean }> {
-  const plans: Array<{ apiFormat: "chat" | "responses"; stream: boolean }> = [];
+): Array<{ apiFormat: "chat" | "responses" | "anthropic"; stream: boolean }> {
+  const plans: Array<{ apiFormat: "chat" | "responses" | "anthropic"; stream: boolean }> = [];
   const seen = new Set<string>();
-  const push = (apiFormat: "chat" | "responses", stream: boolean) => {
+  const push = (apiFormat: "chat" | "responses" | "anthropic", stream: boolean) => {
     const key = `${apiFormat}:${stream ? "1" : "0"}`;
     if (seen.has(key)) return;
     seen.add(key);
@@ -35,7 +35,11 @@ function buildDoctorProbePlans(
     push(preferredApiFormat, preferredStream ?? false);
     push(preferredApiFormat, !(preferredStream ?? false));
   }
-  const alternate = preferredApiFormat === "responses" ? "chat" : "responses";
+  const alternate = preferredApiFormat === "responses"
+    ? "chat"
+    : preferredApiFormat === "anthropic"
+      ? "chat"
+      : "responses";
   push(alternate, false);
   push(alternate, true);
   push("chat", false);
@@ -304,7 +308,7 @@ export const doctorCommand = new Command("doctor")
           : [llmConfig.model];
         const plans = llmConfig.provider === "openai"
           ? buildDoctorProbePlans(llmConfig.apiFormat, llmConfig.stream)
-          : [{ apiFormat: (llmConfig.apiFormat ?? "chat") as "chat" | "responses", stream: llmConfig.stream ?? true }];
+          : [{ apiFormat: (llmConfig.apiFormat ?? "chat") as "chat" | "responses" | "anthropic", stream: llmConfig.stream ?? true }];
 
         for (const model of modelCandidates) {
           for (const plan of plans) {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -56,7 +56,7 @@ export function createProgram(hooks: ProgramHooks = {}): Command {
     .option("--model <model>", "Override LLM model for this CLI run")
     .option("--api-key-env <envVar>", "Read LLM API key from this environment variable for this CLI run")
     .option("--base-url <url>", "Override LLM base URL for this CLI run")
-    .option("--api-format <chat|responses>", "Override LLM API format for this CLI run")
+    .option("--api-format <chat|responses|anthropic>", "Override LLM API format for this CLI run")
     .option("--stream", "Force streaming LLM responses for this CLI run")
     .option("--no-stream", "Force non-streaming LLM responses for this CLI run")
     .action(async () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -67,7 +67,7 @@ export function parseLLMOverridesFromArgv(argv: readonly string[]): LLMConfigCli
     model?: string;
     apiKeyEnv?: string;
     baseUrl?: string;
-    apiFormat?: "chat" | "responses";
+    apiFormat?: "chat" | "responses" | "anthropic";
     stream?: boolean;
   } = {};
 
@@ -92,7 +92,7 @@ export function parseLLMOverridesFromArgv(argv: readonly string[]): LLMConfigCli
       if (value) overrides.baseUrl = value;
     } else if (flag === "--api-format") {
       const value = nextValue();
-      if (value === "chat" || value === "responses") overrides.apiFormat = value;
+      if (value === "chat" || value === "responses" || value === "anthropic") overrides.apiFormat = value;
     } else if (flag === "--stream") {
       overrides.stream = true;
     } else if (flag === "--no-stream") {

--- a/packages/core/src/__tests__/effective-llm-config.test.ts
+++ b/packages/core/src/__tests__/effective-llm-config.test.ts
@@ -57,6 +57,31 @@ describe("resolveEffectiveLLMConfig", () => {
     expect(result.diagnostics.warnings.join("\n")).toContain("旧顶层");
   });
 
+  it("Studio consumer preserves a custom Anthropic Messages protocol", async () => {
+    await writeProject({
+      configSource: "studio",
+      service: "custom:Anthropic Gateway",
+      services: [{
+        service: "custom",
+        name: "Anthropic Gateway",
+        baseUrl: "https://gateway.example",
+        apiFormat: "anthropic",
+      }],
+      defaultModel: "claude-compatible-model",
+    });
+
+    const result = await resolveEffectiveLLMConfig({
+      consumer: "studio",
+      projectRoot: root,
+      envLayers: { global: {}, project: {}, process: {} },
+      requireApiKey: false,
+    });
+
+    expect(result.llm.provider).toBe("custom");
+    expect(result.llm.apiFormat).toBe("anthropic");
+    expect(result.llm.baseUrl).toBe("https://gateway.example");
+  });
+
   it("CLI consumer 允许 INKOS_LLM_SERVICE 切换服务，并从 provider bank 推导 baseUrl", async () => {
     await writeProject({
       configSource: "studio",

--- a/packages/core/src/__tests__/models.test.ts
+++ b/packages/core/src/__tests__/models.test.ts
@@ -413,6 +413,16 @@ describe("LLMConfigSchema", () => {
     expect(result.provider).toBe("openai");
   });
 
+  it("accepts Anthropic Messages as an API format", () => {
+    const result = LLMConfigSchema.parse({
+      provider: "custom",
+      baseUrl: "https://gateway.example",
+      model: "claude-compatible-model",
+      apiFormat: "anthropic",
+    });
+    expect(result.apiFormat).toBe("anthropic");
+  });
+
   it("rejects invalid provider", () => {
     expect(() =>
       LLMConfigSchema.parse({

--- a/packages/core/src/__tests__/provider.test.ts
+++ b/packages/core/src/__tests__/provider.test.ts
@@ -1069,6 +1069,23 @@ describe("createLLMClient with providers lookup", () => {
     expect(client._piModel?.contextWindow).toBe(1_000_000);
   });
 
+  it("custom Anthropic Messages config selects the existing native transport", async () => {
+    const { createLLMClient } = await import("../llm/provider.js");
+    const { LLMConfigSchema } = await import("../models/project.js");
+    const client = createLLMClient(LLMConfigSchema.parse({
+      provider: "custom",
+      service: "custom",
+      model: "claude-compatible-model",
+      apiKey: "",
+      baseUrl: "https://gateway.example",
+      apiFormat: "anthropic",
+    }));
+
+    expect(client.provider).toBe("anthropic");
+    expect(client._piModel?.api).toBe("anthropic-messages");
+    expect(client._piModel?.provider).toBe("anthropic");
+  });
+
   it("custom service + gpt-4o 靠 Layer 2 全局扫命中 openai provider", async () => {
     const { createLLMClient } = await import("../llm/provider.js");
     const { LLMConfigSchema } = await import("../models/project.js");

--- a/packages/core/src/agent/worker-agent.ts
+++ b/packages/core/src/agent/worker-agent.ts
@@ -52,7 +52,11 @@ function workerModel(client: LLMClient, modelId: string, maxTokens?: number): Mo
   return {
     id: modelId,
     name: modelId,
-    api: (client.apiFormat === "responses" ? "openai-responses" : "openai-completions") as Api,
+    api: (client.apiFormat === "anthropic"
+      ? "anthropic-messages"
+      : client.apiFormat === "responses"
+        ? "openai-responses"
+        : "openai-completions") as Api,
     provider: client.provider as Provider,
     baseUrl: "",
     reasoning: false,

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -275,7 +275,7 @@ export interface LLMClient {
   readonly provider: "openai" | "anthropic";
   readonly service?: string;
   readonly configSource?: LLMConfig["configSource"];
-  readonly apiFormat: "chat" | "responses";
+  readonly apiFormat: "chat" | "responses" | "anthropic";
   readonly stream: boolean;
   readonly proxyUrl?: string;
   readonly _piModel?: PiModel<PiApi>;
@@ -326,7 +326,7 @@ export function createLLMClient(config: LLMConfig): LLMClient {
     ? resolveProviderCompat(inkosProvider, baseUrl)
     : undefined;
 
-  const provider = config.provider === "anthropic" ? "anthropic" : "openai";
+  const provider = config.provider === "anthropic" || piApi === "anthropic-messages" ? "anthropic" : "openai";
   // pi-ai provider 字段：大多数情况 pi-ai 会按 baseUrl 自动嗅探（openrouter.ai / api.z.ai /
   // api.x.ai / deepseek.com / anthropic.com 等）。这里只列 pi-ai 嗅探不到、需要显式指定的少数情况。
   let piProvider: string;
@@ -376,6 +376,7 @@ function resolvePiApi(
   presetApi: PiApi | undefined,
 ): PiApi {
   if (serviceName === "custom") {
+    if (apiFormat === "anthropic") return "anthropic-messages";
     return apiFormat === "responses" ? "openai-responses" : "openai-completions";
   }
   return (presetApi ?? "openai-completions") as PiApi;

--- a/packages/core/src/llm/providers/types.ts
+++ b/packages/core/src/llm/providers/types.ts
@@ -60,7 +60,7 @@ export interface ProviderCompat {
 }
 
 export interface ProviderTransportDefaults {
-  readonly apiFormat?: "chat" | "responses";
+  readonly apiFormat?: "chat" | "responses" | "anthropic";
   readonly stream?: boolean;
 }
 

--- a/packages/core/src/llm/providers/verify.ts
+++ b/packages/core/src/llm/providers/verify.ts
@@ -4,7 +4,7 @@ import { fetchWithProxy } from "../../utils/proxy-fetch.js";
 
 export interface VerifyResult {
   readonly recommendedTransport?: {
-    readonly apiFormat?: "chat" | "responses";
+    readonly apiFormat?: "chat" | "responses" | "anthropic";
     readonly stream?: boolean;
   };
   readonly probe: {

--- a/packages/core/src/llm/service-resolver.ts
+++ b/packages/core/src/llm/service-resolver.ts
@@ -30,15 +30,19 @@ export async function resolveServiceModel(
   modelId: string,
   projectRoot: string,
   customBaseUrl?: string,
-  customApiFormat?: "chat" | "responses",
+  customApiFormat?: "chat" | "responses" | "anthropic",
 ): Promise<ResolvedModel> {
   // Determine pi-ai provider
   const baseService = service.startsWith("custom:") ? "custom" : service;
   const preset = resolveServicePreset(baseService);
   const endpoint = getEndpoint(baseService);
-  const piProvider = baseService === "ollama" ? "ollama" : resolveServicePiProvider(baseService) ?? "openai";
+  const piProvider = baseService === "ollama"
+    ? "ollama"
+    : service.startsWith("custom:") && customApiFormat === "anthropic"
+      ? "anthropic"
+      : resolveServicePiProvider(baseService) ?? "openai";
   const apiType = service.startsWith("custom:")
-    ? (customApiFormat === "responses" ? "openai-responses" : "openai-completions")
+    ? (customApiFormat === "anthropic" ? "anthropic-messages" : customApiFormat === "responses" ? "openai-responses" : "openai-completions")
     : (preset?.api ?? "openai-completions");
   const configuredBaseUrl = customBaseUrl ?? preset?.baseUrl ?? "";
   const endpointModel = baseService === "minimax"

--- a/packages/core/src/models/project.ts
+++ b/packages/core/src/models/project.ts
@@ -7,7 +7,7 @@ const LLMServiceEntrySchema = z.object({
   baseUrl: z.string().url().optional(),
   models: z.array(z.string().min(1)).optional(),
   temperature: z.number().min(0).max(2).optional(),
-  apiFormat: z.enum(["chat", "responses"]).optional(),
+  apiFormat: z.enum(["chat", "responses", "anthropic"]).optional(),
   stream: z.boolean().optional(),
 });
 
@@ -32,7 +32,7 @@ export const LLMConfigSchema = z.object({
   thinkingBudget: z.number().int().min(0).default(0),
   extra: z.record(z.unknown()).optional(),
   headers: z.record(z.string()).optional(),
-  apiFormat: z.enum(["chat", "responses"]).default("chat"),
+  apiFormat: z.enum(["chat", "responses", "anthropic"]).default("chat"),
   stream: z.boolean().default(true),
   services: z.array(LLMServiceEntrySchema).optional(),
   defaultModel: z.string().min(1).optional(),

--- a/packages/core/src/utils/effective-llm-config.ts
+++ b/packages/core/src/utils/effective-llm-config.ts
@@ -16,7 +16,7 @@ export interface LLMConfigCliOverrides {
   readonly model?: string;
   readonly apiKeyEnv?: string;
   readonly baseUrl?: string;
-  readonly apiFormat?: "chat" | "responses";
+  readonly apiFormat?: "chat" | "responses" | "anthropic";
   readonly stream?: boolean;
 }
 
@@ -49,7 +49,7 @@ interface ServiceConfigEntry {
   readonly models?: readonly string[];
   readonly temperature?: number;
   readonly maxTokens?: number;
-  readonly apiFormat?: "chat" | "responses";
+  readonly apiFormat?: "chat" | "responses" | "anthropic";
   readonly stream?: boolean;
 }
 
@@ -316,7 +316,14 @@ function applyServiceEntry(llm: Record<string, unknown>, entry: ServiceConfigEnt
   if (entry.temperature !== undefined) llm.temperature = entry.temperature;
   if (entry.apiFormat !== undefined) llm.apiFormat = entry.apiFormat;
   else if (transportDefaults?.apiFormat !== undefined) llm.apiFormat = transportDefaults.apiFormat;
-  else llm.apiFormat = resolveServicePreset(entry.service)?.api.startsWith("openai-responses") ? "responses" : "chat";
+  else {
+    const presetApi = resolveServicePreset(entry.service)?.api;
+    llm.apiFormat = presetApi === "anthropic-messages"
+      ? "anthropic"
+      : presetApi === "openai-responses"
+        ? "responses"
+        : "chat";
+  }
   if (entry.stream !== undefined) llm.stream = entry.stream;
   else if (transportDefaults?.stream !== undefined) llm.stream = transportDefaults.stream;
 }
@@ -360,7 +367,7 @@ function normalizeServiceEntries(raw: unknown): ServiceConfigEntry[] {
         ...(Array.isArray(entry.models) ? { models: normalizeModelIds(entry.models) } : {}),
         ...(typeof entry.temperature === "number" ? { temperature: entry.temperature } : {}),
         ...(typeof entry.maxTokens === "number" ? { maxTokens: entry.maxTokens } : {}),
-        ...(entry.apiFormat === "chat" || entry.apiFormat === "responses" ? { apiFormat: entry.apiFormat } : {}),
+        ...(entry.apiFormat === "chat" || entry.apiFormat === "responses" || entry.apiFormat === "anthropic" ? { apiFormat: entry.apiFormat } : {}),
         ...(typeof entry.stream === "boolean" ? { stream: entry.stream } : {}),
       }));
   }
@@ -383,7 +390,7 @@ function normalizeServiceEntryFromPatch(serviceId: string, value: Record<string,
       ...(Array.isArray(value.models) ? { models: normalizeModelIds(value.models) } : {}),
       ...(typeof value.temperature === "number" ? { temperature: value.temperature } : {}),
       ...(typeof value.maxTokens === "number" ? { maxTokens: value.maxTokens } : {}),
-      ...(value.apiFormat === "chat" || value.apiFormat === "responses" ? { apiFormat: value.apiFormat } : {}),
+      ...(value.apiFormat === "chat" || value.apiFormat === "responses" || value.apiFormat === "anthropic" ? { apiFormat: value.apiFormat } : {}),
       ...(typeof value.stream === "boolean" ? { stream: value.stream } : {}),
     };
   }
@@ -396,7 +403,7 @@ function normalizeServiceEntryFromPatch(serviceId: string, value: Record<string,
       ...(Array.isArray(value.models) ? { models: normalizeModelIds(value.models) } : {}),
       ...(typeof value.temperature === "number" ? { temperature: value.temperature } : {}),
       ...(typeof value.maxTokens === "number" ? { maxTokens: value.maxTokens } : {}),
-      ...(value.apiFormat === "chat" || value.apiFormat === "responses" ? { apiFormat: value.apiFormat } : {}),
+      ...(value.apiFormat === "chat" || value.apiFormat === "responses" || value.apiFormat === "anthropic" ? { apiFormat: value.apiFormat } : {}),
       ...(typeof value.stream === "boolean" ? { stream: value.stream } : {}),
     };
   }
@@ -406,7 +413,7 @@ function normalizeServiceEntryFromPatch(serviceId: string, value: Record<string,
     ...(Array.isArray(value.models) ? { models: normalizeModelIds(value.models) } : {}),
     ...(typeof value.temperature === "number" ? { temperature: value.temperature } : {}),
     ...(typeof value.maxTokens === "number" ? { maxTokens: value.maxTokens } : {}),
-    ...(value.apiFormat === "chat" || value.apiFormat === "responses" ? { apiFormat: value.apiFormat } : {}),
+    ...(value.apiFormat === "chat" || value.apiFormat === "responses" || value.apiFormat === "anthropic" ? { apiFormat: value.apiFormat } : {}),
     ...(typeof value.stream === "boolean" ? { stream: value.stream } : {}),
   };
 }

--- a/packages/studio/src/api/server.test.ts
+++ b/packages/studio/src/api/server.test.ts
@@ -1425,6 +1425,38 @@ describe("createStudioServer daemon lifecycle", () => {
     ]);
   });
 
+  it("accepts and returns Anthropic Messages service configuration", async () => {
+    await writeFile(join(root, "inkos.json"), JSON.stringify({
+      ...projectConfig,
+      llm: {
+        service: "custom:Anthropic Gateway",
+        defaultModel: "claude-compatible-model",
+        services: [{
+          service: "custom",
+          name: "Anthropic Gateway",
+          baseUrl: "https://gateway.example",
+          apiFormat: "anthropic",
+          stream: true,
+        }],
+      },
+    }, null, 2), "utf-8");
+
+    const { createStudioServer } = await import("./server.js");
+    const app = createStudioServer(cloneProjectConfig() as never, root);
+    const response = await app.request("http://localhost/api/v1/services/config");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      services: [{
+        service: "custom",
+        name: "Anthropic Gateway",
+        baseUrl: "https://gateway.example",
+        apiFormat: "anthropic",
+        stream: true,
+      }],
+    });
+  });
+
   it("refreshes top-level llm mirror when switching from custom baseUrl to a preset service", async () => {
     await writeFile(join(root, "inkos.json"), JSON.stringify({
       ...projectConfig,

--- a/packages/studio/src/api/server.ts
+++ b/packages/studio/src/api/server.ts
@@ -1639,7 +1639,7 @@ interface ServiceConfigEntry {
   baseUrl?: string;
   models?: string[];
   temperature?: number;
-  apiFormat?: "chat" | "responses";
+  apiFormat?: "chat" | "responses" | "anthropic";
   stream?: boolean;
 }
 
@@ -1669,7 +1669,7 @@ interface ServiceProbeResult {
   ok: boolean;
   models: Array<{ id: string; name: string }>;
   selectedModel?: string;
-  apiFormat?: "chat" | "responses";
+  apiFormat?: "chat" | "responses" | "anthropic";
   stream?: boolean;
   baseUrl?: string;
   modelsSource?: "api" | "fallback";
@@ -1775,7 +1775,7 @@ function normalizeServiceEntry(serviceId: string, value: Record<string, unknown>
       ...(typeof value.baseUrl === "string" && value.baseUrl.length > 0 ? { baseUrl: value.baseUrl } : {}),
       ...(Array.isArray(value.models) ? { models: normalizeServiceModelIds(value.models) } : {}),
       ...(typeof value.temperature === "number" ? { temperature: value.temperature } : {}),
-      ...(value.apiFormat === "chat" || value.apiFormat === "responses" ? { apiFormat: value.apiFormat } : {}),
+      ...(value.apiFormat === "chat" || value.apiFormat === "responses" || value.apiFormat === "anthropic" ? { apiFormat: value.apiFormat } : {}),
       ...(typeof value.stream === "boolean" ? { stream: value.stream } : {}),
     };
   }
@@ -1787,7 +1787,7 @@ function normalizeServiceEntry(serviceId: string, value: Record<string, unknown>
       ...(typeof value.baseUrl === "string" && value.baseUrl.length > 0 ? { baseUrl: value.baseUrl } : {}),
       ...(Array.isArray(value.models) ? { models: normalizeServiceModelIds(value.models) } : {}),
       ...(typeof value.temperature === "number" ? { temperature: value.temperature } : {}),
-      ...(value.apiFormat === "chat" || value.apiFormat === "responses" ? { apiFormat: value.apiFormat } : {}),
+      ...(value.apiFormat === "chat" || value.apiFormat === "responses" || value.apiFormat === "anthropic" ? { apiFormat: value.apiFormat } : {}),
       ...(typeof value.stream === "boolean" ? { stream: value.stream } : {}),
     };
   }
@@ -1796,7 +1796,7 @@ function normalizeServiceEntry(serviceId: string, value: Record<string, unknown>
     service: serviceId,
     ...(Array.isArray(value.models) ? { models: normalizeServiceModelIds(value.models) } : {}),
     ...(typeof value.temperature === "number" ? { temperature: value.temperature } : {}),
-    ...(value.apiFormat === "chat" || value.apiFormat === "responses" ? { apiFormat: value.apiFormat } : {}),
+    ...(value.apiFormat === "chat" || value.apiFormat === "responses" || value.apiFormat === "anthropic" ? { apiFormat: value.apiFormat } : {}),
     ...(typeof value.stream === "boolean" ? { stream: value.stream } : {}),
   };
 }
@@ -1815,7 +1815,7 @@ function normalizeServiceConfig(raw: unknown): ServiceConfigEntry[] {
         ...(typeof entry.baseUrl === "string" && entry.baseUrl.length > 0 ? { baseUrl: entry.baseUrl } : {}),
         ...(Array.isArray(entry.models) ? { models: normalizeServiceModelIds(entry.models) } : {}),
         ...(typeof entry.temperature === "number" ? { temperature: entry.temperature } : {}),
-        ...(entry.apiFormat === "chat" || entry.apiFormat === "responses" ? { apiFormat: entry.apiFormat } : {}),
+        ...(entry.apiFormat === "chat" || entry.apiFormat === "responses" || entry.apiFormat === "anthropic" ? { apiFormat: entry.apiFormat } : {}),
         ...(typeof entry.stream === "boolean" ? { stream: entry.stream } : {}),
       }));
   }
@@ -2067,12 +2067,12 @@ async function resolveConfiguredServiceEntry(root: string, serviceId: string): P
 }
 
 function buildProbePlans(
-  preferredApiFormat: "chat" | "responses" | undefined,
+  preferredApiFormat: "chat" | "responses" | "anthropic" | undefined,
   preferredStream: boolean | undefined,
-): Array<{ apiFormat: "chat" | "responses"; stream: boolean }> {
-  const candidates: Array<{ apiFormat: "chat" | "responses"; stream: boolean }> = [];
+): Array<{ apiFormat: "chat" | "responses" | "anthropic"; stream: boolean }> {
+  const candidates: Array<{ apiFormat: "chat" | "responses" | "anthropic"; stream: boolean }> = [];
   const seen = new Set<string>();
-  const push = (apiFormat: "chat" | "responses", stream: boolean) => {
+  const push = (apiFormat: "chat" | "responses" | "anthropic", stream: boolean) => {
     const key = `${apiFormat}:${stream ? "1" : "0"}`;
     if (seen.has(key)) return;
     seen.add(key);
@@ -2229,7 +2229,7 @@ function formatServiceProbeError(args: {
   readonly label?: string;
   readonly baseUrl: string;
   readonly model?: string;
-  readonly apiFormat?: "chat" | "responses";
+  readonly apiFormat?: "chat" | "responses" | "anthropic";
   readonly stream?: boolean;
   readonly error: string;
   readonly language?: StudioLanguage;
@@ -2241,7 +2241,11 @@ function formatServiceProbeError(args: {
   const upstreamDetail = rawDetail.includes("上游详情：")
     ? rawDetail
     : "";
-  const protocol = args.apiFormat === "responses" ? "Responses" : "Chat / Completions";
+  const protocol = args.apiFormat === "anthropic"
+    ? "Anthropic Messages"
+    : args.apiFormat === "responses"
+      ? "Responses"
+      : "Chat / Completions";
   const streamSuffix = typeof args.stream === "boolean"
     ? pick(lang, `，${args.stream ? "流式" : "非流式"}`, `, ${args.stream ? "streaming" : "non-streaming"}`)
     : "";
@@ -2372,7 +2376,7 @@ async function probeServiceCapabilities(args: {
   service: string;
   apiKey: string;
   baseUrl: string;
-  preferredApiFormat?: "chat" | "responses";
+  preferredApiFormat?: "chat" | "responses" | "anthropic";
   preferredStream?: boolean;
   preferredModel?: string;
   proxyUrl?: string;
@@ -3757,7 +3761,7 @@ export function createStudioServer(initialConfig: ProjectConfig, root: string, o
     const { apiKey, baseUrl, apiFormat, stream } = await c.req.json<{
       apiKey: string;
       baseUrl?: string;
-      apiFormat?: "chat" | "responses";
+      apiFormat?: "chat" | "responses" | "anthropic";
       stream?: boolean;
     }>();
 

--- a/packages/studio/src/pages/ServiceDetailPage.tsx
+++ b/packages/studio/src/pages/ServiceDetailPage.tsx
@@ -53,7 +53,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
   const [customName, setCustomName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [temperature, setTemperature] = useState("0.7");
-  const [apiFormat, setApiFormat] = useState<"chat" | "responses">("chat");
+  const [apiFormat, setApiFormat] = useState<"chat" | "responses" | "anthropic">("chat");
   const [stream, setStream] = useState(true);
   const [detectedModel, setDetectedModel] = useState<string>("");
   const [detectedConfig, setDetectedConfig] = useState<DetectedConfig | null>(null);
@@ -76,7 +76,7 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
           setBaseUrl(String(matched.baseUrl ?? ""));
         }
         if (typeof matched.temperature === "number") setTemperature(String(matched.temperature));
-        if (matched.apiFormat === "chat" || matched.apiFormat === "responses") setApiFormat(matched.apiFormat);
+        if (matched.apiFormat === "chat" || matched.apiFormat === "responses" || matched.apiFormat === "anthropic") setApiFormat(matched.apiFormat);
         if (typeof matched.stream === "boolean") setStream(matched.stream);
         if (Array.isArray(matched.models)) {
           setConfiguredModels(mergeServiceDetailModels(matched.models.filter((model): model is string => typeof model === "string")));
@@ -342,8 +342,8 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
               {tr(`连接成功，${models.length} 个模型`, `Connected, ${models.length} models`)}
               {detectedModel
                 ? tr(
-                    `，已自动匹配 ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "responses" ? "Responses" : "Chat"} / ${detectedConfig.stream ? "流式" : "非流式"}` : ""}`,
-                    `, auto-matched ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "responses" ? "Responses" : "Chat"} / ${detectedConfig.stream ? "streaming" : "non-streaming"}` : ""}`,
+                    `，已自动匹配 ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "anthropic" ? "Anthropic Messages" : detectedConfig.apiFormat === "responses" ? "Responses" : "Chat / Completions"} / ${detectedConfig.stream ? "流式" : "非流式"}` : ""}`,
+                    `, auto-matched ${detectedModel}${detectedConfig ? ` / ${detectedConfig.apiFormat === "anthropic" ? "Anthropic Messages" : detectedConfig.apiFormat === "responses" ? "Responses" : "Chat / Completions"} / ${detectedConfig.stream ? "streaming" : "non-streaming"}` : ""}`,
                   )
                 : ""}
             </span>
@@ -360,11 +360,12 @@ export function ServiceDetailPage({ serviceId, nav }: { serviceId: string; nav: 
           <Field label={tr("协议类型", "Protocol")}>
             <select
               value={apiFormat}
-              onChange={(e) => setApiFormat(e.target.value as "chat" | "responses")}
+              onChange={(e) => setApiFormat(e.target.value as "chat" | "responses" | "anthropic")}
               className="w-full rounded-lg border border-border/60 bg-background px-3 py-2 text-sm"
             >
-              <option value="chat">Chat / Completions</option>
-              <option value="responses">Responses</option>
+              <option value="chat">OpenAI Chat Completions</option>
+              <option value="responses">OpenAI Responses</option>
+              <option value="anthropic">Anthropic Messages</option>
             </select>
           </Field>
 

--- a/packages/studio/src/pages/service-detail-state.test.ts
+++ b/packages/studio/src/pages/service-detail-state.test.ts
@@ -186,6 +186,56 @@ describe("saveServiceConfig", () => {
     });
   });
 
+  it("persists Anthropic Messages after a verified custom connection", async () => {
+    const bodies: unknown[] = [];
+    const fetchJsonImpl = vi.fn(async (path: string, init?: { body?: string }) => {
+      if (init?.body) bodies.push(JSON.parse(init.body));
+      if (path === "/services/custom%3AAnthropic%20Gateway/secret") return { ok: true };
+      if (path === "/services/config") return { ok: true };
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    await saveServiceConfig({
+      effectiveServiceId: "custom:Anthropic Gateway",
+      serviceId: "custom",
+      isCustom: true,
+      resolvedCustomName: "Anthropic Gateway",
+      apiKey: "",
+      baseUrl: "https://gateway.example",
+      apiFormat: "anthropic",
+      stream: true,
+      temperature: "0.7",
+      detectedModel: "claude-compatible-model",
+      verifiedProbe: {
+        apiKey: "",
+        baseUrl: "https://gateway.example",
+        apiFormat: "anthropic",
+        stream: true,
+        models: [{ id: "claude-compatible-model" }],
+        selectedModel: "claude-compatible-model",
+        detected: { apiFormat: "anthropic", stream: true, baseUrl: "https://gateway.example" },
+      },
+      fetchJsonImpl: fetchJsonImpl as never,
+    });
+
+    expect(bodies).toEqual([
+      { apiKey: "" },
+      {
+        service: "custom:Anthropic Gateway",
+        defaultModel: "claude-compatible-model",
+        services: [{
+          service: "custom",
+          temperature: 0.7,
+          apiFormat: "anthropic",
+          stream: true,
+          models: ["claude-compatible-model"],
+          name: "Anthropic Gateway",
+          baseUrl: "https://gateway.example",
+        }],
+      },
+    ]);
+  });
+
   it("reuses a matching successful test result when saving", async () => {
     const calls: string[] = [];
     const bodies: unknown[] = [];

--- a/packages/studio/src/pages/service-detail-state.ts
+++ b/packages/studio/src/pages/service-detail-state.ts
@@ -24,7 +24,7 @@ export function mergeServiceDetailModels(
 }
 
 export interface ServiceDetailDetectedConfig {
-  readonly apiFormat?: "chat" | "responses";
+  readonly apiFormat?: "chat" | "responses" | "anthropic";
   readonly stream?: boolean;
   readonly baseUrl?: string;
   readonly modelsSource?: "api" | "fallback";
@@ -51,7 +51,7 @@ export interface ServiceProbeResponse {
 export interface ServiceDetailVerifiedProbe {
   readonly apiKey: string;
   readonly baseUrl: string;
-  readonly apiFormat: "chat" | "responses";
+  readonly apiFormat: "chat" | "responses" | "anthropic";
   readonly stream: boolean;
   readonly models: ServiceDetailModelInfo[];
   readonly selectedModel?: string;
@@ -62,7 +62,7 @@ export async function probeServiceForDetail(
   serviceId: string,
   body: {
     readonly apiKey: string;
-    readonly apiFormat: "chat" | "responses";
+    readonly apiFormat: "chat" | "responses" | "anthropic";
     readonly stream: boolean;
     readonly baseUrl?: string;
   },
@@ -84,7 +84,7 @@ export async function rehydrateServiceConnectionStatus(args: {
   readonly shouldVerify: boolean;
   readonly isCustom: boolean;
   readonly baseUrl: string;
-  readonly apiFormat: "chat" | "responses";
+  readonly apiFormat: "chat" | "responses" | "anthropic";
   readonly stream: boolean;
   readonly fetchJsonImpl?: JsonFetcher;
 }): Promise<{
@@ -129,7 +129,7 @@ export async function saveServiceConfig(args: {
   readonly resolvedCustomName: string;
   readonly apiKey: string;
   readonly baseUrl: string;
-  readonly apiFormat: "chat" | "responses";
+  readonly apiFormat: "chat" | "responses" | "anthropic";
   readonly stream: boolean;
   readonly temperature: string;
   readonly detectedModel: string;


### PR DESCRIPTION
## Summary

- Add Anthropic Messages as a selectable protocol in Studio model configuration.
- Extend the shared LLM configuration and provider resolution path to recognize and validate Anthropic Messages.
- Preserve existing OpenAI Chat Completions and OpenAI Responses behavior.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs / SKILL.md
- [ ] Test
- [ ] Performance

## Motivation (optional)

Studio previously exposed OpenAI Chat Completions and OpenAI Responses as configurable protocol types, but did not allow users to explicitly select Anthropic Messages.

This change adds Anthropic Messages support to the Studio configuration flow and wires it through the existing shared LLM/provider resolution path, while keeping existing OpenAI protocol configurations compatible.

## Changes

| File | Change |
|------|--------|
| `packages/studio/src/pages/ServiceDetailPage.tsx` | Add Anthropic Messages to the Studio protocol selector |
| `packages/studio/src/pages/service-detail-state.ts` | Support Anthropic protocol state when loading and saving service configuration |
| `packages/studio/src/pages/service-detail-state.test.ts` | Add regression coverage for Anthropic protocol state handling |
| `packages/studio/src/api/server.ts` | Support Anthropic protocol values in Studio service configuration APIs |
| `packages/studio/src/api/server.test.ts` | Add API coverage for Anthropic protocol configuration |
| `packages/core/src/llm/provider.ts` | Extend shared LLM provider handling for Anthropic Messages |
| `packages/core/src/llm/providers/types.ts` | Add/update protocol typing for Anthropic Messages |
| `packages/core/src/llm/providers/verify.ts` | Verify Anthropic-compatible provider configuration |
| `packages/core/src/llm/service-resolver.ts` | Resolve Anthropic protocol services through the existing service resolution path |
| `packages/core/src/utils/effective-llm-config.ts` | Preserve Anthropic protocol information in effective LLM configuration |
| `packages/core/src/models/project.ts` | Extend persisted project model configuration types where required |
| `packages/core/src/agent/worker-agent.ts` | Ensure worker-side model resolution respects the configured Anthropic protocol |
| `packages/core/src/__tests__/*.test.ts` | Add regression coverage for provider, model, and effective configuration behavior |
| `packages/cli/src/program.ts` / `utils.ts` / `commands/doctor.ts` | Recognize and report Anthropic protocol values consistently in CLI configuration/diagnostics |
| `README.md` | Document Anthropic Messages as a supported protocol |

## Usage (optional)

In Studio:
1. Open **Model Configuration**.
2. Add or edit a model service.
3. Select **Anthropic Messages** as the protocol type.
4. Configure the Base URL, API Key, and model.
5. Save the configuration and test the connection.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all existing + new tests)
- [x] Manual verification: Anthropic Messages can be selected, saved, reloaded, and used from Studio
- [x] Manual verification: existing OpenAI Chat Completions and OpenAI Responses configurations remain functional

## Breaking changes (optional)

None.